### PR TITLE
Fix scrolling problem with Qt native scrollbar

### DIFF
--- a/enable/qt4/scrollbar.py
+++ b/enable/qt4/scrollbar.py
@@ -183,7 +183,7 @@ class NativeScrollBar(Component):
         # of the scroll bar itself.
         max_value = maximum-page_size
         # invert values for vertical ranges because of coordinate system issues
-        value = self._correct_value(value, max_value)
+        value = self._correct_value(value, minimum, max_value)
 
         self._control.setMinimum(minimum)
         self._control.setMaximum(max_value)
@@ -191,7 +191,7 @@ class NativeScrollBar(Component):
         self._control.setPageStep(page_size)
         self._control.setSingleStep(line_size)
 
-    def _correct_value(self, value, max_value):
+    def _correct_value(self, value, min_value, max_value):
         """ Correct vertical position values for Qt and Enable conventions
 
         Enable expects vertical scroll_position to be measured with origin at
@@ -208,7 +208,7 @@ class NativeScrollBar(Component):
         """
         if self.orientation != 'vertical':
             return value
-        return max_value - value
+        return max_value - (value - min_value)
 
 
     #------------------------------------------------------------------------
@@ -217,7 +217,7 @@ class NativeScrollBar(Component):
 
     def _update_enable_pos(self, value):
         # invert values for vertical ranges because of coordinate system issues
-        value = self._correct_value(value, self.high-self.page_size)
+        value = self._correct_value(value, self.low, self.high-self.page_size)
         self.scroll_position = value
 
     def _on_slider_pressed(self):

--- a/enable/qt4/scrollbar.py
+++ b/enable/qt4/scrollbar.py
@@ -183,7 +183,11 @@ class NativeScrollBar(Component):
         # scroll bar, not the document length. We need to subtract the length
         # of the scroll bar itself.
         self._control.setMaximum(maximum-page_size)
-        self._control.setValue(value)
+        # invert values for vertical ranges because of coordinate system issues
+        if self.orientation == 'vertical':
+            self._control.setValue(maximum-page_size-value)
+        else:
+            self._control.setValue(value)
         self._control.setPageStep(page_size)
         self._control.setSingleStep(line_size)
 
@@ -192,7 +196,11 @@ class NativeScrollBar(Component):
     #------------------------------------------------------------------------
 
     def _update_enable_pos(self, value):
-        self.scroll_position = value
+        # invert values for vertical ranges because of coordinate system issues
+        if self.orientation == "vertical":
+            self.scroll_position = self.high - self.page_size - value
+        else:
+            self.scroll_position = value
 
     def _on_slider_pressed(self):
         self.mouse_thumb = "down"
@@ -285,4 +293,3 @@ class NativeScrollBar(Component):
         low, high, page_size, ignore = self.range
         self._clean = False
         self.range =(low, high, page_size, line_size)
-

--- a/enable/tests/qt4/scrollbar_test.py
+++ b/enable/tests/qt4/scrollbar_test.py
@@ -2,11 +2,14 @@
 from contextlib import contextmanager
 import unittest
 
+from traitsui.tests._tools import skip_if_not_qt4
+
 from enable.container import Container
 from enable.qt4.scrollbar import NativeScrollBar
 from enable.window import Window
 
 
+@skip_if_not_qt4
 class ScrollBarTest(unittest.TestCase):
 
     def setUp(self):

