### PR TITLE
fix support for Pillow 3.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ env:
 matrix:
   exclude:
     - python: 2.6
-      env: ETS_TOOLKIT=qt4
+      env: ETS_TOOLKIT=qt4 PILLOW='pillow'
     - python: 2.6
-      env: ETS_TOOLKIT=wx
+      env: ETS_TOOLKIT=wx PILLOW='pillow'
     - python: 2.6
-      env: ETS_TOOLKIT=wx ETS_TOOLKIT=null.image PILLOW='pillow'
+      env: ETS_TOOLKIT=null.image PILLOW='pillow'
 cache:
   directories:
     - $HOME/.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,15 @@ addons:
 env:
   - ETS_TOOLKIT=wx
   - ETS_TOOLKIT=qt4
-  - ETS_TOOLKIT=null.image
+  - ETS_TOOLKIT=null.image PILLOW='pillow<3.0.0'
 matrix:
   exclude:
     - python: 2.6
       env: ETS_TOOLKIT=qt4
     - python: 2.6
       env: ETS_TOOLKIT=wx
+    - python: 2.6
+      env: ETS_TOOLKIT=wx ETS_TOOLKIT=null.image PILLOW='pillow'
 cache:
   directories:
     - $HOME/.cache
@@ -40,8 +42,8 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 install:
-  # nose is already installed
-  # numpy is already installed
+  # Install pillow separately to control the version
+  - pip install $PILLOW
   - pip install -r travis-ci-requirements
   - pip install coveralls
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
   - ETS_TOOLKIT=wx
   - ETS_TOOLKIT=qt4
   - ETS_TOOLKIT=null.image PILLOW='pillow<3.0.0'
+  - ETS_TOOLKIT=null.image PILLOW='pillow'
 matrix:
   exclude:
     - python: 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ addons:
     - libfreetype6-dev
     - python-cairo
 env:
-  - ETS_TOOLKIT=wx
-  - ETS_TOOLKIT=qt4
+  - ETS_TOOLKIT=wx PILLOW='pillow'
+  - ETS_TOOLKIT=qt4 PILLOW='pillow'
   - ETS_TOOLKIT=null.image PILLOW='pillow<3.0.0'
   - ETS_TOOLKIT=null.image PILLOW='pillow'
 matrix:

--- a/kiva/agg/src/graphics_context.i
+++ b/kiva/agg/src/graphics_context.i
@@ -961,6 +961,7 @@ class Image(GraphicsContextArray):
         """
         # read the file using PIL
         from PIL import Image as PilImage
+        from kiva.compat import piltostring
         pil_img = PilImage.open(file)
 
         # Convert image to a numeric array
@@ -968,7 +969,7 @@ class Image(GraphicsContextArray):
             (cvar.ALWAYS_32BIT_WORKAROUND_FLAG and pil_img.mode != "RGBA")):
             pil_img = pil_img.convert(mode="RGBA")
         depth = pil_depth_map[pil_img.mode]
-        img = fromstring(pil_img.tostring(),uint8)
+        img = fromstring(piltostring(pil_img),uint8)
         img = resize(img, (pil_img.size[1],pil_img.size[0],depth))
         format = pil_format_map[pil_img.mode]
 

--- a/kiva/agg/src/graphics_context.i
+++ b/kiva/agg/src/graphics_context.i
@@ -813,7 +813,6 @@ namespace kiva {
                     file format does not support alpha, the image is saved in
                     rgb24 format.
                 """
-		from kiva.compat import pilfromstring
                 FmtsWithoutAlpha = ('jpg', 'bmp', 'eps', "jpeg")
                 size = (self.width(), self.height())
                 fmt = self.format()
