### PR TITLE
Modified draw_image to work around memory leak in QPainter.device().

### DIFF
--- a/kiva/qpainter.py
+++ b/kiva/qpainter.py
@@ -585,9 +585,11 @@ class GraphicsContext(object):
                                     QtGui.QImage.Format_RGB32)
             pixmap = QtGui.QPixmap.fromImage(draw_img)
         elif (isinstance(img, GraphicsContext) and
-              isinstance(img.gc.device(), QtGui.QPixmap)):
+              isinstance(img.qt_dc, QtGui.QPixmap) and img.gc.isActive()):
             # An offscreen Qt kiva context
-            pixmap = img.gc.device()
+            # Calling qpainter.device() appears to introduce a memory leak.
+            # using the display context and calling qpainter.isActive() has the same outcome.
+            pixmap = img.qt_dc
             width, height = pixmap.width(), pixmap.height()
         else:
             warnings.warn("Cannot render image of type '%r' into Qt4 context." % \


### PR DESCRIPTION
Instead of calling QPainter.device() to check that the painter is active
and to get the device, the kiva.qpainter.GraphicsContext qt_dc member is
checked to see that it is an instance of QPixmap. To check that the
painter is active, QPainter.isActive() is called on
kiva.qpainter.GraphicsContext.gc . This has been tested with
qt_example.py  in the Chaco demos by setting:

 ETSConfig.toolkit = "qt4.qpainter" .

Where there was once a memory leak, it now appears that there is none.
