### PR TITLE
Use correct form of signal linkage for Qt5

### DIFF
--- a/enable/savage/trait_defs/ui/qt4/svg_button_editor.py
+++ b/enable/savage/trait_defs/ui/qt4/svg_button_editor.py
@@ -82,8 +82,7 @@ class SVGButtonEditor(Editor):
             control.setCheckable(True)
             control.toggled.connect(self._toggle_button)
 
-        QtCore.QObject.connect(control, QtCore.SIGNAL('clicked()'),
-                               self.update_object)
+        control.clicked.connect(self.update_object)
 
         if self.factory.tooltip:
             control.setToolTip(self.factory.tooltip)


### PR DESCRIPTION
In testing Qt5 support the `enable` package throws and error when calling `QtCore.QObject.connect` directly.  Instead use `control.clicked.connect` to connect to the `clicked()` signal.