### PR TITLE
BUG: prevent context menus in Enable Qt widgets.

### DIFF
--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -48,6 +48,13 @@ class _QtWindowHandler(object):
         qt_window.setMouseTracking(True)
         qt_window.setSizePolicy(QtGui.QSizePolicy.Expanding,
                                 QtGui.QSizePolicy.Expanding)
+        # We prevent context menu events being generated from inside this
+        # widget. If a containing parent widget handles a context menu event,
+        # then Enable might not get the right-click events. Enable does not
+        # represent context menu events in its Event API. Users should use the
+        # ContextMenuTool or just handle the right-click explicitly in other
+        # ways.
+        qt_window.setContextMenuPolicy(QtCore.Qt.PreventContextMenu)
 
     def closeEvent(self, event):
         self._enable_window.cleanup()


### PR DESCRIPTION
As brought up in enthought/pyface/pull/356, Enable's Qt widget should be preventing the `contextMenuEvent` via its context menu policy. Otherwise, the event will bubble up to parent containers which, not knowing that its descendant might want to handle right-click events itself, will define a context menu and interfere.

Enable does not have a separate context menu event in its `Event` API, so we don't have a need to handle them explicitly on the Qt side either. You can still use the `ContextMenuTool` if you want to add a context menu to your Enable widget. It uses the right-click mouse event.