### PR TITLE
FIX: Don't crash if the list of fonts is empty

### DIFF
--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -1075,7 +1075,10 @@ class FontManager:
                 break
         else:
             # use anything
-            self.defaultFont['ttf'] = self.ttffiles[0]
+            try:
+                self.defaultFont['ttf'] = self.ttffiles[0]
+            except IndexError:
+                pass
 
         self.ttflist = createFontList(self.ttffiles)
 

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -384,6 +384,7 @@ def x11FontDirectory():
     for fontdir in X11FontDirectories:
         try:
             if os.path.isdir(fontdir):
+                fontpaths.append(fontdir)
                 for dirpath, dirs, _files in os.walk(fontdir):
                     fontpaths.extend([os.path.join(dirpath, d) for d in dirs])
 

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -343,6 +343,7 @@ def OSXFontDirectory():
     for fontdir in OSXFontDirectories:
         try:
             if os.path.isdir(fontdir):
+                fontpaths.append(fontdir)
                 for dirpath, dirs, _files in os.walk(fontdir):
                     fontpaths.extend([os.path.join(dirpath, d) for d in dirs])
 
@@ -1075,10 +1076,7 @@ class FontManager:
                 break
         else:
             # use anything
-            try:
-                self.defaultFont['ttf'] = self.ttffiles[0]
-            except IndexError:
-                pass
+            self.defaultFont['ttf'] = self.ttffiles[0]
 
         self.ttflist = createFontList(self.ttffiles)
 


### PR DESCRIPTION
Quick-fix for #266.  On OS X, this restores the enable-4.5.1 functionality; my Canopy Data app prints a few warnings to the terminal, and then launches normally. 