### PR TITLE
Fix raising of NotImplemented (which is not an exception)

### DIFF
--- a/enable/savage/svg/backends/kiva/renderer.py
+++ b/enable/savage/svg/backends/kiva/renderer.py
@@ -383,7 +383,7 @@ class Renderer(NullRenderer):
 
     @classmethod
     def makeMatrix(cls, *args):
-        raise NotImplemented()
+        raise NotImplementedErrorError()
 
     @classmethod
     def makePath(cls):

--- a/enable/savage/svg/backends/kiva/renderer.py
+++ b/enable/savage/svg/backends/kiva/renderer.py
@@ -383,7 +383,7 @@ class Renderer(NullRenderer):
 
     @classmethod
     def makeMatrix(cls, *args):
-        raise NotImplementedErrorError()
+        raise NotImplementedError()
 
     @classmethod
     def makePath(cls):

--- a/enable/savage/svg/backends/null/null_renderer.py
+++ b/enable/savage/svg/backends/null/null_renderer.py
@@ -42,122 +42,122 @@ class NullRenderer(object):
 
     @classmethod
     def concatTransform(cls, gc, matrix):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def createAffineMatrix(cls, a,b,c,d,x,y):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def createBrush(cls, color_tuple):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def createNativePen(cls, pen):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def createPen(cls, color_tuple):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def createLinearGradientBrush(cls, x1,y1,x2,y2, stops, spreadMethod='pad',
                                   transforms=None, units='userSpaceOnUse'):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def createRadialGradientBrush(cls, cx,cy, r, stops, fx=None,fy=None,
                                   spreadMethod='pad', transforms=None,
                                   units='userSpaceOnUse'):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def getFont(cls, font_name='Arial'):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def makeMatrix(cls, *args):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def makePath(cls):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def popState(cls, gc):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def pushState(cls, gc):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def setFontSize(cls, font, size):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def setFontStyle(cls, font, style):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def setFontWeight(cls, font, weight):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def setFont(cls, gc, font, brush):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def setBrush(cls, gc, brush):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def setPenDash(cls, pen, dasharray, offset):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def setPen(cls, gc, pen):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def strokePath(cls, gc, path):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def fillPath(cls, gc, path, mode):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def gradientPath(cls, gc, path, brush):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def clipPath(cls, gc, path):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def translate(cls, gc, *args):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def rotate(cls, gc, angle):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def scale(cls, gc, sx, sy):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def GetTextExtent(cls, gc, text):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def DrawText(cls, gc, text, x, y, brush, anchor='start'):
         """ Draw text at the given x,y position with the color of the
             given brush.
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def DrawImage(cls, gc, image, x, y, width, height):
-        raise NotImplemented()
+        raise NotImplementedError()


### PR DESCRIPTION
Fix code that tries to do either `raise NotImplemented` or `raise NotImplemented()`. Since `NotImplemented` isn't an exception type, and isn't callable, both variants actually raise `TypeError`.