### PR TITLE
Add the auto-generated enable/_version.py to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ kiva/quartz/ABCGI.c
 kiva/quartz/CTFont.c
 
 # Auto-generated version info
+enable/_version.py
 kiva/_version.py


### PR DESCRIPTION
This was missed when it was added in #178 