--- a/enable/tests/qt4/scrollbar_test.py
+++ b/enable/tests/qt4/scrollbar_test.py
@@ -1,0 +1,131 @@
+
+from contextlib import contextmanager
+import unittest
+
+from enable.container import Container
+from enable.qt4.scrollbar import NativeScrollBar
+from enable.window import Window
+
+
+class ScrollBarTest(unittest.TestCase):
+
+    def setUp(self):
+        self.container = Container(position=[0, 0], bounds=[600, 600])
+        self.window = Window(None, size=(600, 600), component=self.container)
+
+    @contextmanager
+    def setup_window(self, window):
+        window.control.show()
+        try:
+            yield
+        finally:
+            window.control.destroy()
+
+    @contextmanager
+    def setup_scrollbar(self, scrollbar, window, enable_range, value):
+        scrollbar._draw_mainlayer(self, window._gc)
+        try:
+            yield
+        finally:
+            scrollbar.destroy()
+
+    def test_scroll_position_horizontal(self):
+        bounds = [600.0, 30.0]
+        position = [0.0, 0.0]
+        range = [600, 0.0, 375.0, 20.454545454545453]
+        scrollbar = NativeScrollBar(
+            orientation='horizontal',
+            bounds=bounds,
+            position=position,
+            range=range,
+        )
+        self.container.add(scrollbar)
+        with self.setup_window(self.window):
+            with self.setup_scrollbar(scrollbar, self.window, range, 0):
+                self.assertEqual(scrollbar._control.value(), 0)
+                self.assertEqual(scrollbar.scroll_position, 0)
+
+                # move the scrollbar
+                scrollbar._control.setValue(100)
+                self.assertEqual(scrollbar.scroll_position, 100)
+
+                # set the scroll & redraw
+                scrollbar.scroll_position = 200
+                scrollbar._draw_mainlayer(self, self.window._gc)
+                self.assertEqual(scrollbar._control.value(), 200)
+
+    def test_scroll_position_vertical(self):
+        bounds = [30.0, 600.0]
+        position = [0.0, 0.0]
+        range = [600, 0.0, 375.0, 20.454545454545453]
+        scrollbar = NativeScrollBar(
+            orientation='vertical',
+            bounds=bounds,
+            position=position,
+            range=range,
+        )
+        self.container.add(scrollbar)
+        with self.setup_window(self.window):
+            with self.setup_scrollbar(scrollbar, self.window, range, 0):
+                self.assertEqual(scrollbar._control.value(), 600-375)
+                self.assertEqual(scrollbar.scroll_position, 0)
+
+                # move the scrollbar
+                scrollbar._control.setValue(100)
+                self.assertEqual(scrollbar.scroll_position, 600-375-100)
+
+                # set the scroll & redraw
+                scrollbar.scroll_position = 200
+                scrollbar._draw_mainlayer(self, self.window._gc)
+                self.assertEqual(scrollbar._control.value(), 600-375-200)
+
+    def test_minumum_horizontal(self):
+        bounds = [600.0, 30.0]
+        position = [0.0, 0.0]
+        range = [700, 100.0, 375.0, 20.454545454545453]
+        scrollbar = NativeScrollBar(
+            orientation='horizontal',
+            bounds=bounds,
+            position=position,
+            range=range,
+        )
+        self.container.add(scrollbar)
+        with self.setup_window(self.window):
+            with self.setup_scrollbar(scrollbar, self.window, range, 100):
+                self.assertEqual(scrollbar._control.value(), 100)
+                self.assertEqual(scrollbar.scroll_position, 100)
+
+                # move the scrollbar
+                scrollbar._control.setValue(200)
+                self.assertEqual(scrollbar.scroll_position, 200)
+
+                # set the scroll & redraw
+                scrollbar.scroll_position = 300
+                scrollbar._draw_mainlayer(self, self.window._gc)
+                self.assertEqual(scrollbar._control.value(), 300)
+
+    def test_minimum_vertical(self):
+        bounds = [30.0, 600.0]
+        position = [0.0, 0.0]
+        range = [700, 100.0, 375.0, 20.454545454545453]
+        scrollbar = NativeScrollBar(
+            orientation='vertical',
+            bounds=bounds,
+            position=position,
+            range=range,
+        )
+        self.container.add(scrollbar)
+        with self.setup_window(self.window):
+            with self.setup_scrollbar(scrollbar, self.window, range, 100):
+                # control should be at top
+                self.assertEqual(scrollbar._control.value(), 700-375)
+                self.assertEqual(scrollbar.scroll_position, 100)
+
+                # move the scrollbar to the bottom
+                scrollbar._control.setValue(100)
+                self.assertEqual(scrollbar.scroll_position, 700-375)
+
+                # set the scroll & redraw
+                scrollbar.scroll_position = 200
+                scrollbar._draw_mainlayer(self, self.window._gc)
+                self.assertEqual(scrollbar._control.value(), 700-375-(200-100))

--- a/enable/tests/qt4/scrollbar_test.py
+++ b/enable/tests/qt4/scrollbar_test.py
@@ -31,7 +31,7 @@ class ScrollBarTest(unittest.TestCase):
             window.control.destroy()
 
     @contextmanager
-    def setup_scrollbar(self, scrollbar, window, enable_range, value):
+    def setup_scrollbar(self, scrollbar, window):
         scrollbar._draw_mainlayer(self, window._gc)
         try:
             yield
@@ -50,7 +50,7 @@ class ScrollBarTest(unittest.TestCase):
         )
         self.container.add(scrollbar)
         with self.setup_window(self.window):
