### PR TITLE
Remove `sudo: false` from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: generic
-sudo: false
 
 addons:
   apt:


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration