### PR TITLE
Fixed memory leak

### DIFF
--- a/enable/qt4/image.py
+++ b/enable/qt4/image.py
@@ -34,9 +34,7 @@ class Window(BaseWindow):
         w = self._gc.width()
         h = self._gc.height()
         data = self._gc.pixel_map.convert_to_argb32string()
-        byte_data = QtCore.QByteArray(data)
-        image = QtGui.QImage(byte_data, w, h, QtGui.QImage.Format_RGB32)
-
+        image = QtGui.QImage(data, w, h, QtGui.QImage.Format_RGB32)
         rect = QtCore.QRect(0,0,w,h)
         painter = QtGui.QPainter(self.control)
         painter.drawImage(rect, image)


### PR DESCRIPTION
Enable was leaking pretty rapidly when drawing dynamic curves in enaml. Profiling under Instruments showed that the QByteArray's were leaking. This change changes QImages to be directly constructed from a raw buffer rather than going through a QByteArray. 
