### PR TITLE
Fix horizontal orientation support in SVGButton's Qt backend

### DIFF
--- a/enable/savage/trait_defs/ui/qt4/svg_button_editor.py
+++ b/enable/savage/trait_defs/ui/qt4/svg_button_editor.py
@@ -75,7 +75,10 @@ class SVGButtonEditor(Editor):
         control.setIconSize(QtCore.QSize(self.factory.width, self.factory.height))
 
         if self.factory.label:
-            control.setToolButtonStyle(QtCore.Qt.ToolButtonTextUnderIcon)
+            if self.factory.orientation == 'horizontal':
+                control.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
+            else:
+                control.setToolButtonStyle(QtCore.Qt.ToolButtonTextUnderIcon)
         else:
             control.setToolButtonStyle(QtCore.Qt.ToolButtonIconOnly)
         if self.factory.toggle:


### PR DESCRIPTION
The SVGButton has an orientation parameter but the visual layout in Qt backend doesn't take this into account but always uses a vertical layout.