### PR TITLE
don't use quartz build if on a 64-bit mac OS X

### DIFF
--- a/kiva/setup.py
+++ b/kiva/setup.py
@@ -13,8 +13,8 @@
 # Description: <Enthought kiva package project>
 #------------------------------------------------------------------------------
 
-import sys
 import os
+import platform
 
 
 def configuration(parent_package=None, top_path=None):
@@ -34,7 +34,7 @@ def configuration(parent_package=None, top_path=None):
     config.add_subpackage('trait_defs.ui')
     config.add_subpackage('trait_defs.ui.*')
 
-    if sys.platform == 'darwin':
+    if platform.system() == 'Darwin' and platform.architecture()[0]=='32bit':
         config.add_subpackage('quartz')
 
     config.get_version()


### PR DESCRIPTION
on a 64-bit mac OS X (at least 10.6 and 10.7 - I haven't tested earlier versions), the "quartz" subcomponent of enable causes the build to fail, I think because it's using files that are part of the Carbon API (which was reqplaced by Cocoa and is not available in 64-bit).  This PR simple disables that subcomponent when the build is happening in a non-32bit OS X.
