### PR TITLE
Improve mouse wheel support

### DIFF
--- a/enable/events.py
+++ b/enable/events.py
@@ -118,14 +118,16 @@ class BasicEvent(HasTraits):
             self.y, self.handled)
         return s
 
+
 class MouseEvent(BasicEvent):
-    alt_down     = ReadOnly
+    alt_down = ReadOnly
     control_down = ReadOnly
-    shift_down   = ReadOnly
-    left_down    = ReadOnly
-    middle_down  = ReadOnly
-    right_down   = ReadOnly
-    mouse_wheel  = ReadOnly
+    shift_down = ReadOnly
+    left_down = ReadOnly
+    middle_down = ReadOnly
+    right_down = ReadOnly
+    mouse_wheel = ReadOnly
+    mouse_wheel_axis = ReadOnly
 
 mouse_event_trait = Event(MouseEvent)
 

--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -24,7 +24,10 @@ from enable.events import KeyEvent, MouseEvent, DragEvent
 from traits.api import Instance
 
 # Local imports.
-from constants import BUTTON_NAME_MAP, KEY_MAP, POINTER_MAP, DRAG_RESULTS_MAP
+from constants import (
+    BUTTON_NAME_MAP, KEY_MAP, MOUSE_WHEEL_AXIS_MAP, POINTER_MAP,
+    DRAG_RESULTS_MAP
+)
 
 class _QtWindowHandler(object):
     def __init__(self, qt_window, enable_window):
@@ -407,17 +410,24 @@ class _Window(AbstractWindow):
             delta = event.delta()
             degrees_per_step = 15.0
             mouse_wheel = delta / float(8 * degrees_per_step)
+            mouse_wheel_axis = MOUSE_WHEEL_AXIS_MAP[event.orientation()]
         else:
             mouse_wheel = 0
+            mouse_wheel_axis = 'vertical'
 
-        return MouseEvent(x=x, y=self._flip_y(y), mouse_wheel=mouse_wheel,
-                alt_down=bool(modifiers & QtCore.Qt.AltModifier),
-                shift_down=bool(modifiers & QtCore.Qt.ShiftModifier),
-                control_down=bool(modifiers & QtCore.Qt.ControlModifier),
-                left_down=bool(buttons & QtCore.Qt.LeftButton),
-                middle_down=bool(buttons & QtCore.Qt.MidButton),
-                right_down=bool(buttons & QtCore.Qt.RightButton),
-                window=self)
+        return MouseEvent(
+            x=x,
+            y=self._flip_y(y),
+            mouse_wheel=mouse_wheel,
+            mouse_wheel_axis=mouse_wheel_axis,
+            alt_down=bool(modifiers & QtCore.Qt.AltModifier),
+            shift_down=bool(modifiers & QtCore.Qt.ShiftModifier),
+            control_down=bool(modifiers & QtCore.Qt.ControlModifier),
+            left_down=bool(buttons & QtCore.Qt.LeftButton),
+            middle_down=bool(buttons & QtCore.Qt.MidButton),
+            right_down=bool(buttons & QtCore.Qt.RightButton),
+            window=self
+        )
 
     def _create_drag_event(self, event):
 

--- a/enable/qt4/constants.py
+++ b/enable/qt4/constants.py
@@ -15,7 +15,7 @@ import warnings
 
 from pyface.qt import QtCore
 
-from ..toolkit_constants import key_names, pointer_names
+from ..toolkit_constants import key_names, mouse_wheel_axes_names, pointer_names
 
 DRAG_RESULTS_MAP = { "error":   QtCore.Qt.IgnoreAction,
                      "none":    QtCore.Qt.IgnoreAction,
@@ -148,3 +148,7 @@ for enum_name in dir(QtCore.Qt):
             continue
         key_name = enum_name[len('Key_'):]
         KEY_MAP[enum] = key_name
+
+# set up mouse wheel axes constants
+mouse_wheel_axes = [QtCore.Qt.Vertical, QtCore.Qt.Horizontal]
+MOUSE_WHEEL_AXIS_MAP = dict(zip(mouse_wheel_axes, mouse_wheel_axes_names))

--- a/enable/testing.py
+++ b/enable/testing.py
@@ -151,6 +151,8 @@ class EnableTestAssistant(KivaTestAssistant):
             'alt_down': False,
             'control_down': False,
             'shift_down': False,
+            'mouse_wheel': 0,
+            'mouse_wheel_axis': 'vertical',
         }
         event_attributes.update(**kwargs)
         event = MouseEvent(**event_attributes)

