### PR TITLE
BUG: Don't overwrite entries in the KEY_MAP dictionary.

### DIFF
--- a/enable/qt4/constants.py
+++ b/enable/qt4/constants.py
@@ -144,7 +144,7 @@ for enum_name in dir(QtCore.Qt):
     if enum_name.startswith('Key_'):
         enum = getattr(QtCore.Qt, enum_name)
         # Ignore everything in latin-1 as we just want the unichr() conversion.
-        if enum <= 255:
+        if enum <= 255 or enum in KEY_MAP:
             continue
         key_name = enum_name[len('Key_'):]
         KEY_MAP[enum] = key_name


### PR DESCRIPTION
This corrects a regression introduced by #121.

Basically, the key names defined in `enable.toolkit_constants` need to be used by both Qt and WX. By generating its own key names, the `KEY_MAP` for the Qt backend became subtly incompatible with WX.

This was found when some existing code which uses `KeySpec('Esc')` stopped working after pulling the changes introduced by #121 (thanks @noraderam!).

To solve this problem, I've added an extra check in the loop which fills in the `KEY_MAP` dictionary so that keys which were already added (using their proper `toolkit_constants` names) won't be overwritten.
