### PR TITLE
Simple Button Tool

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ Enhancements
 
  * Added a base class for drag and drop tools, example and test support.
  * PR #160: Basic testing for kiva backends.
+ * PR #168: Simple push-button anf checkbox tool.
 
 
 Enable 4.4.0 (May 1, 2014)
@@ -40,9 +41,9 @@ Enable 3.4.1 (March 3, 2011)
 Fixes
 -----
 
-* Removed OnPaint method from KivaRenderPanel in savage. On Windows there 
+* Removed OnPaint method from KivaRenderPanel in savage. On Windows there
   were competing handlers for the paint event. The OnPaint method expected a
-  certain order, which varied by Platform 
+  certain order, which varied by Platform
 * QImage constructor args were changed to use QByteArray to match changes to
   PySide API changes in PySide RC1
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,7 +9,7 @@ Enhancements
 
  * Added a base class for drag and drop tools, example and test support.
  * PR #160: Basic testing for kiva backends.
- * PR #168: Simple push-button anf checkbox tool.
+ * PR #168: Simple push-button and checkbox tool.
 
 
 Enable 4.4.0 (May 1, 2014)

--- a/docs/source/enable_basic_tools.rst
+++ b/docs/source/enable_basic_tools.rst
@@ -1,0 +1,71 @@
+Enable Tools
+============
+
+Enable ``Tools`` are ``Interator`` subclasses that do not have to have any
+visual representation, and which can be dynamically added and removed from
+components by adding or removing them from the component's ``tools`` list.
+This permits developers to quickly build up complex behaviours from simple,
+reproducible parts without having complex inheritance hierarchies.
+
+Basic Tools
+-----------
+
+Enable provides a number of basic tools for common interactions.
+
+ButtonTool
+~~~~~~~~~~
+
+The :py:class:`ButtonTool` provides basic push-button or checkbox
+interactions, depending on how it is configured.  The primary interface it
+provides is a :py:attr:`clicked` event which is fired when the user clicks in
+the region of the underlying component, or when the :py:meth:`click` method is
+called.  The :py:attr:`clicked` event is fired on mouse up.
+
+To get checkbox-style behaviour, set :py:attr:`togglable` to ``True`` and
+then every click will invert the :py:attr:`checked` trait.  The toggle state
+can also be  changed via the :py:meth:`toggle` method, which does not fire the
+:py:attr:`clicked` event when called.  For buttons with multi-state toggles,
+subclasses can override the :py:meth:`toggle` method to perform more complex
+state changes.
+
+By default, the tool responds to clicks that are within the associated
+component, but subclasses can override this behaviour by replacing the
+:py:method:``is_clickable`` method with something else.
+
+It will commonly be the case that components or :py:class:`ButtonTool`
+subclasses which draw may wish to respond to user interactions by drawing
+themselves in a highlighted or selected mode when the mouse is down inside
+the button region.  The :py:attr:`down` trait provides this information
+conveniently, so that users of the tool can change their drawing state and
+request redraws when it changes.
+
+DragTool
+~~~~~~~~
+
+The :py:class:`DragTool` is an abstract base class that provides basic
+interaction support for draging within Enable.  Many other tools within
+Enable and Chaco use it.
+
+HoverTool
+~~~~~~~~~
+
+The :py:class:`HoverTool` is a simple tool that calls a callback when the
+mouse has been held steadily over the component for a period of time.
+
+MoveTool
+~~~~~~~~
+
+A :py:class:`DragTool` subclass that allows a user to move a component around
+its container by dragging.
+
+ResizeTool
+~~~~~~~~~~
+
+A :py:class:`DragTool` subclass that allows a user to resize a component by
+dragging from the edges of the component.
+
+ValueDragTool
+~~~~~~~~~~~~~
+
+A :py:class:`DragTool` that allows a drag operation to set an arbitrary
+value.

--- a/docs/source/enable_basic_tools.rst
+++ b/docs/source/enable_basic_tools.rst
@@ -30,7 +30,7 @@ state changes.
 
 By default, the tool responds to clicks that are within the associated
 component, but subclasses can override this behaviour by replacing the
