### PR TITLE
TEST: Fix a few failing tests (minor).

### DIFF
--- a/enable/savage/svg/pathdata.py
+++ b/enable/savage/svg/pathdata.py
@@ -31,17 +31,13 @@ class CaselessPreservingLiteral(CaselessLiteral):
         super(CaselessPreservingLiteral,self).__init__( matchString.upper() )
         self.name = "'%s'" % matchString
         self.errmsg = "Expected " + self.name
-        self.myException.msg = self.errmsg
 
     def parseImpl( self, instring, loc, doActions=True ):
         test = instring[ loc:loc+self.matchLen ]
         if test.upper() == self.match:
             return loc+self.matchLen, test
         #~ raise ParseException( instring, loc, self.errmsg )
-        exc = self.myException
-        exc.loc = loc
-        exc.pstr = instring
-        raise exc
+        raise ParseException(instring, loc, self.errmsg, self)
 
 def Sequence(token):
     """ A sequence of the token"""

--- a/enable/tests/kiva_graphics_context_test_case.py
+++ b/enable/tests/kiva_graphics_context_test_case.py
@@ -12,7 +12,7 @@ class TestGCErrors(unittest.TestCase):
         arr = np.array([[1, 2], [3, 4]], dtype=np.uint8)
         gc = GraphicsContext((50, 50))
         # The draw_image methods expects its first argument
-        # to be a 3D whose last dimension has lenght 3 or 4.
+        # to be a 3D whose last dimension has length 3 or 4.
         # Passing in arr should raise a value error.
         self.assertRaises(ValueError, gc.draw_image, arr)
 

--- a/kiva/agg/src/graphics_context.i
+++ b/kiva/agg/src/graphics_context.i
@@ -895,11 +895,13 @@ def init(self, ary_or_size, pix_format="bgra32",
         ary = ary_or_size
         sh = shape(ary)
         if len(sh) == 2:
-            msg = "2D arrays must use a format that is one byte per pixel"
-            assert img_depth == 1, msg
+            if img_depth != 1:
+                msg = "2D arrays must use a format that is one byte per pixel"
+                raise ValueError(msg)
         elif len(sh) == 3:
-            msg = "Image depth and format are incompatible"
-            assert img_depth == sh[2], msg
+            if img_depth != sh[2]:
+                msg = "Image depth and format are incompatible"
+                raise ValueError(msg)
         else:
             msg = "only 2 or 3 dimensional arrays are supported as images"
             msg += " but got sh=%r" % (sh,)


### PR DESCRIPTION
- pyparsing >= 2.0 does no longer stores `myException` attribute
- Kiva GraphicsContext should raise `ValueError` on incorrect
  array argument instead of raising `AssertionError`
