### PR TITLE
Viewport resizing

### DIFF
--- a/enable/qt4/scrollbar.py
+++ b/enable/qt4/scrollbar.py
@@ -183,7 +183,11 @@ class NativeScrollBar(Component):
         # scroll bar, not the document length. We need to subtract the length
         # of the scroll bar itself.
         self._control.setMaximum(maximum-page_size)
-        self._control.setValue(value)
+        # invert values for vertical ranges because of coordinate system issues
+        if self.orientation == 'vertical':
+            self._control.setValue(maximum-page_size-value)
+        else:
+            self._control.setValue(value)
         self._control.setPageStep(page_size)
         self._control.setSingleStep(line_size)
 
@@ -192,7 +196,11 @@ class NativeScrollBar(Component):
     #------------------------------------------------------------------------
 
     def _update_enable_pos(self, value):
-        self.scroll_position = value
+        # invert values for vertical ranges because of coordinate system issues
+        if self.orientation == "vertical":
+            self.scroll_position = self.high - self.page_size - value
+        else:
+            self.scroll_position = value
 
     def _on_slider_pressed(self):
         self.mouse_thumb = "down"
@@ -285,4 +293,3 @@ class NativeScrollBar(Component):
         low, high, page_size, ignore = self.range
         self._clean = False
         self.range =(low, high, page_size, line_size)
-

--- a/enable/scrolled.py
+++ b/enable/scrolled.py
@@ -2,7 +2,7 @@
 from __future__ import with_statement
 
 # Enthought library imports
-from traits.api import Bool, Instance, Int, Any, Float
+from traits.api import Any, Bool, DelegatesTo, Float, Instance, Int
 
 # Local, relative imports
 from base import intersect_bounds, empty_rectangle
@@ -23,7 +23,17 @@ class Scrolled(Container):
     component = Instance(Component)
 
     # The viewport onto our component
-    viewport_component = Instance(Viewport)
+    viewport_component = Instance(Viewport, ())
+
+    # Whether or not the viewport should stay constrained to the bounds
+    # of the viewed component
+    stay_inside = DelegatesTo('viewport_component')
+
+    # Where to anchor vertically on resizes
+    vertical_anchor = DelegatesTo('viewport_component')
+
+    # Where to anchor vertically on resizes
+    horizontal_anchor = DelegatesTo('viewport_component')
 
     # Inside padding is a background drawn area between the edges or scrollbars
     # and the scrolled area/left component.
@@ -298,10 +308,14 @@ class Scrolled(Container):
 
     def _viewport_component_changed(self):
         if self.viewport_component is None:
-            self.viewport_component = Viewport()
+            self.viewport_component = Viewport(
+                stay_inside=self.stay_inside,
+                vertical_anchor=self.vertical_anchor,
+                horizontal_anchor=self.horizontal_anchor,
+            )
         self.viewport_component.view_bounds = self.bounds
         self.viewport_component.component = self.component
-        #self.viewport_component.view_position = [0, 0]
+        self.viewport_component._initialize_position()
         self.add(self.viewport_component)
 
     def _alternate_vsb_changed(self, old, new):

--- a/enable/scrolled.py
+++ b/enable/scrolled.py
@@ -258,8 +258,8 @@ class Scrolled(Container):
         self.update_from_viewport()
         return
 
-    def _component_bounds_items_handler(self, object, new):
-        if new.added != new.removed:
+    def _component_bounds_items_handler(self, object, event):
+        if event.added != event.removed:
             self.update_bounds()
 
     def _component_bounds_handler(self, object, name, old, new):
@@ -299,9 +299,9 @@ class Scrolled(Container):
     def _viewport_component_changed(self):
         if self.viewport_component is None:
             self.viewport_component = Viewport()
-        self.viewport_component.component = self.component
-        self.viewport_component.view_position = [0,0]
         self.viewport_component.view_bounds = self.bounds
+        self.viewport_component.component = self.component
+        #self.viewport_component.view_position = [0, 0]
         self.add(self.viewport_component)
 
     def _alternate_vsb_changed(self, old, new):
@@ -323,12 +323,10 @@ class Scrolled(Container):
     def _bounds_changed ( self, old, new ):
         Component._bounds_changed( self, old, new )
         self.update_bounds()
-        return
 
     def _bounds_items_changed(self, event):
         Component._bounds_items_changed(self, event)
         self.update_bounds()
