### PR TITLE
Use dc.GetCGContext if available

### DIFF
--- a/kiva/quartz/__init__.py
+++ b/kiva/quartz/__init__.py
@@ -3,15 +3,15 @@
 # :License:   BSD Style
 
 from mac_context import get_mac_context
-try:
-    from macport import get_macport as _get_macport
-except ImportError:
-    # macport is not available on 64-bit.
-    _get_macport = None
 
 
 def get_macport(dc):
-    """ Returns the m_macPort of a wxDC (or child class) instance.
-        NOTE: This is only available on 32-bit at this time.
     """
-    return _get_macport(str(dc.this))
+    Returns the Port or the CGContext of a wxDC (or child class) instance.
+    """
+    if 'GetCGContext' in dir(dc):
+        ptr = dc.GetCGContext()
+        return int(ptr)
+    else:
+        from macport import get_macport as _get_macport
+        return _get_macport(str(dc.this))

--- a/kiva/quartz/setup.py
+++ b/kiva/quartz/setup.py
@@ -67,37 +67,35 @@ def configuration(parent_package='', top_path=None):
                          )
 
     wx_info = get_info('wx')
-    if wx_info and '64bit' not in platform.architecture():
-        # Avoid WX on 64-bit due to immature cocoa support
-        # Find the release number of wx.
+    if wx_info:
         wx_release = '2.6'
         for macro, value in wx_info['define_macros']:
             if macro.startswith('WX_RELEASE_'):
                 wx_release = macro[len('WX_RELEASE_'):].replace('_', '.')
                 break
 
+        # only build macport for wxPython version 2.6, it's not needed in the
+        # newer releases (see __init__.py)
         if wx_release == '2.6':
             macport_cpp = config.paths('macport26.cpp')[0]
-        else:
-            macport_cpp = config.paths('macport28.cpp')[0]
 
-        def get_macport_cpp(extension, build_dir):
-            if sys.platform != 'darwin':
-                print 'No %s will be built for this platform.'%(extension.name)
-                return None
-
-            elif wx_release not in ('2.6', '2.8'):
-                print ('No %s will be built because we do not recognize '
-                       'wx version %s' % (extension.name, wx_release))
-                return None
-
-            return macport_cpp
-
-        info = {}
-        dict_append(info, define_macros=[("__WXMAC__", 1)])
-        dict_append(info, **wx_info)
-        config.add_extension('macport', [get_macport_cpp],
-                             depends = [macport_cpp],
-                             **wx_info
-                             )
+            def get_macport_cpp(extension, build_dir):
+                if sys.platform != 'darwin':
+                    print 'No %s will be built for this platform.'%(extension.name)
+                    return None
+    
+                elif wx_release not in ('2.6', '2.8'):
+                    print ('No %s will be built because we do not recognize '
+                           'wx version %s' % (extension.name, wx_release))
+                    return None
+    
+                return macport_cpp
+    
+            info = {}
+            dict_append(info, define_macros=[("__WXMAC__", 1)])
+            dict_append(info, **wx_info)
+            config.add_extension('macport', [get_macport_cpp],
+                                 depends = [macport_cpp],
+                                 **wx_info
+                                 )
     return config


### PR DESCRIPTION
The wx.DC class has a GetCGContext method that returns the same value that kiva's macport extension module returns, rendering that extension obsolete.  The GetCGContext method is available in wx 2.8 and 2.9, and using it works in both Carbon and Cocoa builds, including 64-bit.  This patch changes mac_getport() to use GetCGContext if it's available, and disables the building of the macport extension if building for wx 2.8+.
