### PR TITLE
Add a maximum length to the damaged regions list to curb memory hogging

### DIFF
--- a/enable/abstract_window.py
+++ b/enable/abstract_window.py
@@ -76,6 +76,8 @@ class AbstractWindow(HasTraits):
     # The regions to update upon redraw
     _update_region = Any
 
+    # When exceeding this, the entire window is marked damaged to save memory
+    MAX_DAMAGED_REGIONS = 100
 
 
     #---------------------------------------------------------------------------
@@ -232,7 +234,8 @@ class AbstractWindow(HasTraits):
         return
 
     def invalidate_draw(self, damaged_regions=None, self_relative=False):
-        if damaged_regions is not None and self._update_region is not None:
+        if damaged_regions is not None and self._update_region is not None \
+                and len(self._update_region) < self.MAX_DAMAGED_REGIONS:
             self._update_region += damaged_regions
         else:
             self._update_region = None


### PR DESCRIPTION
Otherwise the damaged regions list of components that have been shown at some point but are no longer visible and thus do not receive paint events can grow arbitrarily long, consuming large amounts of memory. This memory would be released if the component became visible again but who knows when/if that happens.

In our application we have TraitsUI tabs that contain Chaco plots whose PlotDatas are updated regardless of the current tab, and the plots in tabs that are not currently visible can "leak" several megabytes per minute.

I'm not familiar with the innards of Chaco/Enable, and this is just a quick solution proposal, so if you don't like this idea, feel free to bake a better one.

An example program showing the problem (I'm using pyqt backend but I don't think it matters):

1. Run for a while keeping to the default tab (1). 
2. Once you click on tab 2, it starts leaking memory from tab 1,
3. Click on tab 3, it starts leaking memory from both tabs 1 and 2. 
4. After running for a while that way leaking memory, click on tab 1 or 2, and it will release the "leaked" memory taken by that tab's plot as it gets a paint event 

```
import threading, time, random
import numpy as np

from traits.api import HasTraits, Instance, Str
from traitsui.api import View, Tabbed, Item, UItem
from pyface.api import GUI
from chaco.api import ArrayPlotData, Plot
from enable.api import ComponentEditor

n_data = 100
y1 = np.random.rand(n_data)
y2 = np.random.rand(n_data)

class LeakyPlot(HasTraits):
    plot1 = Instance(Plot)
    plot_data1 = Instance(ArrayPlotData)

    plot2 = Instance(Plot)
    plot_data2 = Instance(ArrayPlotData)

    tab3 = Str

    traits_view = View(
        Tabbed (
            UItem('plot1', editor=ComponentEditor()),
            UItem('plot2', editor=ComponentEditor()),
            Item("tab3"),
        )
    )

    def __init__(self):
        super(LeakyPlot, self).__init__()

        self.plot_data1 = ArrayPlotData(y=y1)
        self.plot_data2 = ArrayPlotData(y=y2)

        self.plot1 = Plot(self.plot_data1)
        self.plot1.plot("y", type = "line", name="plot", color = "blue")
        self.plot1.range2d.low_setting = ('auto', 0.0)
        self.plot1.range2d.high_setting = ('auto', 1.0)

        self.plot2 = Plot(self.plot_data2)
        self.plot2.plot("y", type = "line", name="plot", color = "red")
        self.plot2.range2d = self.plot1.range2d

    def update_plot(self):
        with lock:
            self.plot_data1.update_data(y=y1)
            self.plot_data2.update_data(y=y2)


def update_data(plot):
    while not quit:
        time.sleep(0.001)
        with lock:
            for i in range(0, len(y1)):
                y1[i] = random.random()
            for i in range(0, len(y2)):
                y2[i] = random.random()
        GUI.invoke_later(plot.update_plot)

quit = False
lock = threading.Lock()

leaky_plot = LeakyPlot()
data_thread = threading.Thread(target=update_data, name="data updater", args=(leaky_plot,))
data_thread.start()

leaky_plot.configure_traits()

quit = True
data_thread.join()
```