-        return
 
 
     #---------------------------------------------------------------------------
@@ -400,6 +398,7 @@ class Scrolled(Container):
                                             range=range_x,
                                             enabled=False,
                                             )
+                self._hsb.scroll_position = self.viewport_component.view_position[0]
                 self._hsb.on_trait_change(self._handle_horizontal_scroll,
                                           'scroll_position')
                 self._hsb.on_trait_change(self._mouse_thumb_changed,
@@ -411,8 +410,6 @@ class Scrolled(Container):
                 self._hsb.position = hsb_position
         elif self._hsb is not None:
             self._hsb = self._release_sb(self._hsb)
-            if not hasattr(self.component, "bounds_offset"):
-                self.viewport_component.view_position[0] = 0
         else:
             # We don't need to render the horizontal scrollbar, and we don't
             # have one to update, either.
@@ -432,9 +429,9 @@ class Scrolled(Container):
                 self._vsb = NativeScrollBar(orientation = 'vertical',
                                             bounds=bounds,
                                             position=vsb_position,
-                                            range=range_y
+                                            range=range_y,
                                             )
-
+                self._vsb.scroll_position = self.viewport_component.view_position[1]
                 self._vsb.on_trait_change(self._handle_vertical_scroll,
                                           'scroll_position')
                 self._vsb.on_trait_change(self._mouse_thumb_changed,
@@ -446,8 +443,6 @@ class Scrolled(Container):
                 self._vsb.range = range_y
         elif self._vsb:
             self._vsb = self._release_sb(self._vsb)
-            if not hasattr(self.component, "bounds_offset"):
-                self.viewport_component.view_position[1] = 0
         else:
             # We don't need to render the vertical scrollbar, and we don't
             # have one to update, either.

--- a/enable/tests/viewport_test_case.py
+++ b/enable/tests/viewport_test_case.py
@@ -276,17 +276,117 @@ class ViewportTestCase(unittest.TestCase):
         self.assertEqual(view.view_position, [15.0, 20])
 
         # resize beyond left
-        view.bounds = [95, 95]
+        view.height = 95
+        view.width = 95
         self.assertEqual(view.view_position, [0.0, 5])
 
         # resize bigger than view
-        view.bounds = [120, 120]
+        view.bounds[0] = 120
+        view.bounds[1] = 120
         self.assertEqual(view.view_position, [-10.0, 0])
 
+    def test_adjust_container_bounds_vanchor_top(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        view_bounds=[50.0, 50.0],
+                        view_position=[20, 20],
+                        position=[0,0],
+                        bounds=[50,50],
+                        vertical_anchor='top')
 
+        # simple resize bigger
+        container.bounds = [120, 120]
+        self.assertEqual(view.view_position, [20, 40.0])
+
+        # simple resize smaller
+        container.height = 90
+        container.width = 90
+        self.assertEqual(view.view_position, [20, 10.0])
+
+        # simple resize much smaller
+        container.bounds[0] = 40
+        container.bounds[1] = 40
+        self.assertEqual(view.view_position, [20, -40.0])
+
+    def test_adjust_container_bounds_vanchor_top_stay_inside(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        view_bounds=[50.0, 50.0],
+                        view_position=[20, 20],
+                        position=[0,0],
+                        bounds=[50,50],
+                        vertical_anchor='top',
+                        stay_inside=True)
+
+        # simple resize bigger
+        container.bounds = [120, 120]
+        self.assertEqual(view.view_position, [20, 40.0])
+
+        # simple resize smaller
+        container.height = 90
+        container.width = 90
+        self.assertEqual(view.view_position, [20, 10.0])
+
+        # simple resize much smaller
+        container.bounds[0] = 40
+        container.bounds[1] = 40
+        self.assertEqual(view.view_position, [0, -10.0])
+
+    def test_adjust_container_bounds_hanchor_right(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        view_bounds=[50.0, 50.0],
+                        view_position=[20, 20],
+                        position=[0,0],
+                        bounds=[50,50],
+                        horizontal_anchor='right')
+
+        # simple resize bigger
+        container.bounds = [120, 120]
+        self.assertEqual(view.view_position, [40, 20.0])
+
+        # simple resize smaller
+        container.height = 90
+        container.width = 90
+        self.assertEqual(view.view_position, [10, 20.0])
+
+        # simple resize much smaller
+        container.bounds[0] = 40
+        container.bounds[1] = 40
+        self.assertEqual(view.view_position, [-40, 20.0])
+
+    def test_adjust_container_bounds_hanchor_right_stay_inside(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        view_bounds=[50.0, 50.0],
+                        view_position=[20, 20],
+                        position=[0,0],
+                        bounds=[50,50],
+                        vertical_anchor='top',
+                        stay_inside=True)
+
+        # simple resize bigger
+        container.bounds = [120, 120]
+        self.assertEqual(view.view_position, [20, 40.0])
+
+        # simple resize smaller
+        container.height = 90
+        container.width = 90
+        self.assertEqual(view.view_position, [20, 10.0])
+
+        # simple resize much smaller
+        container.bounds[0] = 40
+        container.bounds[1] = 40
+        self.assertEqual(view.view_position, [0, -10.0])
 
 if __name__ == "__main__":
     import nose
     nose.main()
-
-# EOF

--- a/enable/tests/viewport_test_case.py
+++ b/enable/tests/viewport_test_case.py
@@ -181,7 +181,7 @@ class ViewportTestCase(unittest.TestCase):
         view.bounds = [60, 60]
         self.assertEqual(view.view_position, [20, 15.0])
 
-        # resize beyond bottom
+        # resize beyond left
         view.bounds = [95, 95]
         self.assertEqual(view.view_position, [5, 0.0])
 
@@ -204,7 +204,7 @@ class ViewportTestCase(unittest.TestCase):
         view.bounds = [60, 60]
         self.assertEqual(view.view_position, [10, 20.0])
 
-        # resize beyond bottom
+        # resize beyond left
         view.bounds = [80, 80]
         self.assertEqual(view.view_position, [-10, 20.0])
 
@@ -228,7 +228,7 @@ class ViewportTestCase(unittest.TestCase):
         view.bounds = [60, 60]
         self.assertEqual(view.view_position, [10, 20.0])
 
-        # resize beyond bottom
+        # resize beyond left
         view.bounds = [80, 80]
         self.assertEqual(view.view_position, [0, 20.0])
 
@@ -251,7 +251,7 @@ class ViewportTestCase(unittest.TestCase):
         view.bounds = [60, 60]
         self.assertEqual(view.view_position, [15.0, 20])
 
-        # resize beyond bottom
+        # resize beyond left
         view.bounds = [95, 95]
         self.assertEqual(view.view_position, [-2.5, 20])
 
@@ -275,7 +275,7 @@ class ViewportTestCase(unittest.TestCase):
         view.bounds = [60, 60]
         self.assertEqual(view.view_position, [15.0, 20])
 
-        # resize beyond bottom
+        # resize beyond left
         view.bounds = [95, 95]
         self.assertEqual(view.view_position, [0.0, 5])
 

--- a/enable/tests/viewport_test_case.py
+++ b/enable/tests/viewport_test_case.py
@@ -14,6 +14,9 @@ class ViewportTestCase(unittest.TestCase):
                         view_bounds=[50.0, 50.0],
                         position=[0,0],
                         bounds=[50,50])
+
+        self.assertEqual(view.view_position, [10, 10])
+        print view.components_at(0.0, 0.0), view.view_position
         self.assert_(view.components_at(0.0, 0.0)[0] == component)
         self.assert_(view.components_at(44.9, 0.0)[0] == component)
         self.assert_(view.components_at(0.0, 44.9)[0] == component)
@@ -23,7 +26,263 @@ class ViewportTestCase(unittest.TestCase):
         self.assert_(view.components_at(46.0, 0.0) == [])
         self.assert_(view.components_at(45.0, 46.0) == [])
         self.assert_(view.components_at(0.0, 46.0) == [])
-        return
+
+    def test_initial_position(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        view_bounds=[50.0, 50.0],
+                        position=[0,0],
+                        bounds=[50,50])
+        self.assertEqual(view.view_position, [0, 0])
+
+    def test_initial_position_vanchor_top(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        vertical_anchor='top',
+                        view_bounds=[50.0, 50.0],
+                        position=[0,0],
+                        bounds=[50,50])
+        self.assertEqual(view.view_position, [0, 50])
+
+    def test_initial_position_vanchor_center(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        vertical_anchor='center',
+                        view_bounds=[50.0, 50.0],
+                        position=[0,0],
+                        bounds=[50,50])
+        self.assertEqual(view.view_position, [0, 25])
+
+    def test_initial_position_hanchor_right(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        horizontal_anchor='right',
+                        view_bounds=[50.0, 50.0],
+                        position=[0,0],
+                        bounds=[50,50])
+        self.assertEqual(view.view_position, [50, 0])
+
+    def test_initial_position_hanchor_center(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        horizontal_anchor='center',
+                        view_bounds=[50.0, 50.0],
+                        position=[0,0],
+                        bounds=[50,50])
+        self.assertEqual(view.view_position, [25, 0])
+
+    def test_adjust_bounds(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        view_bounds=[50.0, 50.0],
+                        view_position=[10,10],
+                        position=[0,0],
+                        bounds=[50,50])
+
+        # simple resize
+        view.bounds = [60, 60]
+        self.assertEqual(view.view_position, [10, 10])
+
+    def test_adjust_bounds_vanchor_top(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        view_bounds=[50.0, 50.0],
+                        view_position=[20, 20],
+                        position=[0,0],
+                        bounds=[50,50],
+                        vertical_anchor='top')
+
+        # simple resize
+        view.bounds = [60, 60]
+        self.assertEqual(view.view_position, [20, 10.0])
+
+        # resize beyond bottom
+        view.bounds = [80, 80]
+        self.assertEqual(view.view_position, [20, -10.0])
+
+        # resize bigger than view
+        view.bounds = [120, 120]
+        self.assertEqual(view.view_position, [20, -50.0])
+
+    def test_adjust_bounds_vanchor_top_stay_inside(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        view_bounds=[50.0, 50.0],
+                        view_position=[20, 20],
+                        position=[0,0],
+                        bounds=[50,50],
+                        vertical_anchor='top',
+                        stay_inside=True)
+
+        # simple resize
+        view.bounds = [60, 60]
+        self.assertEqual(view.view_position, [20, 10.0])
+
+        # resize beyond bottom
+        view.bounds = [80, 80]
+        self.assertEqual(view.view_position, [20, 0.0])
+
+        # resize bigger than view
+        view.bounds = [120, 120]
+        self.assertEqual(view.view_position, [0, -20.0])
+
+    def test_adjust_bounds_vanchor_center(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        view_bounds=[50.0, 50.0],
+                        view_position=[20, 20],
+                        position=[0,0],
+                        bounds=[50,50],
+                        vertical_anchor='center')
+
+        # simple resize
+        view.bounds = [60, 60]
+        self.assertEqual(view.view_position, [20, 15.0])
+
+        # resize beyond bottom
+        view.bounds = [95, 95]
+        self.assertEqual(view.view_position, [20, -2.5])
+
+        # resize bigger than view
+        view.bounds = [120, 120]
+        self.assertEqual(view.view_position, [20, -15.0])
+
+    def test_adjust_bounds_vanchor_center_stay_inside(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        view_bounds=[50.0, 50.0],
+                        view_position=[20, 20],
+                        position=[0,0],
+                        bounds=[50,50],
+                        vertical_anchor='center',
+                        stay_inside=True)
+
+        # simple resize
+        view.bounds = [60, 60]
+        self.assertEqual(view.view_position, [20, 15.0])
+
+        # resize beyond bottom
+        view.bounds = [95, 95]
+        self.assertEqual(view.view_position, [5, 0.0])
+
+        # resize bigger than view
+        view.bounds = [120, 120]
+        self.assertEqual(view.view_position, [0, -10.0])
+
+    def test_adjust_bounds_hanchor_top(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        view_bounds=[50.0, 50.0],
+                        view_position=[20, 20],
+                        position=[0,0],
+                        bounds=[50,50],
+                        horizontal_anchor='right')
+
+        # simple resize
+        view.bounds = [60, 60]
+        self.assertEqual(view.view_position, [10, 20.0])
+
+        # resize beyond bottom
+        view.bounds = [80, 80]
+        self.assertEqual(view.view_position, [-10, 20.0])
+
+        # resize bigger than view
+        view.bounds = [120, 120]
+        self.assertEqual(view.view_position, [-50, 20.0])
+
+    def test_adjust_bounds_hanchor_top_stay_inside(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        view_bounds=[50.0, 50.0],
+                        view_position=[20, 20],
+                        position=[0,0],
+                        bounds=[50,50],
+                        horizontal_anchor='right',
+                        stay_inside=True)
+
+        # simple resize
+        view.bounds = [60, 60]
+        self.assertEqual(view.view_position, [10, 20.0])
+
+        # resize beyond bottom
+        view.bounds = [80, 80]
+        self.assertEqual(view.view_position, [0, 20.0])
+
+        # resize bigger than view
+        view.bounds = [120, 120]
+        self.assertEqual(view.view_position, [-20.0, 0])
+
+    def test_adjust_bounds_hanchor_center(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        view_bounds=[50.0, 50.0],
+                        view_position=[20, 20],
+                        position=[0,0],
+                        bounds=[50,50],
+                        horizontal_anchor='center')
+
+        # simple resize
+        view.bounds = [60, 60]
+        self.assertEqual(view.view_position, [15.0, 20])
+
+        # resize beyond bottom
+        view.bounds = [95, 95]
+        self.assertEqual(view.view_position, [-2.5, 20])
+
+        # resize bigger than view
+        view.bounds = [120, 120]
+        self.assertEqual(view.view_position, [-15.0, 20])
+
+    def test_adjust_bounds_hanchor_center_stay_inside(self):
+        container = Container(bounds=[100.0, 100.0])
+        component = Component(bounds=[50.0, 50.0], position=[5.0, 5.0])
+        container.add(component)
+        view = Viewport(component=container,
+                        view_bounds=[50.0, 50.0],
+                        view_position=[20, 20],
+                        position=[0,0],
+                        bounds=[50,50],
+                        horizontal_anchor='center',
+                        stay_inside=True)
+
+        # simple resize
+        view.bounds = [60, 60]
+        self.assertEqual(view.view_position, [15.0, 20])
+
+        # resize beyond bottom
+        view.bounds = [95, 95]
+        self.assertEqual(view.view_position, [0.0, 5])
+
+        # resize bigger than view
+        view.bounds = [120, 120]
+        self.assertEqual(view.view_position, [-10.0, 0])
+
 
 
 if __name__ == "__main__":

--- a/enable/tests/viewport_test_case.py
+++ b/enable/tests/viewport_test_case.py
@@ -370,22 +370,22 @@ class ViewportTestCase(unittest.TestCase):
                         view_position=[20, 20],
                         position=[0,0],
                         bounds=[50,50],
-                        vertical_anchor='top',
+                        horizontal_anchor='right',
                         stay_inside=True)
 
         # simple resize bigger
         container.bounds = [120, 120]