-:py:method:``is_clickable`` method with something else.
+:py:method:`is_clickable` method with something else.
 
 It will commonly be the case that components or :py:class:`ButtonTool`
 subclasses which draw may wish to respond to user interactions by drawing
@@ -67,5 +67,5 @@ dragging from the edges of the component.
 ValueDragTool
 ~~~~~~~~~~~~~
 
-A :py:class:`DragTool` that allows a drag operation to set an arbitrary
-value.
+A :py:class:`DragTool` subclass that allows a drag operation to set an
+arbitrary value.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,6 +7,7 @@ Enable Documentation
   enable_concepts.rst
   enable_constraints_layout.rst
   enable_key_events.rst
+  enable_basic_tools.rst
   enable_drag_and_drop.rst
 
   kiva.rst

--- a/enable/testing.py
+++ b/enable/testing.py
@@ -308,7 +308,7 @@ class EnableTestAssistant(KivaTestAssistant):
 
     def mouse_leave(self, interactor, x, y, window=None,
                     alt_down=False, control_down=False, shift_down=False):
-        """ Send a mouse click event to the interactor.
+        """ Send a mouse leave event to the interactor.
 
         Parameters
         ----------
@@ -350,6 +350,52 @@ class EnableTestAssistant(KivaTestAssistant):
                                         control_down=control_down,
                                         shift_down=shift_down)
         self._mouse_event_dispatch(interactor, event, 'mouse_leave')
+        return event
+
+    def mouse_enter(self, interactor, x, y, window=None,
+                    alt_down=False, control_down=False, shift_down=False):
+        """ Send a mouse enter event to the interactor.
+
+        Parameters
+        ----------
+        interactor : Interactor
+            The interactor (or subclass) where to dispatch the event.
+
+        x : float
+            The x coordinates of the mouse position
+
+        y : float
+            The y coordinates of the mouse position
+
+        window : AbstractWindow, optional
+            The enable AbstractWindow to associate with the event. Default
+            is to create a mock class instance. If the window has a mouse
+            owner then that interactor is used.
+
+        alt_down : boolean, optional
+            The button is pressed while `alt` is down. Default value is False.
+
+        control_down : boolean, optional
+            The button is pressed while `control` is down. Default value is
+            False.
+
+        shift_down : boolean, optional
+            The button is pressed while `shift` is down. Default value is
+            False.
+
+        Returns
+        -------
+        event : MouseEvent
+            The event instance after it has be processed by the `interactor`.
+
+        """
+        window = self.create_mock_window() if window is None else window
+        event = self.create_mouse_event(x=x, y=y,
+                                        window=window,
+                                        alt_down=alt_down,
+                                        control_down=control_down,
+                                        shift_down=shift_down)
+        self._mouse_event_dispatch(interactor, event, 'mouse_enter')
         return event
 
     def send_key(self, interactor, key, window=None):

--- a/enable/tests/tools/button_tool_test_case.py
+++ b/enable/tests/tools/button_tool_test_case.py
@@ -55,9 +55,9 @@ class ButtonToolTestCase(EnableTestAssistant, UnittestTools, unittest.TestCase):
         tool = self.tool
         tool.togglable = True
 
-        with self.assertTraitDoesNotChange(tool, 'down', count=1), \
+        with self.assertTraitDoesNotChange(tool, 'down'), \
                 self.assertTraitDoesNotChange(tool, 'clicked'), \
-                self.assertTraitChanges(tool, 'checked'):
+                self.assertTraitChanges(tool, 'checked', count=1):
             tool.toggle()
 
         self.assertTrue(tool.checked)
@@ -67,9 +67,9 @@ class ButtonToolTestCase(EnableTestAssistant, UnittestTools, unittest.TestCase):
         tool.togglable = True
         tool.checked = True
 
-        with self.assertTraitDoesNotChange(tool, 'down', count=1), \
+        with self.assertTraitDoesNotChange(tool, 'down'), \
                 self.assertTraitDoesNotChange(tool, 'clicked'), \
-                self.assertTraitChanges(tool, 'checked'):
+                self.assertTraitChanges(tool, 'checked', count=1):
             tool.toggle()
 
         self.assertFalse(tool.checked)

