### PR TITLE
Fix dashed lines in 64-bit OSX.

### DIFF
--- a/kiva/quartz/ABCGI.pyx
+++ b/kiva/quartz/ABCGI.pyx
@@ -378,7 +378,7 @@ cdef class CGContext:
         """
         cdef int n
         cdef int i
-        cdef float *flengths
+        cdef CGFloat *flengths
 
         if lengths is None:
             # No dash; solid line.
@@ -386,7 +386,7 @@ cdef class CGContext:
             return
         else:
             n = len(lengths)
-            flengths = <float*>PyMem_Malloc(n*sizeof(float))
+            flengths = <CGFloat*>PyMem_Malloc(n*sizeof(CGFloat))
             if flengths == NULL:
                 raise MemoryError("could not allocate %s floats" % n)
             for i from 0 <= i < n:

--- a/kiva/quartz/CoreGraphics.pxi
+++ b/kiva/quartz/CoreGraphics.pxi
@@ -5,6 +5,8 @@
 
 cdef extern from "ApplicationServices/ApplicationServices.h":
     ctypedef void*  CGContextRef
+    
+    ctypedef double CGFloat
 
     ctypedef struct CGPoint:
         float x
@@ -91,8 +93,8 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     # Changing the Current Graphics State
     void CGContextSetFlatness(CGContextRef context, float flatness)
     void CGContextSetLineCap(CGContextRef context, CGLineCap cap)
-    void CGContextSetLineDash(CGContextRef context, float phase,
-        float lengths[], size_t count)
+    void CGContextSetLineDash(CGContextRef context, CGFloat phase,
+        CGFloat lengths[], size_t count)
     void CGContextSetLineJoin(CGContextRef context, CGLineJoin join)
     void CGContextSetLineWidth(CGContextRef context, float width)
     void CGContextSetMiterLimit(CGContextRef context, float limit)


### PR DESCRIPTION
The CGFloat type is a float in 32-bit and a double in 64-bit CoreGraphics code.  Most of the time always treating it as one or the other in kiva/quartz cython code would probably be ok since the C compiler will usually take care of the difference.  However when pointers or arrays are used it is not safe to always use float since the APIs will expect more room to write to.  For CGContextSetLineDash this problem manifests as no dashes being used and repeated log messages such as the following: 

Jun 26 15:44:46 havok.alldunn2.com Python[57422] <Error>: CGContextSetLineDash: invalid dash array: negative lengths are not allowed.

This patch adds the minimum needed to get dashed lines working in 64-bit builds. Adds a ctypedef for CGFloat and uses it in the prototype of CGContextSetLineDash and in set_line_dash.  This causes Cython to use the CGFloat type in the generated code and all is well.

To avoid other problems the rest of the floats that are really CGFloat types in the API should be changed as well...