--- a/enable/tests/qt4/mouse_wheel_test_case.py
+++ b/enable/tests/qt4/mouse_wheel_test_case.py
@@ -1,0 +1,75 @@
+
+from unittest import TestCase
+
+from mock import MagicMock
+
+from traits.api import Any
+from traitsui.tests._tools import skip_if_not_qt4
+
+from enable.container import Container
+from enable.base_tool import BaseTool
+from enable.window import Window
+
+
+class MouseEventTool(BaseTool):
+
+    event = Any
+
+    def normal_mouse_wheel(self, event):
+        self.event = event
+
+
+@skip_if_not_qt4
+class MouseWheelTestCase(TestCase):
+
+    def setUp(self):
+
+        # set up Enable components and tools
+        self.container = Container(postion=[0, 0], bounds=[600, 600])
+        self.tool = MouseEventTool(component=self.container)
+        self.container.tools.append(self.tool)
+
+        # set up qt components
+        self.window = Window(
+            None,
+            size=(600, 600),
+            component=self.container
+        )
+
+        # Hack: event processing code skips if window not actually shown by
+        # testing for value of _size
+        self.window._size = (600, 600)
+
+    def test_vertical_mouse_wheel(self):
+        from pyface.qt import QtCore, QtGui
+        from enable.qt4.constants import mouse_wheel_axes
+
+        # create and mock a mouse wheel event
+        qt_event = QtGui.QWheelEvent(
+            QtCore.QPoint(0, 0), 200, QtCore.Qt.NoButton, QtCore.Qt.NoModifier,
+            mouse_wheel_axes[0]
+        )
+
+        # dispatch event
+        self.window._on_mouse_wheel(qt_event)
+
+        # validate results
+        self.assertEqual(self.tool.event.mouse_wheel_axis, 'vertical')
+        self.assertAlmostEqual(self.tool.event.mouse_wheel, 5.0/3.0)
+
+    def test_horizontal_mouse_wheel(self):
+        from pyface.qt import QtCore, QtGui
+        from enable.qt4.constants import mouse_wheel_axes
+
+        # create and mock a mouse wheel event
+        qt_event = QtGui.QWheelEvent(
+            QtCore.QPoint(0, 0), 200, QtCore.Qt.NoButton, QtCore.Qt.NoModifier,
+            mouse_wheel_axes[1]
+        )
+
+        # dispatch event
+        self.window._on_mouse_wheel(qt_event)
+
+        # validate results
+        self.assertEqual(self.tool.event.mouse_wheel_axis, 'horizontal')
+        self.assertAlmostEqual(self.tool.event.mouse_wheel, 5.0/3.0)

--- a/enable/tests/qt4/mouse_wheel_test_case.py
+++ b/enable/tests/qt4/mouse_wheel_test_case.py
@@ -1,8 +1,6 @@
 
 from unittest import TestCase
 
-from mock import MagicMock
-
 from traits.api import Any
 from traitsui.tests._tools import skip_if_not_qt4
 
@@ -12,7 +10,9 @@ from enable.window import Window
 
 
 class MouseEventTool(BaseTool):
+    """ Tool that captures a single mouse wheel event """
 
+    #: the captured mouse event
     event = Any
 
     def normal_mouse_wheel(self, event):
@@ -42,12 +42,11 @@ class MouseWheelTestCase(TestCase):
 
     def test_vertical_mouse_wheel(self):
         from pyface.qt import QtCore, QtGui
