### PR TITLE
patches to agg to support building on clang 

### DIFF
--- a/kiva/agg/agg-24/include/agg_renderer_outline_aa.h
+++ b/kiva/agg/agg-24/include/agg_renderer_outline_aa.h
@@ -1365,7 +1365,7 @@ namespace agg24
         //---------------------------------------------------------------------
         void profile(const line_profile_aa& prof) { m_profile = &prof; }
         const line_profile_aa& profile() const { return *m_profile; }
-        line_profile_aa& profile() { return *m_profile; }
+        const line_profile_aa& profile() { return *m_profile; }
 
         //---------------------------------------------------------------------
         int subpixel_width() const { return m_profile->subpixel_width(); }

--- a/kiva/agg/agg-24/include/agg_scanline_u.h
+++ b/kiva/agg/agg-24/include/agg_scanline_u.h
@@ -458,7 +458,7 @@ namespace agg24
     class scanline32_u8_am : public scanline32_u8
     {
     public:
-        typedef scanline_u8           base_type;
+        typedef scanline32_u8           base_type;
         typedef AlphaMask             alpha_mask_type;
         typedef base_type::cover_type cover_type;
         typedef base_type::coord_type coord_type;


### PR DESCRIPTION
This small fixes patch agg so that enable will build on mac OSX 10.7 with clang as the compiler (as is the default in Xcode 4.3).  Apparently clang is a bit pickier about what it checks for validity than gcc is. These are inspired by @mdboom's work fixing this for matplotlib.