--- a/enable/tests/tools/button_tool_test_case.py
+++ b/enable/tests/tools/button_tool_test_case.py
@@ -1,0 +1,275 @@
+#
+# (C) Copyright 2015 Enthought, Inc., Austin, TX
+# All right reserved.
+#
+# This file is open source software distributed according to the terms in
+# LICENSE.txt
+#
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from traits.api import Int
+from traits.testing.unittest_tools import UnittestTools, unittest
+
+from enable.component import Component
+from enable.testing import EnableTestAssistant
+from enable.tools.button_tool import ButtonTool
+
+
+class ButtonToolTestCase(EnableTestAssistant, UnittestTools, unittest.TestCase):
+
+    def setUp(self):
+        self.component = Component(position=[50, 50], bounds=[100, 100])
+        self.tool = ButtonTool(component=self.component)
+        self.component.tools.append(self.tool)
+
+    def test_click_function(self):
+        tool = self.tool
+        with self.assertTraitDoesNotChange(tool, 'down'), \
+                self.assertTraitChanges(tool, 'clicked', count=1), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            tool.click()
+
+    def test_click_function_togglable(self):
+        tool = self.tool
+        tool.togglable = True
+
+        with self.assertTraitDoesNotChange(tool, 'down'), \
+                self.assertTraitChanges(tool, 'clicked', count=1), \
+                self.assertTraitChanges(tool, 'checked', count=1):
+            tool.click()
+
+        self.assertTrue(tool.checked)
+
+    def test_toggle_function_untogglable(self):
+        tool = self.tool
+        with self.assertTraitDoesNotChange(tool, 'down'), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitChanges(tool, 'checked'):
+            tool.toggle()
+
+        self.assertTrue(tool.checked)
+
+    def test_toggle_function(self):
+        tool = self.tool
+        tool.togglable = True
+
+        with self.assertTraitDoesNotChange(tool, 'down', count=1), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitChanges(tool, 'checked'):
+            tool.toggle()
+
+        self.assertTrue(tool.checked)
+
+    def test_toggle_function_checked(self):
+        tool = self.tool
+        tool.togglable = True
+        tool.checked = True
+
+        with self.assertTraitDoesNotChange(tool, 'down', count=1), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitChanges(tool, 'checked'):
+            tool.toggle()
+
+        self.assertFalse(tool.checked)
+
+    def test_basic_click(self):
+        window = self.create_mock_window()
+        component = self.component
+        tool = self.tool
+
+        with self.assertTraitChanges(tool, 'down', count=1), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            event = self.mouse_down(component, 100, 100, window=window)
+
+        self.assertTrue(event.handled)
+        self.assertTrue(tool.event_state, 'pressed')
+        self.assertTrue(tool.down)
+        self.assertFalse(tool.checked)
+
+        with self.assertTraitChanges(tool, 'down', count=1), \
+                self.assertTraitChanges(tool, 'clicked', count=1), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            event = self.mouse_up(self.component, 100, 100, window=window)
+
+        self.assertTrue(event.handled)
+        self.assertTrue(tool.event_state, 'normal')
+        self.assertFalse(tool.down)
+        self.assertFalse(tool.checked)
+
+    def test_basic_toggle(self):
+        window = self.create_mock_window()
+        component = self.component
+        tool = self.tool
+        tool.togglable = True
+
+        with self.assertTraitChanges(tool, 'down', count=1), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            event = self.mouse_down(component, 100, 100, window=window)
+
+        self.assertTrue(event.handled)
+        self.assertTrue(tool.event_state, 'pressed')
+        self.assertTrue(tool.down)
+        self.assertFalse(tool.checked)
+
+        with self.assertTraitChanges(tool, 'down', count=1), \
+                self.assertTraitChanges(tool, 'clicked', count=1), \
+                self.assertTraitChanges(tool, 'checked', count=1):
+            event = self.mouse_up(self.component, 100, 100, window=window)
+
+        self.assertTrue(event.handled)
+        self.assertTrue(tool.event_state, 'normal')
+        self.assertFalse(tool.down)
+        self.assertTrue(tool.checked)
+
+    def test_basic_toggle_checked(self):
+        window = self.create_mock_window()
+        component = self.component
+        tool = self.tool
+        tool.togglable = True
+        tool.checked = True
+
+        with self.assertTraitChanges(tool, 'down', count=1), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            event = self.mouse_down(component, 100, 100, window=window)
+
+        self.assertTrue(event.handled)
+        self.assertTrue(tool.event_state, 'pressed')
+        self.assertTrue(tool.down)
+        self.assertTrue(tool.checked)
+
+        with self.assertTraitChanges(tool, 'down', count=1), \
+                self.assertTraitChanges(tool, 'clicked', count=1), \
+                self.assertTraitChanges(tool, 'checked', count=1):
+            event = self.mouse_up(self.component, 100, 100, window=window)
+
+        self.assertTrue(event.handled)
+        self.assertTrue(tool.event_state, 'normal')
+        self.assertFalse(tool.down)
+        self.assertFalse(tool.checked)
+
+    def test_basic_click_disabled(self):
+        window = self.create_mock_window()
+        component = self.component
+        tool = self.tool
+        tool.enabled = False
+
+        with self.assertTraitDoesNotChange(tool, 'down'), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            event = self.mouse_down(component, 100, 100, window=window)
+
+        self.assertFalse(event.handled)
+        self.assertTrue(tool.event_state, 'normal')
+        self.assertFalse(tool.down)
+        self.assertFalse(tool.checked)
+
+        with self.assertTraitDoesNotChange(tool, 'down'), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            event = self.mouse_up(self.component, 100, 100, window=window)
+
+        self.assertFalse(event.handled)
+        self.assertTrue(tool.event_state, 'normal')
+        self.assertFalse(tool.down)
+        self.assertFalse(tool.checked)
+
+    def test_click_drag(self):
+        window = self.create_mock_window()
+        component = self.component
+        tool = self.tool
+
+        with self.assertTraitChanges(tool, 'down', count=1), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            event = self.mouse_down(component, 100, 100, window=window)
+
+        self.assertTrue(event.handled)
+        self.assertTrue(tool.event_state, 'pressed')
+        self.assertTrue(tool.down)
+        self.assertFalse(tool.checked)
+
+        # move mouse out of component
+        with self.assertTraitChanges(tool, 'down', count=1), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            event = self.mouse_move(self.component, 25, 25, window=window)
+
+        self.assertFalse(event.handled)
+        self.assertTrue(tool.event_state, 'pressed')
+        self.assertFalse(tool.down)
+        self.assertFalse(tool.checked)
+
+        # move mouse into component
+        with self.assertTraitChanges(tool, 'down', count=1), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            event = self.mouse_move(self.component, 100, 100, window=window)
+
+        self.assertFalse(event.handled)
+        self.assertTrue(tool.event_state, 'pressed')
+        self.assertTrue(tool.down)
+        self.assertFalse(tool.checked)
+
+        # move mouse out of component
+        with self.assertTraitChanges(tool, 'down', count=1), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            event = self.mouse_move(self.component, 200, 200, window=window)
+
+        self.assertFalse(event.handled)
+        self.assertTrue(tool.event_state, 'pressed')
+        self.assertFalse(tool.down)
+        self.assertFalse(tool.checked)
+
+        # release button
+        with self.assertTraitDoesNotChange(tool, 'down'), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            event = self.mouse_up(self.component, 200, 200, window=window)
+
+        self.assertFalse(event.handled)
+        self.assertTrue(tool.event_state, 'normal')
+        self.assertFalse(tool.down)
+        self.assertFalse(tool.checked)
+
+    def test_click_mouse_leave(self):
+        window = self.create_mock_window()
+        component = self.component
+        tool = self.tool
+
+        with self.assertTraitChanges(tool, 'down', count=1), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            event = self.mouse_down(component, 100, 100, window=window)
+
+        self.assertTrue(event.handled)
+        self.assertTrue(tool.event_state, 'pressed')
+        self.assertTrue(tool.down)
+        self.assertFalse(tool.checked)
+
+        # move mouse out of component
+        with self.assertTraitChanges(tool, 'down', count=1), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            event = self.mouse_leave(self.component, 25, 25, window=window)
+
+        self.assertFalse(event.handled)
+        self.assertTrue(tool.event_state, 'pressed')
+        self.assertFalse(tool.down)
+        self.assertFalse(tool.checked)
+
+        # move mouse into component
+        with self.assertTraitChanges(tool, 'down', count=1), \
+                self.assertTraitDoesNotChange(tool, 'clicked'), \
+                self.assertTraitDoesNotChange(tool, 'checked'):
+            event = self.mouse_enter(self.component, 100, 100, window=window)
+
+        self.assertFalse(event.handled)
+        self.assertTrue(tool.event_state, 'pressed')
+        self.assertTrue(tool.down)
+        self.assertFalse(tool.checked)