@@ -839,7 +838,8 @@ namespace kiva {
                 else:
                     bmp = self.bmp_array
 
-                img = pilfromstring(pilformat, size, bmp.tostring())
+                from kiva import compat
+                img = compat.pilfromstring(pilformat, size, bmp.tostring())
                 img.save(filename, format=file_format, options=pil_options)
 
 

--- a/kiva/agg/src/graphics_context.i
+++ b/kiva/agg/src/graphics_context.i
@@ -813,8 +813,8 @@ namespace kiva {
                     file format does not support alpha, the image is saved in
                     rgb24 format.
                 """
+		from kiva.compat import pilfromstring
                 FmtsWithoutAlpha = ('jpg', 'bmp', 'eps', "jpeg")
-                from PIL import Image as PilImage
                 size = (self.width(), self.height())
                 fmt = self.format()
 
@@ -839,7 +839,7 @@ namespace kiva {
                 else:
                     bmp = self.bmp_array
 
-                img = PilImage.fromstring(pilformat, size, bmp.tostring())
+                img = pilfromstring(pilformat, size, bmp.tostring())
                 img.save(filename, format=file_format, options=pil_options)
 
 

--- a/kiva/compat.py
+++ b/kiva/compat.py
@@ -10,14 +10,14 @@ PILLOW_VERSION = getattr(PIL, 'PILLOW_VERSION', PIL.VERSION)
 
 
 def piltostring(image):
-    if PILLOW_VERSION.starts_with('3'):
+    if PILLOW_VERSION.startswith('3'):
         return image.tobytes()
     else:
         return image.tostring()
 
 
 def pilfromstring(*args, **kwargs):
-    if PILLOW_VERSION.starts_with('3'):
+    if PILLOW_VERSION.startswith('3'):
         return Image.frombytes(*args, **kwargs)
     else:
         return Image.tostring(*args, **kwargs)

--- a/kiva/compat.py
+++ b/kiva/compat.py
@@ -3,21 +3,20 @@ Compatibility module to help support various versions of PIL and
 Pillow.
 
 """
-import PIL
 from PIL import Image
 
-PILLOW_VERSION = getattr(PIL, 'PILLOW_VERSION', PIL.VERSION)
+HAS_FROM_BYTES = hasattr(Image, 'frombytes')
 
 
 def piltostring(image):
-    if PILLOW_VERSION.startswith('3'):
+    if hasattr(image, 'tobytes'):
         return image.tobytes()
     else:
         return image.tostring()
 
 
 def pilfromstring(*args, **kwargs):
-    if PILLOW_VERSION.startswith('3'):
+    if HAS_FROM_BYTES:
         return Image.frombytes(*args, **kwargs)
     else:
         return Image.fromstring(*args, **kwargs)

--- a/kiva/compat.py
+++ b/kiva/compat.py
@@ -6,7 +6,7 @@ Pillow.
 import PIL
 from PIL import Image
 
-PILLOW_VERSION = getattr(PIL, 'PILLOW_VERSION', PIL.PIL_VERSION)
+PILLOW_VERSION = getattr(PIL, 'PILLOW_VERSION', PIL.VERSION)
 
 
 def piltostring(image):

--- a/kiva/compat.py
+++ b/kiva/compat.py
@@ -3,20 +3,21 @@ Compatibility module to help support various versions of PIL and
 Pillow.
 
 """
+import PIL
 from PIL import Image
 
-HAS_FROM_STRING = hasattr(Image, 'fromstring')
+PILLOW_VERSION = getattr(PIL, 'PILLOW_VERSION', PIL.VERSION)
 
 
 def piltostring(image):
-    if hasattr(image, 'tostring'):
-        return image.tostring()
-    else:
+    if PILLOW_VERSION.startswith('3'):
         return image.tobytes()
+    else:
+        return image.tostring()
 
 
 def pilfromstring(*args, **kwargs):
-    if HAS_FROM_STRING:
-        return Image.fromstring(*args, **kwargs)
-    else:
+    if PILLOW_VERSION.startswith('3'):
         return Image.frombytes(*args, **kwargs)
+    else:
+        return Image.fromstring(*args, **kwargs)

--- a/kiva/compat.py
+++ b/kiva/compat.py
@@ -3,21 +3,20 @@ Compatibility module to help support various versions of PIL and
 Pillow.
 
 """
-import PIL
 from PIL import Image
 
-PILLOW_VERSION = getattr(PIL, 'PILLOW_VERSION', PIL.VERSION)
+HAS_FROM_STRING = hasattr(Image, 'fromstring')
 
 
 def piltostring(image):
-    if PILLOW_VERSION.startswith('3'):
-        return image.tobytes()
-    else:
+    if hasattr(image, 'tostring'):
         return image.tostring()
+    else:
+        return image.tobytes()
 
 
 def pilfromstring(*args, **kwargs):
-    if PILLOW_VERSION.startswith('3'):
-        return Image.frombytes(*args, **kwargs)
-    else:
+    if HAS_FROM_STRING:
         return Image.fromstring(*args, **kwargs)
+    else:
+        return Image.frombytes(*args, **kwargs)

--- a/kiva/compat.py
+++ b/kiva/compat.py
@@ -4,9 +4,9 @@ Pillow.
 
 """
 import PIL
+from PIL import Image
 
-PIL_VERSION = getattr(PIL, 'VERSION')
-PILLOW_VERSION = getattr(PIL, 'PILLOW_VERSION', PIL_VERSION)
+PILLOW_VERSION = getattr(PIL, 'PILLOW_VERSION', PIL.PIL_VERSION)
 
 
 def piltostring(image):
@@ -14,3 +14,10 @@ def piltostring(image):
         return image.tobytes()
     else:
         return image.tostring()
+
+
+def pilfromstring(*args, **kwargs):
+    if PILLOW_VERSION.starts_with('3'):
+        return Image.frombytes(*args, **kwargs)
+    else:
+        return Image.tostring(*args, **kwargs)

--- a/kiva/compat.py
+++ b/kiva/compat.py
@@ -1,0 +1,16 @@
+"""
+Compatibility module to help support various versions of PIL and
+Pillow.
+
+"""
+import PIL
+
+PIL_VERSION = getattr(PIL, 'VERSION')
+PILLOW_VERSION = getattr(PIL, 'PILLOW_VERSION', PIL_VERSION)
+
+
+def piltostring(image):
+    if PILLOW_VERSION.starts_with('3'):
+        return image.tobytes()
+    else:
+        return image.tostring()

--- a/kiva/compat.py
+++ b/kiva/compat.py
@@ -20,4 +20,4 @@ def pilfromstring(*args, **kwargs):
     if PILLOW_VERSION.startswith('3'):
         return Image.frombytes(*args, **kwargs)
     else:
-        return Image.tostring(*args, **kwargs)
+        return Image.fromstring(*args, **kwargs)

--- a/kiva/tests/test_graphics_context.py
+++ b/kiva/tests/test_graphics_context.py
@@ -8,6 +8,7 @@ from hypothesis import given
 from hypothesis.strategies import sampled_from
 
 from kiva.image import GraphicsContext
+from kiva.compat import piltostring
 
 # alpha blending is approximate in agg, so we allow some "slop" between
 # desired and actual results, allow channel differences of to 2.
@@ -126,7 +127,7 @@ class TestAlphaBlackImage(unittest.TestCase):
 
     def sun(self, interpolation_scheme="simple"):
         pil_img = PILImage.open('doubleprom_soho_full.jpg')
-        img = fromstring(pil_img.tostring(), UInt8)
+        img = fromstring(piltostring(pil_img), UInt8)
         img.resize((pil_img.size[1], pil_img.size[0], 3))
         alpha = ones(pil_img.size, UInt8) * 255
         img = concatenate((img[:, :, ::-1], alpha[:, :, newaxis]), -1).copy()


### PR DESCRIPTION
The new Pillow 3.0.x has the `tostring` and `fromstring` methods from `Image` raise an exception. This PR fixed enable the support for Pillow 3.0.x

in more details:
- a compatibility module is added to allow using new and old versions of Pillow
- Wx and Qt backends are checked against Pillow 3.0.0
-  The null.image backend is check against Pillow<3.0.0 and Pillow 3.0.0 on python 2.7 and only on Pillow<3.0.0 on python 2.6

