### PR TITLE
Ensure integer sizes

### DIFF
--- a/kiva/agg/src/graphics_context.i
+++ b/kiva/agg/src/graphics_context.i
@@ -292,47 +292,58 @@ namespace kiva {
             %pythoncode
             %{
             # We define our own constructor AND destructor.
-
             def __init__(self, ary_or_size, pix_format="bgra32",
-                         interpolation="nearest",bottom_up = 1):
+                         interpolation="nearest", bottom_up=1):
                 """ When specifying size, it must be a two element tuple.
                     Array input is always treated as an image.
 
                     This class handles the polymorphism of the underlying
                     template classes for individual pixel formats.
                 """
-                array_locally_allocated = False
-                self.corner_pixel_origin = True
 
                 pix_format_id = pix_format_string_map[pix_format]
                 img_depth = pix_format_bytes[pix_format]
                 interpolation_id = interp_string_map[interpolation]
-
                 if type(ary_or_size) is tuple:
-                    width,height = ary_or_size
-                    # fix me: this is a slow way to create an array.
-                    #         the new empty() method in Numeric is much
-                    #         faster because it doesn\'t zero memory.
-                    ary = zeros((height,width,img_depth),uint8)
-                    array_locally_allocated = True
+                    width, height = ary_or_size
+                    # Ensure that we pass on integers.
+                    width = int(width)
+                    height = int(height)
+                    ary = zeros((height, width, img_depth), uint8)
+                    ary[:] = 255
                 else:
                     ary = ary_or_size
                     sh = shape(ary)
                     if len(sh) == 2:
-                        msg = "2D arrays must use a format that is one byte per pixel"
-                        assert img_depth == 1, msg
+                        if img_depth != 1:
+                            msg = "2D arrays must use a format that is one byte per pixel"
+                            raise ValueError(msg)
                     elif len(sh) == 3:
-                        msg = "Image depth and format are incompatible"
-                        assert img_depth == sh[2], msg
+                        if img_depth != sh[2]:
+                            msg = "Image depth and format are incompatible"
+                            raise ValueError(msg)
                     else:
                         msg = "only 2 or 3 dimensional arrays are supported as images"
                         msg += " but got sh=%r" % (sh,)
                         raise TypeError(msg)
                     msg = "Only UnsignedInt8 arrays are supported but got "
-                    assert(ary.dtype == dtype('uint8')), msg + repr(ary.dtype)
+                    assert ary.dtype == dtype('uint8'), msg + repr(ary.dtype)
 
-                obj = graphics_context_from_array(ary,pix_format_id,
-                                                  interpolation_id,
+                if cvar.ALWAYS_32BIT_WORKAROUND_FLAG:
+                    if ary.shape[-1] == 3:
+                        if pix_format not in ('rgb24', 'bgr24'):
+                            import warnings
+                            warnings.warn('need to workaround AGG bug since '
+                                    'ALWAYS_32BIT_WORKAROUND is on, but got unhandled '
+                                    'format %r' % pix_format)
+                        else:
+                            pix_format = '%sa32' % pix_format[:3]
+                            ary = numpy.dstack([ary, numpy.empty(ary.shape[:2], dtype=uint8)])
+                            ary[:,:,-1].fill(255)
+                    pix_format_id = pix_format_string_map[pix_format]
+                    img_depth = pix_format_bytes[pix_format]
+
+                obj = graphics_context_from_array(ary,pix_format_id,interpolation_id,
                                                   bottom_up)
 
                 _swig_setattr(self, GraphicsContextArray, 'this', obj)
@@ -343,9 +354,6 @@ namespace kiva {
                 _swig_setattr(self, GraphicsContextArray, 'thisown2', 1)
 
                 self.bmp_array = ary
-
-                if array_locally_allocated is True:
-                    self.clear()
 
             def __del__(self, destroy=_agg.destroy_graphics_context):
                 try:
@@ -872,70 +880,6 @@ namespace kiva {
 
 %pythoncode
 %{
-# constructors for GraphicsContextArray and Image
-
-# !! Temporary until we get the __init__ code in swig fixed.
-def init(self, ary_or_size, pix_format="bgra32",
-             interpolation="nearest",bottom_up = 1):
-    """ When specifying size, it must be a two element tuple.
-        Array input is always treated as an image.
-
-        This class handles the polymorphism of the underlying
-        template classes for individual pixel formats.
-    """
-
-    pix_format_id = pix_format_string_map[pix_format]
-    img_depth = pix_format_bytes[pix_format]
-    interpolation_id = interp_string_map[interpolation]
-    if type(ary_or_size) is tuple:
-        width,height = ary_or_size
-        ary = zeros((height,width,img_depth),uint8)
-        ary[:] = 255
-    else:
-        ary = ary_or_size
-        sh = shape(ary)
-        if len(sh) == 2:
-            if img_depth != 1:
-                msg = "2D arrays must use a format that is one byte per pixel"
-                raise ValueError(msg)
-        elif len(sh) == 3:
-            if img_depth != sh[2]:
-                msg = "Image depth and format are incompatible"
-                raise ValueError(msg)
-        else:
-            msg = "only 2 or 3 dimensional arrays are supported as images"
-            msg += " but got sh=%r" % (sh,)
-            raise TypeError(msg)
-        msg = "Only UnsignedInt8 arrays are supported but got "
-        assert ary.dtype == dtype('uint8'), msg + repr(ary.dtype)
-
-    if cvar.ALWAYS_32BIT_WORKAROUND_FLAG:
-        if ary.shape[-1] == 3:
-            if pix_format not in ('rgb24', 'bgr24'):
-                import warnings
-                warnings.warn('need to workaround AGG bug since '
-                	'ALWAYS_32BIT_WORKAROUND is on, but got unhandled '
-                	'format %r' % pix_format)
-            else:
-                pix_format = '%sa32' % pix_format[:3]
-                ary = numpy.dstack([ary, numpy.empty(ary.shape[:2], dtype=uint8)])
-                ary[:,:,-1].fill(255)
-        pix_format_id = pix_format_string_map[pix_format]
-        img_depth = pix_format_bytes[pix_format]
-
-    obj = graphics_context_from_array(ary,pix_format_id,interpolation_id,
-                                      bottom_up)
-
-    _swig_setattr(self, GraphicsContextArray, 'this', obj)
-    # swig 1.3.28 does not have real thisown, thisown is mapped
-    # to this.own() but with previous 'self.this=obj' an
-    # attribute 'own' error is raised. Does this workaround
-    # work with pre-1.3.28 swig?
-    _swig_setattr(self, GraphicsContextArray, 'thisown2', 1)
-
-    self.bmp_array = ary
-
-GraphicsContextArray.__init__ = init
 
 pil_format_map = {}
 pil_format_map["RGB"] = "rgb24"

--- a/kiva/tests/test_macport.py
+++ b/kiva/tests/test_macport.py
@@ -1,42 +1,49 @@
 import sys
 
+from traitsui.tests._tools import skip_if_not_wx
+
+
+@skip_if_not_wx
 def test_macport():
-    if sys.platform == 'darwin':
-        import wx
+    if sys.platform != 'darwin':
+        from unittest.case import SkipTest
+        raise SkipTest("macport is only built on OS X")
 
-        from kiva.quartz import get_macport
+    import wx
 
-        class SimpleWindow(wx.Frame):
-            """
-            Simple test of get_macport().
-            """
-            def __init__(self):
-                wx.Frame.__init__(self, parent=None, id=-1, title="foo",
-                                   pos=(100,100),
-                                   size=(300,300))
-                oldstyle = self.GetWindowStyle()
-                oldstyle = oldstyle | wx.FULL_REPAINT_ON_RESIZE
-                self.SetWindowStyle(oldstyle)
-                self.Show(1)
-                self.Bind(wx.EVT_PAINT, self.OnPaint)
-                self.memdc = wx.MemoryDC()
-                self.bitmap = wx.EmptyBitmap(200,200)
-                self.memdc.SelectObject(self.bitmap)
+    from kiva.quartz import get_macport
 
-            def OnPaint(self, evt):
-                dc = wx.PaintDC(self)
-                print "paintdc.this:", dc.this
-                print "paintdc.macport: %x" % get_macport(dc)
-                print "memdc.this:", self.memdc.this
-                print "memdc.macport: %x" % get_macport(self.memdc)
+    class SimpleWindow(wx.Frame):
+        """
+        Simple test of get_macport().
+        """
+        def __init__(self):
+            wx.Frame.__init__(self, parent=None, id=-1, title="foo",
+                               pos=(100,100),
+                               size=(300,300))
+            oldstyle = self.GetWindowStyle()
+            oldstyle = oldstyle | wx.FULL_REPAINT_ON_RESIZE
+            self.SetWindowStyle(oldstyle)
+            self.Show(1)
+            self.Bind(wx.EVT_PAINT, self.OnPaint)
+            self.memdc = wx.MemoryDC()
+            self.bitmap = wx.EmptyBitmap(200,200)
+            self.memdc.SelectObject(self.bitmap)
 
-                # We're done here
-                self.Close()
+        def OnPaint(self, evt):
+            dc = wx.PaintDC(self)
+            print "paintdc.this:", dc.this
+            print "paintdc.macport: %x" % get_macport(dc)
+            print "memdc.this:", self.memdc.this
+            print "memdc.macport: %x" % get_macport(self.memdc)
 
-        class MyApp(wx.App):
-            def OnInit(self):
-                w = SimpleWindow()
-                return 1
+            # We're done here
+            self.Close()
 
-        app = MyApp(False)
-        app.MainLoop()
+    class MyApp(wx.App):
+        def OnInit(self):
+            w = SimpleWindow()
+            return 1
+
+    app = MyApp(False)
+    app.MainLoop()


### PR DESCRIPTION
numpy 1.12 completes the deprecation of floats as shapes. The `GraphicsContext()` constructor permits such floats, so we coerce internally at the last possible moment.

This also fixes the skip logic for an unrelated test so that I'd have a clean test suite.

This should fix the test failure in enthought/chaco#342 in the one Travis environment that is using numpy 1.12.