### PR TITLE
Quartz backend: Don't call CGContextClosePath or CGContextClip with an empty path

### DIFF
--- a/kiva/quartz/ABCGI.pyx
+++ b/kiva/quartz/ABCGI.pyx
@@ -537,7 +537,8 @@ cdef class CGContext:
     def close_path(self):
         """ Close the path of the current subpath.
         """
-        CGContextClosePath(self.context)
+        if not CGContextIsPathEmpty(self.context):
+            CGContextClosePath(self.context)
 
     def curve_to(self, float cp1x, float cp1y, float cp2x, float cp2y,
         float x, float y):
@@ -602,7 +603,8 @@ cdef class CGContext:
     def clip(self):
         """
         """
-        CGContextClip(self.context)
+        if not CGContextIsPathEmpty(self.context):
+            CGContextClip(self.context)
 
     def even_odd_clip(self):
         """


### PR DESCRIPTION
When run on a Mac, a project that I'm working on that makes heavy use of Chaco prints out a steady stream of messages like:

```
Wed Aug 29 18:14:54 Warren-Weckessers-MacBook-Pro.local Python[87697] <Error>: doClip: empty path.
Wed Aug 29 18:14:54 Warren-Weckessers-MacBook-Pro.local Python[87697] <Error>: CGContextClosePath: no current point.
Wed Aug 29 18:14:54 Warren-Weckessers-MacBook-Pro.local Python[87697] <Error>: doClip: empty path.
Wed Aug 29 18:14:54 Warren-Weckessers-MacBook-Pro.local Python[87697] <Error>: CGContextClosePath: no current point.
Wed Aug 29 18:14:54 Warren-Weckessers-MacBook-Pro.local Python[87697] <Error>: doClip: empty path.
Wed Aug 29 18:14:54 Warren-Weckessers-MacBook-Pro.local Python[87697] <Error>: CGContextClosePath: no current point.
```

This pull request fixes the problem by making sure that CGContextClip and CGContextClosePath are not called with an empty path.