-        self.assertEqual(view.view_position, [20, 40.0])
+        self.assertEqual(view.view_position, [40, 20])
 
         # simple resize smaller
         container.height = 90
         container.width = 90
-        self.assertEqual(view.view_position, [20, 10.0])
+        self.assertEqual(view.view_position, [10, 20])
 
         # simple resize much smaller
         container.bounds[0] = 40
         container.bounds[1] = 40
-        self.assertEqual(view.view_position, [0, -10.0])
+        self.assertEqual(view.view_position, [-10, 0])
 
 if __name__ == "__main__":
     import nose

--- a/enable/viewport.py
+++ b/enable/viewport.py
@@ -290,6 +290,22 @@ class Viewport(Component):
             new.viewports.append(self)
             self._update_component_view_bounds()
 
+    @on_trait_change('component:bounds')
+    def _component_bounds_updated(self, obj, name, old, new):
+        if name == 'bounds':
+            delta_x = new[0] - old[0]
+            delta_y = new[1] - old[1]
+        elif name == 'bounds_items':
+            delta_x = 0
+            delta_y = 0
+            if new.index == 1:
+                delta_y = new.added[0] - new.removed[0]
+            else:
+                delta_x = new.added[0] - new.removed[0]
+                if len(new.removed) == 2:
+                    delta_y = new.added[1] - new.removed[1]
+        self._adjust_view_from_component_resize(delta_x, delta_y)
+
     def _bounds_changed(self, old, new):
         Component._bounds_changed(self, old, new)
         new_w = new[0]/self.zoom
