### PR TITLE
Ignore X11 fonts on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,11 @@ kiva/quartz/CTFont.c
 # Auto-generated version info
 enable/_version.py
 kiva/_version.py
+
+# Unclean test crud.
+arc.png
+arc_to.png
+dash.bmp
+sun.test_*.bmp
+text_image.test_*.bmp
+.hypothesis/

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -109,7 +109,7 @@ weight_dict = {
 }
 
 font_family_aliases = set(['serif', 'sans-serif', 'sans serif', 'cursive',
-                           'fantasy', 'monospace', 'sans'])
+                           'fantasy', 'monospace', 'sans', 'modern'])
 
 #  OS Font paths
 MSFolders = \
@@ -1138,7 +1138,7 @@ class FontManager:
         for i, family1 in enumerate(families):
             family1 = family1.lower()
             if family1 in font_family_aliases:
-                if family1 in ('sans', 'sans serif'):
+                if family1 in ('sans', 'sans serif', 'modern'):
                     family1 = 'sans-serif'
                 options = preferred_fonts[family1]
                 options = [x.lower() for x in options]

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -445,11 +445,14 @@ def findSystemFonts(fontpaths=None, fontext='ttf'):
                 if len(ext) > 1 and ext[1:].lower() in fontexts:
                     fontfiles[f] = 1
         else:
-            fontpaths = x11FontDirectory()
             # check for OS X & load its fonts if present
             if sys.platform == 'darwin':
+                fontpaths = []
                 for f in OSXInstalledFonts(fontext=fontext):
                     fontfiles[f] = 1
+            else:
+                # Otherwise, check X11.
+                fontpaths = x11FontDirectory()
 
             for f in get_fontconfig_fonts(fontext):
                 fontfiles[f] = 1


### PR DESCRIPTION
Fixes #151 

Most installations of X11 on macOS include a `Vera.ttf` font that is incapable of displaying common Unicode characters.

Also, interpret the font family `modern` as `sans-serif`. We use `Font('modern')` in a number of tests to get a "default font". If we go through `KivaFontTrait('modern')`, that will parse down to `Font('')`, which picks up `sans-serif` anyways. This makes both codepaths consistent. Otherwise, `Font('modern')` tries to find a typeface actually named "modern" when it's intended as a general family, like `sans-serif`. This causes warnings in these tests as it falls back to the arbitrary default font instead of looking for a proper `sans-serif` font.