### PR TITLE
Fix #101 Setup: Add necessary import for distutils.commands.clean

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ from os.path import join
 import setuptools
 
 import distutils
+import distutils.command.clean
 import os
 import shutil
 


### PR DESCRIPTION
On many python distributions (eg. on fedora), importing distutils
does not import the `distutils.commands.clean` package used in
setup.py
