### PR TITLE
Fix support for Qt5 QWheelEvents whose pixelDelta is zero

### DIFF
--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -430,6 +430,8 @@ class _Window(AbstractWindow):
                     mouse_wheel_delta = (0, delta)
             else:
                 delta = event.pixelDelta()
+                if delta.x() == 0 and delta.y() == 0:  # pixelDelta is optional
+                    delta = event.angleDelta()
                 mouse_wheel_delta = (delta.x(), delta.y())
                 if abs(mouse_wheel_delta[0]) > abs(mouse_wheel_delta[1]):
                     mouse_wheel = mouse_wheel_delta[0] / float(8 * degrees_per_step)

--- a/enable/tests/qt4/mouse_wheel_test_case.py
+++ b/enable/tests/qt4/mouse_wheel_test_case.py
@@ -55,7 +55,7 @@ class MouseWheelTestCase(TestCase):
             qt_event = QtGui.QWheelEvent(
                 QtCore.QPointF(0, 0),
                 self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
-                QtCore.QPoint(0, 200), QtCore.QPoint(0, 200.0/120), 200,
+                QtCore.QPoint(0, 200), QtCore.QPoint(0, 200), 200,
                 QtCore.Qt.Vertical, QtCore.Qt.NoButton, QtCore.Qt.NoModifier,
                 QtCore.Qt.ScrollUpdate
             )
@@ -83,7 +83,7 @@ class MouseWheelTestCase(TestCase):
             qt_event = QtGui.QWheelEvent(
                 QtCore.QPoint(0, 0),
                 self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
-                QtCore.QPoint(200, 0), QtCore.QPoint(200.0/120, 0), 200,
+                QtCore.QPoint(200, 0), QtCore.QPoint(200, 0), 200,
                 QtCore.Qt.Vertical, QtCore.Qt.NoButton, QtCore.Qt.NoModifier,
                 QtCore.Qt.ScrollUpdate
             )
@@ -95,3 +95,26 @@ class MouseWheelTestCase(TestCase):
         self.assertEqual(self.tool.event.mouse_wheel_axis, 'horizontal')
         self.assertAlmostEqual(self.tool.event.mouse_wheel, 5.0/3.0)
         self.assertEqual(self.tool.event.mouse_wheel_delta, (200, 0))
+
+    def test_vertical_mouse_wheel_without_pixel_delta(self):
+        from pyface.qt import QtCore, QtGui
+        is_qt4 = (QtCore.__version_info__[0] <= 4)
+        if is_qt4:
+            self.skipTest("Not directly applicable in Qt4")
+
+        # create and mock a mouse wheel event
+        qt_event = QtGui.QWheelEvent(
+            QtCore.QPointF(0, 0),
+            self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
+            QtCore.QPoint(0, 0), QtCore.QPoint(0, 200), 200,
+            QtCore.Qt.Vertical, QtCore.Qt.NoButton, QtCore.Qt.NoModifier,
+            QtCore.Qt.ScrollUpdate
+        )
+
+        # dispatch event
+        self.window._on_mouse_wheel(qt_event)
+
+        # validate results
+        self.assertEqual(self.tool.event.mouse_wheel_axis, 'vertical')
+        self.assertEqual(self.tool.event.mouse_wheel, 5.0/3.0)
+        self.assertEqual(self.tool.event.mouse_wheel_delta, (0, 200))


### PR DESCRIPTION
* pixelDelta is not provided on all platforms (see https://doc.qt.io/qt-5/qwheelevent.html#pixelDelta), so one needs to use angleDelta or scroll events won't work. For example, on Windows or X11. Perhaps pixelDelta is just reliably available on MacOS? There are probably several ways to do this, I think the one proposed here is one of the simplest. The scaling (or lack of it) between angle and pixel deltas hasn't been thought out, but I followed the existing code in this (see also the related qt4 if branch in basewindow).
* also fix the pixelDelta argument in QWheelEvent constructor calls in the related unit test: it's an integer QPoint, not a float
* add a unit test for a wheel event without pixelDelta