### PR TITLE
setup.py: use package_data instead of pretending that a non-package is a package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -241,7 +241,6 @@ if __name__ == "__main__":
     config = configuration().todict()
     packages = setuptools.find_packages(exclude=config['packages'] +
                                         ['docs', 'examples'])
-    packages += ['enable.savage.trait_defs.ui.wx.data']
     config['packages'] += packages
 
     setup(name='enable',
@@ -285,6 +284,7 @@ if __name__ == "__main__":
           package_data={
               '': ['*.zip', '*.svg', 'images/*'],
               'enable': ['tests/primitives/data/PngSuite/*.png'],
+              'enable.savage.trait_defs.ui.wx': ['data/*.svg'],
               'kiva': ['tests/agg/doubleprom_soho_full.jpg'],
           },
           platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],


### PR DESCRIPTION
I believe that this is the correct fix for the issue identified in #73. I've double-checked that the tarball built with `python setup.py sdist` includes the `data/button_toggle.svg` file.