### PR TITLE
Replace mock with unittest.mock when using Python 3

### DIFF
--- a/enable/testing.py
+++ b/enable/testing.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2008-2013 by Enthought, Inc.
 # All rights reserved.
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from enable.abstract_window import AbstractWindow
 from enable.events import MouseEvent, KeyEvent, DragEvent

--- a/enable/tests/test_assistant_test_case.py
+++ b/enable/tests/test_assistant_test_case.py
@@ -1,4 +1,7 @@
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import nose
 
 from traitsui.tests._tools import skip_if_null

--- a/enable/tests/tools/apptools/commands_test_case.py
+++ b/enable/tests/tools/apptools/commands_test_case.py
@@ -11,7 +11,10 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 
 # Third party library imports
-from mock import MagicMock
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 # Enthought library imports
 from traits.testing.unittest_tools import UnittestTools, unittest

--- a/enable/tests/tools/apptools/move_command_tool_test_case.py
+++ b/enable/tests/tools/apptools/move_command_tool_test_case.py
@@ -11,7 +11,10 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 
 # Third party library imports
-from mock import MagicMock
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 # Enthought library imports
 from apptools.undo.api import CommandStack

--- a/enable/tests/tools/apptools/resize_command_tool_test_case.py
+++ b/enable/tests/tools/apptools/resize_command_tool_test_case.py
@@ -11,7 +11,10 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 
 # Third party library imports
-from mock import MagicMock
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 # Enthought library imports
 from apptools.undo.api import CommandStack

--- a/enable/tests/tools/apptools/undo_tool_test_case.py
+++ b/enable/tests/tools/apptools/undo_tool_test_case.py
@@ -11,7 +11,10 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 
 # Third party library imports
-from mock import MagicMock
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 # Enthought library imports
 from apptools.undo.api import UndoManager

--- a/enable/tests/wx/mouse_wheel_test_case.py
+++ b/enable/tests/wx/mouse_wheel_test_case.py
@@ -1,7 +1,10 @@
 
 from unittest import TestCase
 
-from mock import MagicMock
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 from traits.api import Any
 from traitsui.tests._tools import skip_if_not_wx

--- a/kiva/testing.py
+++ b/kiva/testing.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2008-2013 by Enthought, Inc.
 # All rights reserved.
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from kiva.image import GraphicsContext
 


### PR DESCRIPTION
Remove the need for the 3rd party `mock` when using Python 3 by switching to `unittest.mock`.

Closes #314 