### PR TITLE
.relative imports with * are forbidden in Python 2.5

### DIFF
--- a/kiva/__init__.py
+++ b/kiva/__init__.py
@@ -15,10 +15,8 @@ A multi-platform DisplayPDF vector drawing engine.
 Part of the Enable project of the Enthought Tool Suite.
 """
 
-from __future__ import absolute_import
-
-from .constants import *
-from .fonttools import Font
+from constants import *
+from fonttools import Font
 
 import os
 if os.environ.has_key('KIVA_WISHLIST'):


### PR DESCRIPTION
Though they do work with later versions of Python.
