### PR TITLE
Fix Travis PIL Requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_install:
   - sudo ln -s /usr/lib/`uname -i`-linux-gnu/libz.so /usr/lib/
 install:
   # nose is already installed
+  # numpy is already installed
   - pip install cython
-  - pip install --upgrade numpy
   - pip install --no-dependencies -r dev_requirements.txt
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r requirements-2.6.txt; fi
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   # nose is already installed
   - pip install cython
   - pip install --upgrade numpy
-  - pip install -r dev_requirements.txt
+  - pip install --no-dependencies -r dev_requirements.txt
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r requirements-2.6.txt; fi
   - pip install coveralls
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   # nose is already installed
   # numpy is already installed
   - pip install cython
-  - pip install --no-dependencies -r dev_requirements.txt
+  - pip install -r dev_requirements.txt
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r requirements-2.6.txt; fi
   - pip install coveralls
   - python setup.py develop

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,7 +6,8 @@ pyparsing
 PyPDF2
 pyglet
 pygarrayimage
-reportlab
+reportlab<=3.1
 -e git+http://github.com/enthought/traits.git#egg=traits
+-e git+http://github.com/enthought/pyface.git#egg=pyface
 -e git+http://github.com/enthought/traitsui.git#egg=traitsui
 -e git+http://github.com/nucleic/kiwi.git#egg=kiwisolver


### PR DESCRIPTION
Use `pip` without dependencies to avoid Pillow install.

Hopefully fixes #170 