### PR TITLE
Use older version of fonttools

### DIFF
--- a/travis-ci-requirements
+++ b/travis-ci-requirements
@@ -3,7 +3,7 @@ numpy
 coverage
 pillow
 pyparsing
-fonttools
+fonttools==3.2.0
 PyPDF2
 https://bitbucket.org/pyglet/pyglet/get/pyglet-1.1.4.zip ; python_version <= "2.7"
 pygarrayimage

--- a/travis-ci-requirements
+++ b/travis-ci-requirements
@@ -3,7 +3,7 @@ numpy
 coverage
 pillow
 pyparsing
-fonttools==3.2.0
+fonttools==3.10.0
 PyPDF2
 https://bitbucket.org/pyglet/pyglet/get/pyglet-1.1.4.zip ; python_version <= "2.7"
 pygarrayimage


### PR DESCRIPTION
It looks like fonttools is undergoing rapid change.  Fixing version form December that should be good.