### PR TITLE
Agg's GraphicsContext.set_text_matrix() function should accept a 3x3 numpy array

### DIFF
--- a/kiva/agg/src/graphics_context.i
+++ b/kiva/agg/src/graphics_context.i
@@ -492,6 +492,20 @@ namespace kiva {
 
             bool is_font_initialized();
 
+            %feature("shadow") set_text_matrix(agg24::trans_affine& value)
+            %{
+            def set_text_matrix(self, matrix):
+                """ Set the text matrix.
+
+                `matrix` must be either a kiva.agg.AffineMatrix instance, or
+                a 3x3 numpy array.
+                """
+                if isinstance(matrix, ndarray) and matrix.shape == (3,3):
+                    matrix = AffineMatrix(matrix[0, 0], matrix[0, 1],
+                                          matrix[1, 0], matrix[1, 1],
+                                          matrix[2, 0], matrix[2, 1])
+                _agg.GraphicsContextArray_set_text_matrix(self, matrix)
+            %}
             void set_text_matrix(agg24::trans_affine& value);
 
             agg24::trans_affine get_text_matrix();

--- a/kiva/agg/tests/graphics_context_test_case.py
+++ b/kiva/agg/tests/graphics_context_test_case.py
@@ -362,6 +362,14 @@ class GraphicsContextArrayTestCase(unittest.TestCase):
         except TypeError:
             pass
 
+    def test_set_text_matrix_ndarray(self):
+        """ Test that gc.set_text_matrix accepts 3x3 ndarrays. """
+        gc = agg.GraphicsContextArray((5, 5))
+        m = array([[1.0, 2.0, 0.0], [3.0, 4.0, 0.0], [5.0, 6.0, 1.0]])
+        gc.set_text_matrix(m)
+        m2 = gc.get_text_matrix()
+        self.assertEqual(m2, agg.AffineMatrix(1.0, 2.0, 3.0, 4.0, 5.0, 6.0))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request allows the set_text_matrix() method of the GraphicsContext class in the Agg backend to accept 3x3 numpy arrays.  This is consistent with the other backends.

Before:

```
In [1]: from kiva.affine import affine_from_rotation

In [2]: from kiva.agg import GraphicsContextArray

In [3]: r = affine_from_rotation(pi/3)

In [4]: r
Out[4]: 
array([[ 0.5      ,  0.8660254,  0.       ],
       [-0.8660254,  0.5      ,  0.       ],
       [ 0.       ,  0.       ,  1.       ]])

In [5]: gc = GraphicsContextArray((10,10))

In [6]: gc.set_text_matrix(r)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/Users/warren/<ipython-input-6-35ba276ec0fc> in <module>()
----> 1 gc.set_text_matrix(r)

/Library/Frameworks/Python.framework/Versions/7.3/lib/python2.7/site-packages/kiva/agg/agg.pyc in set_text_matrix(self, *args)
    916 
    917     def is_font_initialized(self, *args): return _agg.GraphicsContextArray_is_font_initialized(self, *args)
--> 918     def set_text_matrix(self, *args): return _agg.GraphicsContextArray_set_text_matrix(self, *args)
    919     def get_text_matrix(self, *args): return _agg.GraphicsContextArray_get_text_matrix(self, *args)
    920     def set_character_spacing(self, *args): return _agg.GraphicsContextArray_set_character_spacing(self, *args)

TypeError: in method 'GraphicsContextArray_set_text_matrix', argument 2 of type 'agg24::trans_affine &'
```

After:

```
In [1]: from kiva.affine import affine_from_rotation

In [2]: from kiva.agg import GraphicsContextArray

In [3]: r = affine_from_rotation(pi/3)

In [4]: gc = GraphicsContextArray((10,10))

In [5]: gc.set_text_matrix(r)

In [6]: gc.get_text_matrix()
Out[6]: AffineMatrix(0.5,0.866025,-0.866025,0.5,0,0)
```
