### PR TITLE
BUGFIX: handle missing window control during mouse events on qt

### DIFF
--- a/enable/abstract_window.py
+++ b/enable/abstract_window.py
@@ -298,6 +298,10 @@ class AbstractWindow(HasTraits):
             return False
 
         mouse_event = self._create_mouse_event(event)
+        # if no mouse event generated for some reason, return
+        if mouse_event is None:
+            return False
+        
         mouse_owner = self.mouse_owner
 
         if mouse_owner is not None:

--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -366,6 +366,9 @@ class _Window(AbstractWindow):
                         window=self)
 
     def _create_mouse_event(self, event):
+        # If the control no longer exists, don't send mouse event
+        if self.control is None:
+            return None
         # If the event (if there is one) doesn't contain the mouse position,
         # modifiers and buttons then get sensible defaults.
         try:


### PR DESCRIPTION
Under some circumstances we were trying to handle mouse events for missing controls - usually where the window was being removed programmatically from traits ui.  This fixes the issue by checking that the control exists before trying to create a mouse event.

If not control is found, we return None, and so we add a check for this possibility in the abstract window base class.
