### PR TITLE
Trivial: add fonttools to dependencies in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ the Enable/Kiva project:
 - `Setuptools <https://pypi.python.org/pypi/setuptools>`_
 - `Numpy <http://pypi.python.org/pypi/numpy>`_
 - `SWIG <http://www.swig.org/>`_
+- `fonttools <https://pypi.python.org/pypi/FontTools>`_
 - (on Linux) X11-devel (development tools for X11)
 - (on Mac OS X) `Cython <http://www.cython.org>`_
 


### PR DESCRIPTION
It seems like it is now needed to compile enable, so this adds it together with Swig and Cython as required dependency.