### PR TITLE
Change instances of float to CGFloat using the new ctypedef.

### DIFF
--- a/kiva/quartz/CoreGraphics.pxi
+++ b/kiva/quartz/CoreGraphics.pxi
@@ -9,24 +9,24 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     ctypedef double CGFloat
 
     ctypedef struct CGPoint:
-        float x
-        float y
+        CGFloat x
+        CGFloat y
 
     ctypedef struct CGSize:
-        float width
-        float height
+        CGFloat width
+        CGFloat height
 
     ctypedef struct CGRect:
         CGPoint origin
         CGSize size
 
     ctypedef struct CGAffineTransform:
-        float a
-        float b
-        float c
-        float d
-        float tx
-        float ty
+        CGFloat a
+        CGFloat b
+        CGFloat c
+        CGFloat d
+        CGFloat tx
+        CGFloat ty
 
     ctypedef enum CGBlendMode:
         kCGBlendModeNormal
@@ -80,9 +80,9 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     void CGContextEndPage(CGContextRef context)
 
     # User-space transformations
-    void CGContextScaleCTM(CGContextRef context, float sx, float sy)
-    void CGContextTranslateCTM(CGContextRef context, float tx, float ty)
-    void CGContextRotateCTM(CGContextRef context, float angle)
+    void CGContextScaleCTM(CGContextRef context, CGFloat sx, CGFloat sy)
+    void CGContextTranslateCTM(CGContextRef context, CGFloat tx, CGFloat ty)
+    void CGContextRotateCTM(CGContextRef context, CGFloat angle)
     void CGContextConcatCTM(CGContextRef context, CGAffineTransform transform)
     CGAffineTransform CGContextGetCTM(CGContextRef context)
 
@@ -91,13 +91,13 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     void CGContextRestoreGState(CGContextRef context)
 
     # Changing the Current Graphics State
-    void CGContextSetFlatness(CGContextRef context, float flatness)
+    void CGContextSetFlatness(CGContextRef context, CGFloat flatness)
     void CGContextSetLineCap(CGContextRef context, CGLineCap cap)
     void CGContextSetLineDash(CGContextRef context, CGFloat phase,
         CGFloat lengths[], size_t count)
     void CGContextSetLineJoin(CGContextRef context, CGLineJoin join)
-    void CGContextSetLineWidth(CGContextRef context, float width)
-    void CGContextSetMiterLimit(CGContextRef context, float limit)
+    void CGContextSetLineWidth(CGContextRef context, CGFloat width)
+    void CGContextSetMiterLimit(CGContextRef context, CGFloat limit)
     void CGContextSetPatternPhase(CGContextRef context, CGSize phase)
     void CGContextSetShouldAntialias(CGContextRef context, bool shouldAntialias)
     void CGContextSetShouldSmoothFonts(CGContextRef context, bool shouldSmoothFonts)
@@ -105,19 +105,19 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
 
     # Constructing Paths
     void CGContextBeginPath(CGContextRef context)
-    void CGContextMoveToPoint(CGContextRef context, float x, float y)
-    void CGContextAddLineToPoint(CGContextRef context, float x, float y)
+    void CGContextMoveToPoint(CGContextRef context, CGFloat x, CGFloat y)
+    void CGContextAddLineToPoint(CGContextRef context, CGFloat x, CGFloat y)
     void CGContextAddLines(CGContextRef context, CGPoint points[], size_t count)
-    void CGContextAddCurveToPoint(CGContextRef context, float cp1x, float cp1y,
-        float cp2x, float cp2y, float x, float y)
-    void CGContextAddQuadCurveToPoint(CGContextRef context, float cpx,
-        float cpy, float x, float y)
+    void CGContextAddCurveToPoint(CGContextRef context, CGFloat cp1x, CGFloat cp1y,
+        CGFloat cp2x, CGFloat cp2y, CGFloat x, CGFloat y)
+    void CGContextAddQuadCurveToPoint(CGContextRef context, CGFloat cpx,
+        CGFloat cpy, CGFloat x, CGFloat y)
     void CGContextAddRect(CGContextRef context, CGRect rect)
     void CGContextAddRects(CGContextRef context, CGRect rects[], size_t count)
-    void CGContextAddArc(CGContextRef context, float x, float y, float radius,
-        float startAngle, float endAngle, int clockwise)
-    void CGContextAddArcToPoint(CGContextRef context, float x1, float y1,
-        float x2, float y2, float radius)
+    void CGContextAddArc(CGContextRef context, CGFloat x, CGFloat y, CGFloat radius,
+        CGFloat startAngle, CGFloat endAngle, int clockwise)
+    void CGContextAddArcToPoint(CGContextRef context, CGFloat x1, CGFloat y1,
+        CGFloat x2, CGFloat y2, CGFloat radius)
     void CGContextClosePath(CGContextRef context)
     void CGContextAddEllipseInRect(CGContextRef context, CGRect rect)
 
@@ -127,7 +127,7 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     void CGContextFillPath(CGContextRef context)
     void CGContextEOFillPath(CGContextRef context)
     void CGContextStrokeRect(CGContextRef context, CGRect rect)
-    void CGContextStrokeRectWithWidth(CGContextRef context, CGRect rect, float width)
+    void CGContextStrokeRectWithWidth(CGContextRef context, CGRect rect, CGFloat width)
     void CGContextFillRect(CGContextRef context, CGRect rect)
     void CGContextFillRects(CGContextRef context, CGRect rects[], size_t count)
     void CGContextClearRect(CGContextRef context, CGRect rect)
@@ -181,36 +181,36 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     ctypedef void* CGColorRef
 
     # Color Settings - Partial
-    CGColorRef CGColorCreate(CGColorSpaceRef colorspace, float components[])
-#    CGColorRef CGColorCreateWithPattern(CGColorSpaceRef colorspace, CGPatternRef pattern, float components[])
+    CGColorRef CGColorCreate(CGColorSpaceRef colorspace, CGFloat components[])
+#    CGColorRef CGColorCreateWithPattern(CGColorSpaceRef colorspace, CGPatternRef pattern, CGFloat components[])
     CGColorRef CGColorCreateCopy(CGColorRef color)
-    CGColorRef CGColorCreateCopyWithAlpha(CGColorRef color, float alpha)
-    CGColorRef CGColorCreateGenericRGB(float red, float green, float blue, float alpha)
+    CGColorRef CGColorCreateCopyWithAlpha(CGColorRef color, CGFloat alpha)
+    CGColorRef CGColorCreateGenericRGB(CGFloat red, CGFloat green, CGFloat blue, CGFloat alpha)
     CGColorRef CGColorRetain(CGColorRef color)
     void CGColorRelease(CGColorRef color)
     bool CGColorEqualToColor(CGColorRef color1, CGColorRef color2)
     size_t CGColorGetNumberOfComponents(CGColorRef color)
-    float *CGColorGetComponents(CGColorRef color)
-    float CGColorGetAlpha(CGColorRef color)
+    CGFloat *CGColorGetComponents(CGColorRef color)
+    CGFloat CGColorGetAlpha(CGColorRef color)
     CGColorSpaceRef CGColorGetColorSpace(CGColorRef color)
 #    CGPatternRef CGColorGetPattern(CGColorRef color)
 
     void CGContextSetFillColorSpace(CGContextRef context, CGColorSpaceRef colorspace)
-    void CGContextSetFillColor(CGContextRef context, float components[])
+    void CGContextSetFillColor(CGContextRef context, CGFloat components[])
     void CGContextSetStrokeColorSpace(CGContextRef context,
         CGColorSpaceRef colorspace)
-    void CGContextSetStrokeColor(CGContextRef context, float components[])
-    void CGContextSetGrayFillColor(CGContextRef context, float gray, float alpha)
-    void CGContextSetGrayStrokeColor(CGContextRef context, float gray, float alpha)
-    void CGContextSetRGBFillColor(CGContextRef context, float red, float green,
-        float blue, float alpha)
-    void CGContextSetRGBStrokeColor(CGContextRef context, float red, float green,
-        float blue, float alpha)
-    void CGContextSetCMYKFillColor(CGContextRef context, float cyan, float magenta,
-        float yellow, float black, float alpha)
-    void CGContextSetCMYKStrokeColor(CGContextRef context, float cyan, float magenta,
-        float yellow, float black, float alpha)
-    void CGContextSetAlpha(CGContextRef context, float alpha)
+    void CGContextSetStrokeColor(CGContextRef context, CGFloat components[])
+    void CGContextSetGrayFillColor(CGContextRef context, CGFloat gray, CGFloat alpha)
+    void CGContextSetGrayStrokeColor(CGContextRef context, CGFloat gray, CGFloat alpha)
+    void CGContextSetRGBFillColor(CGContextRef context, CGFloat red, CGFloat green,
+        CGFloat blue, CGFloat alpha)
+    void CGContextSetRGBStrokeColor(CGContextRef context, CGFloat red, CGFloat green,
+        CGFloat blue, CGFloat alpha)
+    void CGContextSetCMYKFillColor(CGContextRef context, CGFloat cyan, CGFloat magenta,
+        CGFloat yellow, CGFloat black, CGFloat alpha)
+    void CGContextSetCMYKStrokeColor(CGContextRef context, CGFloat cyan, CGFloat magenta,
+        CGFloat yellow, CGFloat black, CGFloat alpha)
+    void CGContextSetAlpha(CGContextRef context, CGFloat alpha)
     void CGContextSetRenderingIntent(CGContextRef context,
         CGColorRenderingIntent intent)
     void CGContextSetBlendMode(CGContextRef context, CGBlendMode mode)
@@ -246,20 +246,20 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
         kCGEncodingFontSpecific
         kCGEncodingMacRoman
 
-    void CGContextSelectFont(CGContextRef context, char* name, float size,
+    void CGContextSelectFont(CGContextRef context, char* name, CGFloat size,
         CGTextEncoding textEncoding)
-    void CGContextSetFontSize(CGContextRef context, float size)
-    void CGContextSetCharacterSpacing(CGContextRef context, float spacing)
+    void CGContextSetFontSize(CGContextRef context, CGFloat size)
+    void CGContextSetCharacterSpacing(CGContextRef context, CGFloat spacing)
     void CGContextSetTextDrawingMode(CGContextRef context, CGTextDrawingMode mode)
-    void CGContextSetTextPosition(CGContextRef context, float x, float y)
+    void CGContextSetTextPosition(CGContextRef context, CGFloat x, CGFloat y)
     CGPoint CGContextGetTextPosition(CGContextRef context)
     void CGContextSetTextMatrix(CGContextRef context, CGAffineTransform transform)
     CGAffineTransform CGContextGetTextMatrix(CGContextRef context)
     void CGContextShowText(CGContextRef context, char* bytes, size_t length)
     void CGContextShowGlyphs(CGContextRef context, CGGlyph glyphs[], size_t count)
-    void CGContextShowTextAtPoint(CGContextRef context, float x, float y,
+    void CGContextShowTextAtPoint(CGContextRef context, CGFloat x, CGFloat y,
         char* bytes, size_t length)
-    void CGContextShowGlyphsAtPoint(CGContextRef context, float x, float y,
+    void CGContextShowGlyphsAtPoint(CGContextRef context, CGFloat x, CGFloat y,
         CGGlyph g[], size_t count)
     void CGContextShowGlyphsWithAdvances(CGContextRef c, CGGlyph glyphs[],
         CGSize advances[], size_t count)
@@ -273,27 +273,27 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     CGDataProviderRef CGDataProviderCreateWithURL(CFURLRef url)
 
     # Using Geometric Primitives
-    CGPoint CGPointMake(float x, float y)
-    CGSize CGSizeMake(float width, float height)
-    CGRect CGRectMake(float x, float y, float width, float height)
+    CGPoint CGPointMake(CGFloat x, CGFloat y)
+    CGSize CGSizeMake(CGFloat width, CGFloat height)
+    CGRect CGRectMake(CGFloat x, CGFloat y, CGFloat width, CGFloat height)
     CGRect CGRectStandardize(CGRect rect)
-    CGRect CGRectInset(CGRect rect, float dx, float dy)
-    CGRect CGRectOffset(CGRect rect, float dx, float dy)
+    CGRect CGRectInset(CGRect rect, CGFloat dx, CGFloat dy)
+    CGRect CGRectOffset(CGRect rect, CGFloat dx, CGFloat dy)
     CGRect CGRectIntegral(CGRect rect)
     CGRect CGRectUnion(CGRect r1, CGRect r2)
     CGRect CGRectIntersection(CGRect rect1, CGRect rect2)
     void CGRectDivide(CGRect rect, CGRect * slice, CGRect * remainder,
-        float amount, CGRectEdge edge)
+        CGFloat amount, CGRectEdge edge)
 
     # Getting Geometric Information
-    float CGRectGetMinX(CGRect rect)
-    float CGRectGetMidX(CGRect rect)
-    float CGRectGetMaxX(CGRect rect)
-    float CGRectGetMinY(CGRect rect)
-    float CGRectGetMidY(CGRect rect)
-    float CGRectGetMaxY(CGRect rect)
-    float CGRectGetWidth(CGRect rect)
-    float CGRectGetHeight(CGRect rect)
+    CGFloat CGRectGetMinX(CGRect rect)
+    CGFloat CGRectGetMidX(CGRect rect)
+    CGFloat CGRectGetMaxX(CGRect rect)
+    CGFloat CGRectGetMinY(CGRect rect)
+    CGFloat CGRectGetMidY(CGRect rect)
+    CGFloat CGRectGetMaxY(CGRect rect)
+    CGFloat CGRectGetWidth(CGRect rect)
+    CGFloat CGRectGetHeight(CGRect rect)
     int CGRectIsNull(CGRect rect)
     int CGRectIsEmpty(CGRect rect)
     int CGRectIntersectsRect(CGRect rect1, CGRect rect2)
@@ -308,15 +308,15 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
 
     CGAffineTransform CGAffineTransformIdentity
 
-    CGAffineTransform CGAffineTransformMake(float a, float b, float c, float d,
-        float tx, float ty)
-    CGAffineTransform CGAffineTransformMakeTranslation(float tx, float ty)
-    CGAffineTransform CGAffineTransformMakeScale(float sx, float sy)
-    CGAffineTransform CGAffineTransformMakeRotation(float angle)
-    CGAffineTransform CGAffineTransformTranslate(CGAffineTransform t, float tx,
-        float ty)
-    CGAffineTransform CGAffineTransformScale(CGAffineTransform t, float sx, float sy)
-    CGAffineTransform CGAffineTransformRotate(CGAffineTransform t, float angle)
+    CGAffineTransform CGAffineTransformMake(CGFloat a, CGFloat b, CGFloat c, CGFloat d,
+        CGFloat tx, CGFloat ty)
+    CGAffineTransform CGAffineTransformMakeTranslation(CGFloat tx, CGFloat ty)
+    CGAffineTransform CGAffineTransformMakeScale(CGFloat sx, CGFloat sy)
+    CGAffineTransform CGAffineTransformMakeRotation(CGFloat angle)
+    CGAffineTransform CGAffineTransformTranslate(CGAffineTransform t, CGFloat tx,
+        CGFloat ty)
+    CGAffineTransform CGAffineTransformScale(CGAffineTransform t, CGFloat sx, CGFloat sy)
+    CGAffineTransform CGAffineTransformRotate(CGAffineTransform t, CGFloat angle)
     CGAffineTransform CGAffineTransformInvert(CGAffineTransform t)
     CGAffineTransform CGAffineTransformConcat(CGAffineTransform t1,
         CGAffineTransform t2)
@@ -344,15 +344,15 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
 
     CGImageRef CGImageCreate(size_t width, size_t height, size_t bitsPerComponent,
         size_t bitsPerPixel, size_t bytesPerRow, CGColorSpaceRef colorspace,
-        CGImageAlphaInfo alphaInfo, CGDataProviderRef provider, float decode[],
+        CGImageAlphaInfo alphaInfo, CGDataProviderRef provider, CGFloat decode[],
         bool shouldInterpolate, CGColorRenderingIntent intent)
     CGImageRef CGImageMaskCreate(size_t width, size_t height, size_t bitsPerComponent,
         size_t bitsPerPixel, size_t bytesPerRow, CGDataProviderRef provider,
-        float decode[], bool shouldInterpolate)
+        CGFloat decode[], bool shouldInterpolate)
     CGImageRef CGImageCreateWithJPEGDataProvider(CGDataProviderRef source,
-        float decode[], bool shouldInterpolate, CGColorRenderingIntent intent)
+        CGFloat decode[], bool shouldInterpolate, CGColorRenderingIntent intent)
     CGImageRef CGImageCreateWithPNGDataProvider(CGDataProviderRef source,
-        float decode[], bool shouldInterpolate, CGColorRenderingIntent intent)
+        CGFloat decode[], bool shouldInterpolate, CGColorRenderingIntent intent)
     CGImageRef CGImageCreateCopyWithColorSpace(CGImageRef image,
         CGColorSpaceRef colorspace)
     CGImageRef CGImageRetain(CGImageRef image)
