### PR TITLE
Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
 
 env:
   global:
-    - INSTALL_EDM_VERSION=1.5.2
+    - INSTALL_EDM_VERSION=1.11.0
       PYTHONUNBUFFERED="1"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
   - env: RUNTIME=2.7 TOOLKIT=null PILLOW='pillow<3.0.0'
   - env: RUNTIME=3.5 TOOLKIT=null PILLOW='pillow<3.0.0'
   - env: RUNTIME=3.6 TOOLKIT=null PILLOW='pillow<3.0.0'
-  allow_failures:
-  - env: RUNTIME=2.7 TOOLKIT=wx PILLOW='pillow'
   fast_finish: true
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,9 @@ env:
 
 matrix:
   include:
-  - env: RUNTIME=2.7 TOOLKIT=wx PILLOW='pillow'
-  - env: RUNTIME=2.7 TOOLKIT=pyqt PILLOW='pillow'
-  - env: RUNTIME=3.5 TOOLKIT=pyqt PILLOW='pillow'
-  - env: RUNTIME=3.5 TOOLKIT=pyqt5 PILLOW='pillow'
-  - env: RUNTIME=3.6 TOOLKIT=pyqt PILLOW='pillow'
-  - env: RUNTIME=3.6 TOOLKIT=pyqt5 PILLOW='pillow'
-  - env: RUNTIME=2.7 TOOLKIT=null PILLOW='pillow'
-  - env: RUNTIME=3.5 TOOLKIT=null PILLOW='pillow'
-  - env: RUNTIME=3.6 TOOLKIT=null PILLOW='pillow'
+  - env: RUNTIME=2.7 TOOLKITS="null wx pyqt" PILLOW='pillow'
+  - env: RUNTIME=3.5 TOOLKITS="null pyqt pyqt5" PILLOW='pillow'
+  - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5" PILLOW='pillow'
   - env: RUNTIME=2.7 TOOLKIT=null PILLOW='pillow<3.0.0'
   - env: RUNTIME=3.5 TOOLKIT=null PILLOW='pillow<3.0.0'
   - env: RUNTIME=3.6 TOOLKIT=null PILLOW='pillow<3.0.0'
@@ -55,9 +49,9 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 install:
-  - edm run -- python ci/edmtool.py install --runtime=${RUNTIME} --toolkit=${TOOLKIT} --pillow=${PILLOW}
+  - for toolkit in ${TOOLKITS}; do edm run -- python ci/edmtool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --pillow=${PILLOW} || exit; done
 script:
-  - edm run -- python ci/edmtool.py test --runtime=${RUNTIME} --toolkit=${TOOLKIT} --pillow=${PILLOW}
+  - for toolkit in ${TOOLKITS}; do edm run -- python ci/edmtool.py test --runtime=${RUNTIME} --toolkit=${toolkit} --pillow=${PILLOW} || exit; done
 
 after_success:
   - edm run -- coverage combine


### PR DESCRIPTION
- update edm version from 1.5.2 to 1.11.0
- update the test matrix to run tests for all supported toolkits for a runtime in the same job.
- disallow failure on wx toolkit on python 2.7