@@ -297,7 +313,7 @@ class Viewport(Component):
         w, h = self.view_bounds
         delta_x = new_w - w
         delta_y = new_h - h
-        self._adjust_bounds(delta_x, delta_y)
+        self._adjust_view_from_viewport_resize(delta_x, delta_y)
 
     def _bounds_items_changed(self, event):
         return self._bounds_changed(None, self.bounds)
@@ -328,12 +344,80 @@ class Viewport(Component):
     def _initialize_position(self):
         self.trait_set(view_position=self._initial_position())
 
-    def _adjust_bounds(self, delta_x, delta_y):
+    def _adjust_view_from_viewport_resize(self, delta_x, delta_y):
+        """ The viewport has been resized, so need to adjust view parameters
+
+        This computes the new view bounds, shifts the view position depending
+        on the horizontal and vertical anchoring, and if we are trying to stay
+        inside the viewed component, adjusts for that as well.
+
+        Parameters
+        ----------
+        delta_x : float
+            The change in width of the view_bounds in viewed component
+            coordinates.
+
+        delta_y : float
+            The change in height of the view_bounds in viewed component
+            coordinates.
+        """
+        # resize the view
         w, h = self.view_bounds
-        x, y = self.view_position
         new_w = w + delta_x
         new_h = h + delta_y
 
+        x, y = self._shift_view_position(delta_x, delta_y)
+
+        if self.stay_inside and self.component is not None:
+            extra_width = self.component.width - new_w
+            extra_height = self.component.height - new_h
+            x, y = self._adjust_stay_inside(x, y, extra_width, extra_height)
+
+        self.trait_set(view_bounds=[new_w, new_h], view_position=[x, y])
+
+    def _adjust_view_from_component_resize(self, delta_x, delta_y):
+        """ The viewport has been resized, so need to adjust view parameters
+
+        This shifts the view position depending on the horizontal and vertical
+        anchoring, and if we are trying to stay inside the viewed component,
+        adjusts for that as well.  The view bounds should not change from a
+        component resize.
+
+        Parameters
+        ----------
+        delta_x : float
+            The change in width of the viewed component.
+
+        delta_y : float
+            The change in height of the viewed component.
+        """
+        x, y = self._shift_view_position(-delta_x, -delta_y)
+
+        if self.stay_inside and self.component is not None:
+            w, h = self.view_bounds
+            extra_width = self.component.width - w
+            extra_height = self.component.height - h
+            x, y = self._adjust_stay_inside(x, y, extra_width, extra_height)
+
+        self.trait_set(view_position=[x, y])
+
+    def _shift_view_position(self, delta_x, delta_y):
+        """ Compute new view position, accounting for anchoring
+
+        Parameters
+        ----------
+        delta_x : float
+            The change in width that needs to be accounted for.
+
+        delta_y : float
+            The change in height that needs to be accounted for.
+
+        Returns
+        -------
+        position : tuple of float, float
+            The new x, y coordinates for the view position.
+        """
+        x, y = self.view_position
         if self.vertical_anchor == 'top':
             y -= delta_y
         elif self.vertical_anchor == 'center':