-        from enable.qt4.constants import mouse_wheel_axes
 
         # create and mock a mouse wheel event
         qt_event = QtGui.QWheelEvent(
             QtCore.QPoint(0, 0), 200, QtCore.Qt.NoButton, QtCore.Qt.NoModifier,
-            mouse_wheel_axes[0]
+            QtCore.Qt.Vertical
         )
 
         # dispatch event
@@ -59,12 +58,11 @@ class MouseWheelTestCase(TestCase):
 
     def test_horizontal_mouse_wheel(self):
         from pyface.qt import QtCore, QtGui
-        from enable.qt4.constants import mouse_wheel_axes
 
         # create and mock a mouse wheel event
         qt_event = QtGui.QWheelEvent(
             QtCore.QPoint(0, 0), 200, QtCore.Qt.NoButton, QtCore.Qt.NoModifier,
-            mouse_wheel_axes[1]
+            QtCore.Qt.Horizontal
         )
 
         # dispatch event

--- a/enable/tests/wx/mouse_wheel_test_case.py
+++ b/enable/tests/wx/mouse_wheel_test_case.py
@@ -12,7 +12,9 @@ from enable.window import Window
 
 
 class MouseEventTool(BaseTool):
+    """ Tool that captures a single mouse wheel event """
 
+    #: the captured mouse event
     event = Any
 
     def normal_mouse_wheel(self, event):
@@ -44,12 +46,11 @@ class MouseWheelTestCase(TestCase):
 
     def test_vertical_mouse_wheel(self):
         import wx
-        from enable.wx.constants import mouse_wheel_axes
 
         # create and mock a mouse wheel event
         wx_event = wx.MouseEvent(mouseType=wx.wxEVT_MOUSEWHEEL)
         wx_event.GetWheelRotation = MagicMock(return_value=200)
-        wx_event.GetWheelAxis = MagicMock(return_value=mouse_wheel_axes[0])
+        wx_event.GetWheelAxis = MagicMock(return_value=wx.MOUSE_WHEEL_VERTICAL)
         wx_event.GetLinesPerAction = MagicMock(return_value=1)
         wx_event.GetWheelDelta = MagicMock(return_value=120)
 
@@ -62,18 +63,18 @@ class MouseWheelTestCase(TestCase):
 
     def test_horizontal_mouse_wheel(self):
         import wx
-        from enable.wx.constants import mouse_wheel_axes
 
-        tool = MouseEventTool(component=self.container)
-        self.container.tools.append(tool)
-
+        # create and mock a mouse wheel event
         wx_event = wx.MouseEvent(mouseType=wx.wxEVT_MOUSEWHEEL)
         wx_event.GetWheelRotation = MagicMock(return_value=200)
-        wx_event.GetWheelAxis = MagicMock(return_value=mouse_wheel_axes[1])
+        wx_event.GetWheelAxis = MagicMock(
+            return_value=wx.MOUSE_WHEEL_HORIZONTAL)
         wx_event.GetLinesPerAction = MagicMock(return_value=1)
         wx_event.GetWheelDelta = MagicMock(return_value=120)
 
+        # dispatch event
         self.window._handle_mouse_event('mouse_wheel', wx_event)
 
-        self.assertEqual(tool.event.mouse_wheel_axis, 'horizontal')
-        self.assertAlmostEqual(tool.event.mouse_wheel, 5.0/3.0)
+        # validate results
+        self.assertEqual(self.tool.event.mouse_wheel_axis, 'horizontal')
+        self.assertAlmostEqual(self.tool.event.mouse_wheel, 5.0/3.0)