@@ -366,7 +366,7 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     CGColorSpaceRef CGImageGetColorSpace(CGImageRef image)
     CGImageAlphaInfo CGImageGetAlphaInfo(CGImageRef image)
     CGDataProviderRef CGImageGetDataProvider(CGImageRef image)
-    float *CGImageGetDecode(CGImageRef image)
+    CGFloat *CGImageGetDecode(CGImageRef image)
     bool CGImageGetShouldInterpolate(CGImageRef image)
     CGColorRenderingIntent CGImageGetRenderingIntent(CGImageRef image)
     void CGContextDrawImage(CGContextRef context, CGRect rect, CGImageRef image)
@@ -419,12 +419,12 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     CGPathRef CGPathRetain(CGPathRef path)
     void CGPathRelease(CGPathRef path)
     bool CGPathEqualToPath(CGPathRef path1, CGPathRef path2)
-    void CGPathMoveToPoint(CGMutablePathRef path, CGAffineTransform *m, float x, float y)
-    void CGPathAddLineToPoint(CGMutablePathRef path, CGAffineTransform *m, float x, float y)
+    void CGPathMoveToPoint(CGMutablePathRef path, CGAffineTransform *m, CGFloat x, CGFloat y)
+    void CGPathAddLineToPoint(CGMutablePathRef path, CGAffineTransform *m, CGFloat x, CGFloat y)
     void CGPathAddQuadCurveToPoint(CGMutablePathRef path, CGAffineTransform *m,
-        float cpx, float cpy, float x, float y)
+        CGFloat cpx, CGFloat cpy, CGFloat x, CGFloat y)
     void CGPathAddCurveToPoint(CGMutablePathRef path, CGAffineTransform *m,
-        float cp1x, float cp1y, float cp2x, float cp2y, float x, float y)
+        CGFloat cp1x, CGFloat cp1y, CGFloat cp2x, CGFloat cp2y, CGFloat x, CGFloat y)
     void CGPathCloseSubpath(CGMutablePathRef path)
     void CGPathAddRect(CGMutablePathRef path, CGAffineTransform *m, CGRect rect)
     void CGPathAddRects(CGMutablePathRef path, CGAffineTransform *m,
@@ -432,9 +432,9 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     void CGPathAddLines(CGMutablePathRef path, CGAffineTransform *m,
         CGPoint points[], size_t count)
     void CGPathAddArc(CGMutablePathRef path, CGAffineTransform *m,
-        float x, float y, float radius, float startAngle, float endAngle, bool clockwise)
+        CGFloat x, CGFloat y, CGFloat radius, CGFloat startAngle, CGFloat endAngle, bool clockwise)
     void CGPathAddArcToPoint(CGMutablePathRef path, CGAffineTransform *m,
-        float x1, float y1, float x2, float y2, float radius)
+        CGFloat x1, CGFloat y1, CGFloat x2, CGFloat y2, CGFloat radius)
     void CGPathAddPath(CGMutablePathRef path1, CGAffineTransform *m, CGPathRef path2)
     bool CGPathIsEmpty(CGPathRef path)
     bool CGPathIsRect(CGPathRef path, CGRect *rect)