@@ -343,27 +427,54 @@ class Viewport(Component):
             x -= delta_x
         elif self.horizontal_anchor == 'center':
             x -= delta_x/2
+        return x, y
 
-        if self.stay_inside and self.component is not None:
-            extra_height = self.component.height - new_h
-            extra_width = self.component.width - new_w
+    def _adjust_stay_inside(self, x, y, extra_width, extra_height):
+        """ Compute new view position, resisting views outside component
 
-            if extra_height >= 0:
-                y = min(max(0, y), extra_height)
-            elif self.vertical_anchor == 'top':
-                y = extra_height
-            elif self.vertical_anchor == 'center':
-                y = extra_height/2
-            else:
-                y = 0
+        The algorithm followed is:
 
-            if extra_width >= 0:
-                x =  min(max(0, x), extra_width)
-            elif self.horizontal_anchor == 'right':
-                x = extra_width
-            elif self.horizontal_anchor == 'center':
-                x = extra_width/2
-            else:
-                x = 0
+        * if the view is smaller than the component, position should be
+          between 0 and the amount of extra space
+        * otherwise, expand view outside of component based on anchor point
 
-        self.trait_set(view_bounds=[new_w, new_h], view_position=[x, y])
+        Parameters
+        ----------
+        x : float
+            The proposed x coordinate of the new view position.
+
+        y : float
+            The proposed y coordinate of the new view position.
+
+        extra_width : float
+            The difference in width between the viewed component and the view
+            bounds (may be negative)
+
+        extra_height : float
+            The difference in height between the viewed component and the view
+            bounds (may be negative)
+
+        Returns
+        -------
+        position : tuple of float, float
+            The new x, y coordinates for the view position.
+        """
+        if extra_height >= 0:
+            y = min(max(0, y), extra_height)
+        elif self.vertical_anchor == 'top':
+            y = extra_height
+        elif self.vertical_anchor == 'center':
+            y = extra_height/2
+        else:
+            y = 0
+
+        if extra_width >= 0:
+            x =  min(max(0, x), extra_width)
+        elif self.horizontal_anchor == 'right':
+            x = extra_width
+        elif self.horizontal_anchor == 'center':
+            x = extra_width/2
+        else:
+            x = 0
+
+        return x, y