--- a/enable/tests/wx/mouse_wheel_test_case.py
+++ b/enable/tests/wx/mouse_wheel_test_case.py
@@ -1,0 +1,79 @@
+
+from unittest import TestCase
+
+from mock import MagicMock
+
+from traits.api import Any
+from traitsui.tests._tools import skip_if_not_wx
+
+from enable.container import Container
+from enable.base_tool import BaseTool
+from enable.window import Window
+
+
+class MouseEventTool(BaseTool):
+
+    event = Any
+
+    def normal_mouse_wheel(self, event):
+        self.event = event
+
+
+@skip_if_not_wx
+class MouseWheelTestCase(TestCase):
+
+    def setUp(self):
+        import wx
+
+        # set up Enable components and tools
+        self.container = Container(postion=[0, 0], bounds=[600, 600])
+        self.tool = MouseEventTool(component=self.container)
+        self.container.tools.append(self.tool)
+
+        # set up wx components and tools
+        self.parent = wx.Frame(None, size=(600, 600))
+        self.window = Window(
+            self.parent,
+            size=(600, 600),
+            component=self.container
+        )
+
+        # Hack: event processing code skips if window not actually shown by
+        # testing for value of _size
+        self.window._size = (600, 600)
+
+    def test_vertical_mouse_wheel(self):
+        import wx
+        from enable.wx.constants import mouse_wheel_axes
+
+        # create and mock a mouse wheel event
+        wx_event = wx.MouseEvent(mouseType=wx.wxEVT_MOUSEWHEEL)
+        wx_event.GetWheelRotation = MagicMock(return_value=200)
+        wx_event.GetWheelAxis = MagicMock(return_value=mouse_wheel_axes[0])
+        wx_event.GetLinesPerAction = MagicMock(return_value=1)
+        wx_event.GetWheelDelta = MagicMock(return_value=120)
+
+        # dispatch event
+        self.window._on_mouse_wheel(wx_event)
+
+        # validate results
+        self.assertEqual(self.tool.event.mouse_wheel_axis, 'vertical')
+        self.assertAlmostEqual(self.tool.event.mouse_wheel, 5.0/3.0)
+
+    def test_horizontal_mouse_wheel(self):
+        import wx
+        from enable.wx.constants import mouse_wheel_axes
+
+        tool = MouseEventTool(component=self.container)
+        self.container.tools.append(tool)
+
+        wx_event = wx.MouseEvent(mouseType=wx.wxEVT_MOUSEWHEEL)
+        wx_event.GetWheelRotation = MagicMock(return_value=200)
+        wx_event.GetWheelAxis = MagicMock(return_value=mouse_wheel_axes[1])
+        wx_event.GetLinesPerAction = MagicMock(return_value=1)
+        wx_event.GetWheelDelta = MagicMock(return_value=120)
+
+        self.window._handle_mouse_event('mouse_wheel', wx_event)
+
+        self.assertEqual(tool.event.mouse_wheel_axis, 'horizontal')
+        self.assertAlmostEqual(tool.event.mouse_wheel, 5.0/3.0)

--- a/enable/toolkit_constants.py
+++ b/enable/toolkit_constants.py
@@ -122,3 +122,4 @@ key_names = [
     'Alt',
 ]
 
+mouse_wheel_axes_names = ['vertical', 'horizontal']

--- a/enable/wx/base_window.py
+++ b/enable/wx/base_window.py
@@ -16,7 +16,9 @@ from traitsui.wx.menu import MakeMenu
 from enable.events import MouseEvent, KeyEvent, DragEvent
 from enable.abstract_window import AbstractWindow
 
-from .constants import DRAG_RESULTS_MAP, POINTER_MAP, KEY_MAP
+from .constants import (
+    DRAG_RESULTS_MAP, MOUSE_WHEEL_AXIS_MAP, POINTER_MAP, KEY_MAP
+)
 
 try:
     from pyface.wx.drag_and_drop import clipboard, PythonDropTarget
@@ -302,7 +304,7 @@ class BaseWindow(AbstractWindow):
         handled = self._handle_key_event('key_released', event)
         if not handled:
             event.Skip()
-    
+
     def _create_key_event(self, event_type, event):
         """ Convert a GUI toolkit keyboard event into a KeyEvent.
         """
@@ -310,7 +312,7 @@ class BaseWindow(AbstractWindow):
             focus_owner = self.component
         else:
             focus_owner = self.focus_owner
-        
+
         if focus_owner is not None:
             if event_type == 'character':
                 key = unichr(event.GetUniChar())