@@ -465,7 +465,7 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
 
     ctypedef void* CGFunctionRef
 
-    ctypedef void (*CGFunctionEvaluateCallback)(void *info, float *in_data, float *out)
+    ctypedef void (*CGFunctionEvaluateCallback)(void *info, CGFloat *in_data, CGFloat *out)
 
     ctypedef void (*CGFunctionReleaseInfoCallback)(void *info)
 
@@ -475,7 +475,7 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
         CGFunctionReleaseInfoCallback releaseInfo
 
     CGFunctionRef CGFunctionCreate(void *info, size_t domainDimension,
-        float *domain, size_t rangeDimension, float *range,
+        CGFloat *domain, size_t rangeDimension, CGFloat *range,
         CGFunctionCallbacks *callbacks)
     CGFunctionRef CGFunctionRetain(CGFunctionRef function)
     void CGFunctionRelease(CGFunctionRef function)
@@ -485,7 +485,7 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     CGShadingRef CGShadingCreateAxial(CGColorSpaceRef colorspace, CGPoint start,
         CGPoint end, CGFunctionRef function, bool extendStart, bool extendEnd)
     CGShadingRef CGShadingCreateRadial(CGColorSpaceRef colorspace,
-        CGPoint start, float startRadius, CGPoint end, float endRadius,
+        CGPoint start, CGFloat startRadius, CGPoint end, CGFloat endRadius,
         CGFunctionRef function, bool extendStart, bool extendEnd)
     CGShadingRef CGShadingRetain(CGShadingRef shading)
     void CGShadingRelease(CGShadingRef shading)

