### PR TITLE
Fix pip install complaints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - pip install cython
   - sudo apt-get install python-numpy
   - sudo apt-get install swig
-  - pip install --allow-external --allow-unverified PIL
+  - pip install PIL --allow-external PIL --allow-unverified PIL
   - pip install pyparsing
   # Test against the current master of traits and traitsui
   - pip install git+http://github.com/enthought/traits.git#egg=traits


### PR DESCRIPTION
The new version of pip complaints for PIL because it is an external repo and the checksum cannot be verified
