### PR TITLE
Don't use a GraphicsContext for storage in the Image component

### DIFF
--- a/enable/primitives/image.py
+++ b/enable/primitives/image.py
@@ -11,11 +11,10 @@
 """
 
 # Enthought library imports
-from traits.api import Array, Enum, Instance, Property, cached_property
+from traits.api import Array, Enum, Property, cached_property
 
 # Local imports
 from enable.component import Component
-from kiva.image import GraphicsContext
 
 
 class Image(Component):
@@ -37,8 +36,8 @@ class Image(Component):
     #: the size-hint for constraints-based layout
     layout_size_hint = Property(data, depends_on="data")
 
-    #: the image as an Image GC
-    _image = Property(Instance(GraphicsContext), depends_on="data")
+    #: the image as a C-contiguous ndarray
+    _image = Property(Array(shape=(None, None, None)), depends_on="data")
 
     @classmethod
     def from_file(cls, filename, **traits):
@@ -56,9 +55,8 @@ class Image(Component):
     def _draw_mainlayer(self, gc, view_bounds=None, mode="normal"):
         """ Draws the image. """
         with gc:
-            gc.draw_image(
-                self._image, (self.x, self.y, self.width, self.height)
-            )
+            rect = (self.x, self.y, self.width, self.height)
+            gc.draw_image(self._image, rect)
 
     @cached_property
     def _get_format(self):
@@ -79,5 +77,4 @@ class Image(Component):
             data = self.data.copy()
         else:
             data = self.data
-        image_gc = GraphicsContext(data, pix_format=self.format)
-        return image_gc
+        return data

--- a/enable/tests/primitives/test_image.py
+++ b/enable/tests/primitives/test_image.py
@@ -106,13 +106,13 @@ class ImageTest(unittest.TestCase, UnittestTools):
 
     def test_image_gc_24(self):
         # this is non-contiguous, because data comes from slice
-        image_gc = self.image_24._image
-        assert_array_equal(image_gc.bmp_array, self.data[..., :3])
+        image = self.image_24._image
+        assert_array_equal(image, self.data[..., :3])
 
     def test_image_gc_32(self):
         # this is contiguous
-        image_gc = self.image_32._image
-        assert_array_equal(image_gc.bmp_array, self.data)
+        image = self.image_32._image
+        assert_array_equal(image, self.data)
 
     def test_draw_24(self):
         gc = GraphicsContext((256, 128), pix_format="rgb24")


### PR DESCRIPTION
@corranwebster: You are the author of the `Image` component. Do you recall what your motivation was for putting the image data into a `GraphicsContext` and passing that when drawing? Why not just draw directly from an array?

I'd like to phase out certain usage of AGG so that it can be removed. This is one of the spots that needs attention.