### PR TITLE
FIX: missing print_function imports

### DIFF
--- a/examples/enable/latency_demo.py
+++ b/examples/enable/latency_demo.py
@@ -1,6 +1,8 @@
 """
 Test to see what level of click latency is noticeable.
 """
+from __future__ import print_function
+
 import time
 
 from traits.api import Float

--- a/examples/enable/view_bounds_test.py
+++ b/examples/enable/view_bounds_test.py
@@ -1,6 +1,8 @@
 """
 Demonstrates how clipping of objects occurs with the view_bounds parameter to draw().
 """
+from __future__ import print_function
+
 from enable.example_support import DemoFrame, demo_main
 
 from enable.api import Container, Component, Scrolled, Window


### PR DESCRIPTION
This just adds in `print_function` imports in a couple of examples they were missing from causing `SyntaxError`s in Python 2.