### PR TITLE
Fix an exec() syntax error

### DIFF
--- a/examples/kiva_explorer.py
+++ b/examples/kiva_explorer.py
@@ -64,7 +64,7 @@ class ScriptedComponent(Component):
             try:
                 self.error = ''
                 start_time = time.time()
-                exec(self._draw_code in {}, {'gc': gc})
+                exec(self._draw_code, {}, {'gc': gc})
                 self.last_draw_time = time.time() - start_time
             except Exception as exc:
                 self.error = str(exc)


### PR DESCRIPTION
This didn't get converted to Python 2/3 correctly