--- a/enable/viewport.py
+++ b/enable/viewport.py
@@ -76,12 +76,12 @@ class Viewport(Component):
 
     def __init__(self, **traits):
         Component.__init__(self, **traits)
-        self._adjust_bounds(0, 0)
+        if self.component is not None:
+            self._initialize_position()
         if 'zoom_tool' not in traits:
             self.zoom_tool = ViewportZoomTool(self)
         if self.enable_zoom:
             self._enable_zoom_changed(False, True)
-        return
 
     def components_at(self, x, y, add_containers = False):
         """
@@ -288,6 +288,7 @@ class Viewport(Component):
 
         if (new is not None) and (self not in new.viewports):
             new.viewports.append(self)
+            self._initialize_position()
             self._update_component_view_bounds()
         return
 
@@ -312,6 +313,19 @@ class Viewport(Component):
 
     def _get_bounds(self):
         return self.view_bounds
+
+    def _initialize_position(self):
+        x = 0
+        y = 0
+        if self.vertical_anchor == 'top':
+            y = self.component.height-self.view_bounds[1]
+        elif self.vertical_anchor == 'center':
+            y = (self.component.height-self.view_bounds[1])/2.0
+        if self.horizontal_anchor == 'right':
+            x = self.component.width-self.view_bounds[0]
+        elif self.horizontal_anchor == 'center':
+            x = (self.component.width-self.view_bounds[0])/2.0
+        self.trait_set(view_position=[x, y])
 
     def _adjust_bounds(self, delta_x, delta_y):
         w, h = self.view_bounds

--- a/examples/enable/scrolled_canvas_demo.py
+++ b/examples/enable/scrolled_canvas_demo.py
@@ -32,8 +32,10 @@ class MyFrame(DemoFrame):
                                j*spacing + offset - boxsize/2 + 0.5]
                 canvas.add(box)
 
-        viewport = Viewport(component=canvas, enable_zoom=True)
-        viewport.view_position = [0,0]
+        viewport = Viewport(component=canvas, enable_zoom=True,
+                            vertical_anchor='center',
+                            horizontal_anchor='center')
+        #viewport.view_position = [0,0]
         viewport.tools.append(ViewportPanTool(viewport))
 
         # Uncomment the following to enforce limits on the zoom

--- a/examples/enable/scrolled_demo.py
+++ b/examples/enable/scrolled_demo.py
@@ -117,14 +117,15 @@ class MyFrame(DemoFrame):
 
     def _create_window(self):
 
-        container = Container(bounds=[800,600], bgcolor=(0.9, 0.7, 0.7, 1.0),
+        container = Container(bounds=[800, 600], bgcolor=(0.9, 0.7, 0.7, 1.0),
                               auto_size=False, fit_window=False)
         circle1 = Circle(bounds=[75,75], position=[100,100],
                          shadow_type="dashed")
         container.add(circle1)
 
         scr = Scrolled(container, bounds=[200,200], position=[50,50],
-                       fit_window=False)
+                       stay_inside=True, vertical_anchor='top',
+                       horizontal_anchor='left', fit_window=False)
 
         return Window(self, -1, component=scr)
 


### PR DESCRIPTION
This adds logic to the `Viewport` component (and some auxiliary changes for the `Scrolled` component) that allows move familiar scrolling conventions.

Viewports can now specify horizontal and vertical anchors for the view which indicate where the initial position of the viewport should be relative to the component, and the fixed point when the bounds of the view change.

In addition the unimplemented `stay_inside` option is now implemented: when changing the bounds of the viewport the view will try to stay within the bounds of the viewed component, if possible.

This PR is built on #205, since it makes the interactive testing easier, but is technically orthogonal to it.

Tests included.