--- a/enable/tools/button_tool.py
+++ b/enable/tools/button_tool.py
@@ -41,7 +41,7 @@ class ButtonTool(BaseTool):
     #: Event fired when button is clicked
     clicked = Event
 
-    #: Is the button togglable?
+    #: Is the button toggled?
     checked = Bool(False)
 
     #: Is the mouse button pressed down in the clickable region

--- a/enable/tools/button_tool.py
+++ b/enable/tools/button_tool.py
@@ -1,0 +1,114 @@
+#
+# (C) Copyright 2015 Enthought, Inc., Austin, TX
+# All right reserved.
+#
+# This file is open source software distributed according to the terms in
+# LICENSE.txt
+#
+
+"""
+ButtonTool
+==========
+
+A simple tool that responds to mouse clicks.
+
+"""
+
+from traits.api import Bool, Event
+
+from enable.base_tool import BaseTool
+
+
+class ButtonTool(BaseTool):
+    """ A button tool
+
+    This tool allows any component to act like either a push button or a
+    toggle button (such as a checkbox) with appropriate traits listeners.
+
+    Components which use this class can listen to the ``clicked`` event
+    or listen to the ``checked`` state, depending on whether they want
+    "push button" or "check box" style behaviour.
+
+    Components may also want to listen to the ``down`` attribute to change
+    the way that they are drawn in response to the mouse position, for example
+    by highlighting the component.
+
+    """
+    #-------------------------------------------------------------------------
+    # 'ButtonTool' interface
+    #-------------------------------------------------------------------------
+
+    #: Event fired when button is clicked
+    clicked = Event
+
+    #: Is the button togglable?
+    checked = Bool(False)
+
+    #: Is the mouse button pressed down in the clickable region
+    down = Bool(False)
+
+    #: whether or not the button can be pressed.
+    enabled = Bool(True)
+
+    #: whether or not the button can be toggled (eg. checkbox or radio button).
+    togglable = Bool(False)
+
+    def is_clickable(self, x, y):
+        """ Is the (x,y) position in a region that responds to clicks.
+
+        Used by the tool to determine when to start a click and when the
+        button should be considered pressed down (this controls the state
+        of the ``down`` trait).
+
+        """
+        return self.component.is_in(x, y)
+
+    def click(self):
+        """ Perform a click, toggling if needed, and firing the clicked event
+
+        This doesn't change the state of the ``down`` trait.
+
+        """
+        if self.togglable:
+            self.toggle()
+        self.clicked = True
+
+    def toggle(self):
+        """ Toggle the state of the button.
+
+        This does not fire the clicked event.
+
+        Default is to invert the checked state, but subclasses could implement
+        move complex cycling of toggle states.
+
+        """
+        self.checked = not self.checked
+
+    #-------------------------------------------------------------------------
+    # 'BaseTool' stateful event handlers
+    #-------------------------------------------------------------------------
+
+    def normal_left_down(self, event):
+        if self.enabled and self.is_clickable(event.x, event.y):
+            event.window.mouse_owner = self
+            self.down = True
+            self.event_state = 'pressed'
+            self.component.active_tool = self
+            event.handled = True
+
+    def pressed_mouse_move(self, event):
+        self.down = self.is_clickable(event.x, event.y)
+
+    def pressed_mouse_leave(self, event):
+        self.down = False
+
+    def pressed_mouse_enter(self, event):
+        self.down = self.is_clickable(event.x, event.y)
+
+    def pressed_left_up(self, event):
+        if self.down:
+            self.click()
+            event.handled = True
+        event.window.mouse_owner = None
+        self.down = False
+        self.event_state = "normal"

