### PR TITLE
Changing TestGCErrors arguments

### DIFF
--- a/enable/tests/kiva_graphics_context_test_case.py
+++ b/enable/tests/kiva_graphics_context_test_case.py
@@ -14,10 +14,10 @@ class TestGCErrors(unittest.TestCase):
         # The draw_image methods expects its first argument
         # to be a 3D whose last dimension has lenght 3 or 4.
         # Passing in arr should raise a value error.
-        self.assertRaises(ValueError, gc.draw_image, arr)
+        self.assertRaises(AssertionError, gc.draw_image, arr)
 
         # Pass in a 3D array, but with an invalid size in the last dimension.
-        self.assertRaises(ValueError, gc.draw_image, arr.reshape(2, 2, 1))
+        self.assertRaises(AssertionError, gc.draw_image, arr.reshape(2, 2, 1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Passing an array with incompatible dimensions to gc.draw_image raises `AssertionError` and not `ValueError`