-            with self.setup_scrollbar(scrollbar, self.window, range, 0):
+            with self.setup_scrollbar(scrollbar, self.window):
                 self.assertEqual(scrollbar._control.value(), 0)
                 self.assertEqual(scrollbar.scroll_position, 0)
 
@@ -75,7 +75,7 @@ class ScrollBarTest(unittest.TestCase):
         )
         self.container.add(scrollbar)
         with self.setup_window(self.window):
-            with self.setup_scrollbar(scrollbar, self.window, range, 0):
+            with self.setup_scrollbar(scrollbar, self.window):
                 self.assertEqual(scrollbar._control.value(), 600-375)
                 self.assertEqual(scrollbar.scroll_position, 0)
 
@@ -100,7 +100,7 @@ class ScrollBarTest(unittest.TestCase):
         )
         self.container.add(scrollbar)
         with self.setup_window(self.window):
-            with self.setup_scrollbar(scrollbar, self.window, range, 100):
+            with self.setup_scrollbar(scrollbar, self.window):
                 self.assertEqual(scrollbar._control.value(), 100)
                 self.assertEqual(scrollbar.scroll_position, 100)
 
@@ -125,7 +125,7 @@ class ScrollBarTest(unittest.TestCase):
         )
         self.container.add(scrollbar)
         with self.setup_window(self.window):
-            with self.setup_scrollbar(scrollbar, self.window, range, 100):
+            with self.setup_scrollbar(scrollbar, self.window):
                 # control should be at top
                 self.assertEqual(scrollbar._control.value(), 700-375)
                 self.assertEqual(scrollbar.scroll_position, 100)

--- a/enable/tests/qt4/scrollbar_test.py
+++ b/enable/tests/qt4/scrollbar_test.py
@@ -35,7 +35,7 @@ class ScrollBarTest(unittest.TestCase):
 
     @contextmanager
     def setup_scrollbar(self, scrollbar, window):
-        scrollbar._draw_mainlayer(self, window._gc)
+        scrollbar._draw_mainlayer(window._gc)
         try:
             yield
         finally:

--- a/enable/tests/qt4/scrollbar_test.py
+++ b/enable/tests/qt4/scrollbar_test.py
@@ -27,6 +27,7 @@ class ScrollBarTest(unittest.TestCase):
     @contextmanager
     def setup_window(self, window):
         window.control.show()
+        window._size = window._get_control_size()
         self.gui.process_events()
         try:
             yield

--- a/enable/tests/qt4/scrollbar_test.py
+++ b/enable/tests/qt4/scrollbar_test.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 
 from traits.testing.unittest_tools import unittest
 from traitsui.tests._tools import skip_if_not_qt4
+from pyface.gui import GUI
 
 from enable.container import Container
 from enable.window import Window
@@ -19,12 +20,14 @@ class ScrollBarTest(unittest.TestCase):
     def setUp(self):
         if NativeScrollBar is None:
             raise unittest.SkipTest("Qt4 NativeScrollbar not available.")
+        self.gui = GUI()
         self.container = Container(position=[0, 0], bounds=[600, 600])
         self.window = Window(None, size=(600, 600), component=self.container)
 
     @contextmanager
     def setup_window(self, window):
         window.control.show()
+        self.gui.process_events()
         try:
             yield
         finally:

--- a/enable/tests/qt4/scrollbar_test.py
+++ b/enable/tests/qt4/scrollbar_test.py
@@ -1,18 +1,24 @@
 
 from contextlib import contextmanager
-import unittest
 
+from traits.testing.unittest_tools import unittest
 from traitsui.tests._tools import skip_if_not_qt4
 
 from enable.container import Container
-from enable.qt4.scrollbar import NativeScrollBar
 from enable.window import Window
+
+try:
+    from enable.qt4.scrollbar import NativeScrollBar
+except Exception:
+    NativeScrollBar = None
 
 
 @skip_if_not_qt4
 class ScrollBarTest(unittest.TestCase):
 
     def setUp(self):
+        if NativeScrollBar is None:
+            raise unittest.SkipTest("Qt4 NativeScrollbar not available.")
         self.container = Container(position=[0, 0], bounds=[600, 600])
         self.window = Window(None, size=(600, 600), component=self.container)
 


### PR DESCRIPTION
Scrolling was in the reverse direction for vertical scrollbars (ie. when scrollbar was at top, view was at bottom and vice-versa).  This fixes this issue.

Testing is difficult for this - have just spent an unproductive hour trying to get something working.  We probably want a little set of utility routines.  I'll leave it up to the PR reviewer as to whether we should try to add tests before merging.