--- a/examples/enable/tools/button_tool.py
+++ b/examples/enable/tools/button_tool.py
@@ -1,0 +1,117 @@
+#
+# (C) Copyright 2015 Enthought, Inc., Austin, TX
+# All right reserved.
+#
+# This file is open source software distributed according to the terms in
+# LICENSE.txt
+#
+
+"""
+Undoable Move Tool
+==================
+
+This example shows how to integrate a simple component move tool with apptools
+undo/redo infrastructure.
+
+"""
+from __future__ import (division, absolute_import, print_function,
+                        unicode_literals)
+
+from traits.api import Bool
+from kiva.constants import FILL, STROKE
+
+from enable.api import Container, Window, transparent_color
+from enable.colors import ColorTrait
+from enable.example_support import DemoFrame, demo_main
+from enable.primitives.api import Box
+from enable.tools.button_tool import ButtonTool
+
+
+class SelectableBox(Box):
+    """ A box that can be selected and renders in a different color """
+
+    selected = Bool
+
+    selected_color = ColorTrait('green')
+
+    def select(self, selected):
+        self.selected = selected
+
+    def _selected_changed(self):
+        self.request_redraw()
+
+    def _draw_mainlayer(self, gc, view_bounds=None, mode="default"):
+        "Draw the box background in a specified graphics context"
+
+        # Set up all the control variables for quick access:
+        bs  = self.border_size
+        bsd = bs + bs
+        bsh = bs / 2.0
+        x, y = self.position
+        dx, dy = self.bounds
+
+        with gc:
+            if self.selected:
+                color = self.selected_color_
+            else:
+                color = self.color_
+            if color is not transparent_color:
+                gc.set_fill_color(color)
+                gc.draw_rect((x + bs, y + bs, dx - bsd, dy - bsd), FILL)
+
+            # Draw the border (if required):
+            if bs > 0:
+                border_color = self.border_color_
+                if border_color is not transparent_color:
+                    gc.set_stroke_color(border_color)
+                    gc.set_line_width(bs)
+                    gc.draw_rect((x + bsh, y + bsh, dx - bs, dy - bs), STROKE)
+        return
+
+class MyFrame(DemoFrame):
+    """ Example of using a ButtonTool
+
+    """
+
+    def button_clicked(self):
+        print('clicked')
+
+    #-------------------------------------------------------------------------
+    # DemoApplication interface
+    #-------------------------------------------------------------------------
+
+    def _create_window(self):
+        # create a box that changes color when clicked
+        push_button_box = SelectableBox(bounds=[100,50], position=[50, 50], color='red')
+
+        # create a basic push button tool for it
+        push_button_tool = ButtonTool(component=push_button_box)
+        push_button_box.tools.append(push_button_tool)
+
+        # print when box clicked, change color when button down
+        push_button_tool.on_trait_change(self.button_clicked, 'clicked')
+        push_button_tool.on_trait_change(push_button_box.select, 'down')
+
+        # another box for a toggle button
+        toggle_box = SelectableBox(bounds=[100,50], position=[50, 125],
+            color='lightblue', selected_color='blue')
+
+        # a toggle button tool
+        toggle_button_tool = ButtonTool(component=toggle_box, togglable=True)
+        toggle_box.tools.append(toggle_button_tool)
+
+        # change color when checked down
+        toggle_button_tool.on_trait_change(toggle_box.select, 'checked')
+
+        container = Container(bounds=[600, 600])
+        container.add(push_button_box)
+        container.add(toggle_box)
+
+        window = Window(self, -1, component=container)
+        return window
+
+
+if __name__ == "__main__":
+    # Save demo so that it doesn't get garbage collected when run within
+    # existing event loop (i.e. from ipython).
+    demo = demo_main(MyFrame, size=(600, 600))


### PR DESCRIPTION
Basically a common tool that can be used whenever we want something to be "clickable" or "togglable".  Probably of significant utility in Chaco.

Has tests and documentation.

Ready for review.