### PR TITLE
Switch from obsolete PIL to Pillow fork

### DIFF
--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -7,6 +7,6 @@ __version__ = '4.5.0-dev'
 
 __requires__ = [
     'traitsui',
-    'PIL',
+    'Pillow',
     'kiwisolver',
 ]


### PR DESCRIPTION
I'm really not sure about that change. Does it work for you?

Here, enable-4.3.0.egg-info/requires.txt gets "PIL" in it, but I do not have any PIL.egginfo, only a Pillow-2.6.1.egg-info.