### PR TITLE
Transparency bug with image backend

### DIFF
--- a/enable/qt4/image.py
+++ b/enable/qt4/image.py
@@ -34,7 +34,7 @@ class Window(BaseWindow):
         w = self._gc.width()
         h = self._gc.height()
         data = self._gc.pixel_map.convert_to_argb32string()
-        image = QtGui.QImage(data, w, h, QtGui.QImage.Format_RGB32)
+        image = QtGui.QImage(data, w, h, QtGui.QImage.Format_ARGB32)
         rect = QtCore.QRect(0,0,w,h)
         painter = QtGui.QPainter(self.control)
         painter.drawImage(rect, image)


### PR DESCRIPTION
The image backend was not passing along the alpha channel to Qt, so setting the background color to transparent was resulting in a black background.