@@ -322,7 +324,7 @@ class BaseWindow(AbstractWindow):
                     key = KEY_MAP.get(key_code)
                 else:
                     key = unichr(event.GetUniChar()).lower()
- 
+
             # Use the last-seen mouse coordinates instead of GetX/GetY due
             # to wx bug.
             x, y = self._last_mouse_pos
@@ -343,7 +345,7 @@ class BaseWindow(AbstractWindow):
                 window = self)
         else:
             event.Skip()
-        
+
         return None
 
     def _create_mouse_event ( self, event ):
@@ -352,9 +354,11 @@ class BaseWindow(AbstractWindow):
             x           = event.GetX()
             y           = event.GetY()
             self._last_mouse_pos = (x, y)
-            mouse_wheel = ((event.GetLinesPerAction() *
+
+            mouse_wheel = ((float(event.GetLinesPerAction()) *
                             event.GetWheelRotation()) /
                             (event.GetWheelDelta() or 1))
+            wheel_axis = MOUSE_WHEEL_AXIS_MAP[event.GetWheelAxis()]
 
             # Note: The following code fixes a bug in wxPython that returns
             # 'mouse_wheel' events in screen coordinates, rather than window
@@ -362,16 +366,19 @@ class BaseWindow(AbstractWindow):
             if float(wx.VERSION_STRING[:3]) < 2.8:
                 if mouse_wheel != 0 and sys.platform == "win32":
                     x, y = self.control.ScreenToClientXY( x, y )
-            return MouseEvent( x            = x,
-                               y            = self._flip_y( y ),
-                               alt_down     = event.AltDown(),
-                               control_down = event.ControlDown(),
-                               shift_down   = event.ShiftDown(),
-                               left_down    = event.LeftIsDown(),
-                               middle_down  = event.MiddleIsDown(),
-                               right_down   = event.RightIsDown(),
-                               mouse_wheel  = mouse_wheel,
-                               window = self )
+            return MouseEvent(
+                x=x,
+                y=self._flip_y(y),
+                alt_down=event.AltDown(),
+                control_down=event.ControlDown(),
+                shift_down=event.ShiftDown(),
+                left_down=event.LeftIsDown(),
+                middle_down=event.MiddleIsDown(),
+                right_down=event.RightIsDown(),
+                mouse_wheel=mouse_wheel,
+                mouse_wheel_axis=wheel_axis,
+                window=self,
+            )
 
         # If no event specified, make one up:
         x, y = wx.GetMousePosition()

--- a/enable/wx/constants.py
+++ b/enable/wx/constants.py
@@ -14,7 +14,9 @@ from __future__ import absolute_import
 import warnings
 import wx
 
-from ..toolkit_constants import pointer_names, key_names
+from ..toolkit_constants import (
+    pointer_names, key_names, mouse_wheel_axes_names
+)
 
 DRAG_RESULTS_MAP = { "error":   wx.DragError,
                      "none":    wx.DragNone,
@@ -141,3 +143,13 @@ if len(key_symbols) != len(key_names):
     warnings.warn("The WX toolkit backend keymap is out of sync!")
 
 KEY_MAP = dict(zip(key_symbols, key_names))
+
+if tuple(float(v) for v in wx.__version__.split('.')) < (2, 9, 4):
+    mouse_wheel_axes = [0, 1]
+else:
+    mouse_wheel_axes = [wx.MOUSE_WHEEL_VERTICAL, wx.MOUSE_WHEEL_HORIZONTAL]
+
+if len(mouse_wheel_axes) != len(mouse_wheel_axes_names):
+    warnings.warn("The WX toolkit backend mouse wheel axes are out of sync!")
+
+MOUSE_WHEEL_AXIS_MAP = dict(zip(mouse_wheel_axes, mouse_wheel_axes_names))


### PR DESCRIPTION
This PR does three things:

- makes scroll wheel rotation values on Wx floating point values.  Fixes #286. 
- adds support for horizontal mouse wheel events via a new `mouse_wheel_axis` trait on `MouseEvents`.  This fixes #134.
- adds tests of the mouse wheel logic for mouse events on Wx and Qt.