--- a/kiva/quartz/CoreText.pxi
+++ b/kiva/quartz/CoreText.pxi
@@ -221,25 +221,25 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
         kCTLineTruncationMiddle = 2
 
     # Fonts
-    CTFontRef CTFontCreateWithName(CFStringRef name, float size,
+    CTFontRef CTFontCreateWithName(CFStringRef name, CGFloat size,
         void *matrix)
     CTFontRef CTFontCreateWithFontDescriptor(CTFontDescriptorRef descriptor,
-        float size, void *matrix)
+        CGFloat size, void *matrix)
     
     #CTFontRef CTFontCreateUIFontForLanguage(CTFontUIFontType uiType,
-    #    float size, CFStringRef language)
-    #CTFontRef CTFontCreateCopyWithAttributes(CTFontRef font, float size,
+    #    CGFloat size, CFStringRef language)
+    #CTFontRef CTFontCreateCopyWithAttributes(CTFontRef font, CGFloat size,
     #    void *matrix, CTFontDescriptorRef attributes)
-    CTFontRef CTFontCreateCopyWithSymbolicTraits(CTFontRef font, float size,
+    CTFontRef CTFontCreateCopyWithSymbolicTraits(CTFontRef font, CGFloat size,
         void *matrix, CTFontSymbolicTraits symTraitValue, 
         CTFontSymbolicTraits symTraitMask)
-    #CTFontRef CTFontCreateCopyWithFamily(CTFontRef font, float size,
+    #CTFontRef CTFontCreateCopyWithFamily(CTFontRef font, CGFloat size,
     #    void *matrix, CFStringRef family)
     #CTFontRef CTFontCreateForString(CTFontRef currentFont, CFStringRef string,
     #    CFRange range)
     CTFontDescriptorRef CTFontCopyFontDescriptor(CTFontRef font)
     CFTypeRef CTFontCopyAttribute(CTFontRef font, CFStringRef attribute)
-    float CTFontGetSize(CTFontRef font)
+    CGFloat CTFontGetSize(CTFontRef font)
     void CTFontGetMatrix(CTFontRef font)
     CTFontSymbolicTraits CTFontGetSymbolicTraits(CTFontRef font)
     CFDictionaryRef CTFontCopyTraits(CTFontRef font)
@@ -255,17 +255,17 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     CFArrayRef CTFontCopySupportedLanguages(CTFontRef font)
     Boolean CTFontGetGlyphsForCharacters(CTFontRef font,
         UniChar characters[], CGGlyph glyphs[], CFIndex count)
-    float CTFontGetAscent(CTFontRef font)
-    float CTFontGetDescent(CTFontRef font)
-    float CTFontGetLeading(CTFontRef font)
+    CGFloat CTFontGetAscent(CTFontRef font)
+    CGFloat CTFontGetDescent(CTFontRef font)
+    CGFloat CTFontGetLeading(CTFontRef font)
     unsigned CTFontGetUnitsPerEm(CTFontRef font)
     CFIndex CTFontGetGlyphCount(CTFontRef font)
     CGRect CTFontGetBoundingBox(CTFontRef font)
-    float CTFontGetUnderlinePosition(CTFontRef font)
-    float CTFontGetUnderlineThickness(CTFontRef font)
-    float CTFontGetSlantAngle(CTFontRef font)
-    float CTFontGetCapHeight(CTFontRef font)
-    float CTFontGetXHeight(CTFontRef font)
+    CGFloat CTFontGetUnderlinePosition(CTFontRef font)
+    CGFloat CTFontGetUnderlineThickness(CTFontRef font)
+    CGFloat CTFontGetSlantAngle(CTFontRef font)
+    CGFloat CTFontGetCapHeight(CTFontRef font)
+    CGFloat CTFontGetXHeight(CTFontRef font)
     CGGlyph CTFontGetGlyphWithName(CTFontRef font, CFStringRef glyphName)
     CGRect CTFontGetBoundingRectsForGlyphs(CTFontRef font,
         CTFontOrientation orientation, CGGlyph glyphs[],
@@ -283,13 +283,13 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     CFArrayRef CTFontCopyFeatures(CTFontRef font)
     CFArrayRef CTFontCopyFeatureSettings(CTFontRef font)
     CGFontRef CTFontCopyGraphicsFont(CTFontRef font, CTFontDescriptorRef *attributes)
-    CTFontRef CTFontCreateWithGraphicsFont(CGFontRef graphicsFont, float size,
+    CTFontRef CTFontCreateWithGraphicsFont(CGFontRef graphicsFont, CGFloat size,
         void *matrix, CTFontDescriptorRef attributes)
     #ATSFontRef CTFontGetPlatformFont(CTFontRef font, CTFontDescriptorRef *attributes)
-    #CTFontRef CTFontCreateWithPlatformFont(ATSFontRef platformFont, float size,
+    #CTFontRef CTFontCreateWithPlatformFont(ATSFontRef platformFont, CGFloat size,
     #    void *matrix, CTFontDescriptorRef attributes)
     #CTFontRef CTFontCreateWithQuickdrawInstance(ConstStr255Param name,
-    #    int16_t identifier, uint8_t style, float size)
+    #    int16_t identifier, uint8_t style, CGFloat size)
     
     #CFArrayRef CTFontCopyAvailableTables(CTFontRef font,
     #    CTFontTableOptions options)
@@ -311,7 +311,7 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
 
     # Font Descriptors
     CTFontDescriptorRef CTFontDescriptorCreateWithNameAndSize(CFStringRef name,
-        float size)
+        CGFloat size)
     CTFontDescriptorRef CTFontDescriptorCreateWithAttributes(
         CFDictionaryRef attributes)
     CTFontDescriptorRef CTFontDescriptorCreateCopyWithAttributes(
@@ -319,7 +319,7 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     
     #CTFontDescriptorRef CTFontDescriptorCreateCopyWithVariation(
     #    CTFontDescriptorRef original, CFNumberRef variationIdentifier,
-    #    float variationValue)
+    #    CGFloat variationValue)
     #CTFontDescriptorRef CTFontDescriptorCreateCopyWithFeature(
     #    CTFontDescriptorRef original, CFNumberRef featureTypeIdentifier,
     #    CFNumberRef featureSelectorIdentifier)
@@ -338,18 +338,18 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     CTLineRef CTLineCreateWithAttributedString(CFAttributedStringRef string)
     CTLineRef CTLineCreateTruncatedLine(CTLineRef line, double width,
         CTLineTruncationType truncationType, CTLineRef truncationToken)
-    CTLineRef CTLineCreateJustifiedLine(CTLineRef line, float justificationFactor,
+    CTLineRef CTLineCreateJustifiedLine(CTLineRef line, CGFloat justificationFactor,
         double justificationWidth)
     CFIndex CTLineGetGlyphCount(CTLineRef line)
     CFArrayRef CTLineGetGlyphRuns(CTLineRef line)
     CFRange CTLineGetStringRange(CTLineRef line)
-    double CTLineGetPenOffsetForFlush(CTLineRef line, float flushFactor,
+    double CTLineGetPenOffsetForFlush(CTLineRef line, CGFloat flushFactor,
         double flushWidth)
     void CTLineDraw(CTLineRef line, CGContextRef context)
     CGRect CTLineGetImageBounds(CTLineRef line, CGContextRef context)
-    double CTLineGetTypographicBounds(CTLineRef line, float* ascent,
-        float* descent, float* leading)
+    double CTLineGetTypographicBounds(CTLineRef line, CGFloat* ascent,
+        CGFloat* descent, CGFloat* leading)
     double CTLineGetTrailingWhitespaceWidth(CTLineRef line)
     CFIndex CTLineGetStringIndexForPosition(CTLineRef line, CGPoint position)
-    float CTLineGetOffsetForStringIndex(CTLineRef line, CFIndex charIndex,
-        float* secondaryOffset)
+    CGFloat CTLineGetOffsetForStringIndex(CTLineRef line, CFIndex charIndex,
+        CGFloat* secondaryOffset)


### PR DESCRIPTION
This fixes gradients and text measurement in the 64-bit build of the Quartz
backend. The 32-bit build is unchanged.

I'm pretty sure I covered all the places where CoreGraphics or CoreText functions are expecting CGFloat pointers, but a second set of eyes would be helpful.
