### PR TITLE
Include licenses and other files in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,9 @@
+include CHANGES.txt
+include CONTRIBUTING.rst
+include LICENSE.txt
+include image_LICENSE.txt
+include image_LICENSE_*.txt
+include TODO.txt
 include kiva/agg/agg.i
 include docs/Makefile
 include docs/kiva/agg/notes


### PR DESCRIPTION
The license requires that the license be included in all copies of the program.  Also include some other documentation files.