### PR TITLE
Quick and Dirty Documentation Improvements

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'enable'
-copyright = '2008-2015, Enthought'
+copyright = '2008-2019, Enthought'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
@@ -77,11 +77,36 @@ pygments_style = 'sphinx'
 
 # Options for HTML output
 # -----------------------
+# Use enthought-sphinx-theme if available
+try:
+    import enthought_sphinx_theme
 
-# The style sheet to use for HTML and HTML Help pages. A file of that name
-# must exist either in Sphinx' static/ path, or in one of the custom paths
-# given in html_static_path.
-html_style = 'default.css'
+    html_theme_path = [enthought_sphinx_theme.theme_path]
+    html_theme = "enthought"
+except ImportError as exc:
+    import warnings
+
+    msg = """Can't find Enthought Sphinx Theme, using default.
+                Exception was: {}
+                Enthought Sphinx Theme can be downloaded from
+                https://github.com/enthought/enthought-sphinx-theme"""
+    warnings.warn(RuntimeWarning(msg.format(exc)))
+
+    # Use old defaults if enthought-sphinx-theme not available
+
+    # The name of an image file (within the static path) to place at the top
+    # of the sidebar.
+    html_logo = "e-logo-rev.png"
+
+    # The name of an image file (within the static path) to use as favicon of
+    # the docs.  This file should be a Windows icon file (.ico) being 16x16
+    # or 32x32 pixels large.
+    html_favicon = "et.ico"
+
+    # The style sheet to use for HTML and HTML Help pages. A file of that name
+    # must exist either in Sphinx' static/ path, or in one of the custom paths
+    # given in html_static_path.
+    html_style = "default.css"
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -89,15 +114,6 @@ html_style = 'default.css'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None
-
-# The name of an image file (within the static path) to place at the top of
-# the sidebar.
-html_logo = "_static/e-logo-rev.png"
-
-# The name of an image file (within the static path) to use as favicon of the
-# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
-# pixels large.
-html_favicon = "et.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/enable_concepts.rst
+++ b/docs/source/enable_concepts.rst
@@ -104,13 +104,13 @@ them get the event.
 
 .. note::
 
-  (The notion of an active tool is not used in current code, just older client
+  The notion of an active tool is not used in current code, just older client
   code. Experience has shown that the notion of a tool promoting itself to be
   the "active" tool isn't really useful, because usually the tools need to
   interact with each other. For newer tools, such as Pan, Zoom, or !DragZoom,
   when the user starts interacting with a tool, that tool calls capture_mouse()
   at the window level, and then all mouse events go to that tool, circumventing
-  the entire dispatch() mechanism.)
+  the entire dispatch() mechanism.
 
 The event handlers that :class:`Component` dispatches to are of the form
 :samp:`{event_state}{event_suffix}`, where *event_suffix* corresponds to the
@@ -129,9 +129,9 @@ event handler method name in its definition.
 
 .. note::
 
-  (This scheme is difficult to implement when the number of states and events
+  This scheme is difficult to implement when the number of states and events
   gets large. There's nothing to tell you if you've forgotten to implement one
-  of the possible combinations.)
+  of the possible combinations.
 
 If an interactor transforms an event, then it has to return the full
 transformation that it applies to the event.
@@ -163,14 +163,14 @@ that event to be in the coordinate system of its parent container.
 
 .. note::
 
-  (This introduces some complexity in trying to handle mouse event capture. If a
+  This introduces some complexity in trying to handle mouse event capture. If a
   tool or component captures the mouse, the top-level window has no idea what
   the coordinate system of that object is. It has to be able to ask an event,
   "give me your total transformation up to this point", and then apply that
   transformation to all subsequent events. Programmers using Chaco or Enable
   don't usually have to think about this, but the interactor does have to be
   able to do it. Containers implement this, so if you're just writing a standard
-  component, you don't have to worry about it.)
+  component, you don't have to worry about it.
 
 Viewports
 ~~~~~~~~~

--- a/docs/source/enable_concepts.rst
+++ b/docs/source/enable_concepts.rst
@@ -14,9 +14,9 @@ receives input for it (keyboard, mouse, and multitouch events).
 
 Basic traits of Component include:
 
- * :attr:`visible`: Whether it's visible
- * :attr:`invisible_layout`: Whether it uses space even when not visible (by 
-   default, invisible objects don't take up space in layout)
+* :attr:`visible`: Whether it's visible
+* :attr:`invisible_layout`: Whether it uses space even when not visible (by
+  default, invisible objects don't take up space in layout)
 
 Padding
 ~~~~~~~
@@ -25,19 +25,19 @@ Layout in Enable uses padding, similar to CSS. In Chaco, it's used for things
 around the edges of plot, like labels and tick marks that extend outside the
 main plot area.
 
- * :attr:`fill_padding`: Whether the background color fills the padding area as 
-   well as the main area of the component.
- * :attr:`padding_left`
- * :attr:`padding_right`
- * :attr:`padding_top`
- * :attr:`padding_bottom`
- * :attr:`padding`: Sets or gets all 4 padding size traits at once
- * :attr:`hpadding`: Read-only convenience property for the total amount of 
-   horizontal padding
- * :attr:`vpadding`: Read-only convenience property for the total amount of 
-   vertical padding
- * :attr:`padding_accepts_focus`: Whether the component responds to mouse events
-   over the padding area
+* :attr:`fill_padding`: Whether the background color fills the padding area as
+  well as the main area of the component.
+* :attr:`padding_left`
+* :attr:`padding_right`
+* :attr:`padding_top`
+* :attr:`padding_bottom`
+* :attr:`padding`: Sets or gets all 4 padding size traits at once
+* :attr:`hpadding`: Read-only convenience property for the total amount of
+  horizontal padding
+* :attr:`vpadding`: Read-only convenience property for the total amount of
+  vertical padding
+* :attr:`padding_accepts_focus`: Whether the component responds to mouse events
+  over the padding area
 
 Parent Classes
 ~~~~~~~~~~~~~~
@@ -53,8 +53,8 @@ something that doesn't draw but does respond to events, subclass
 
 :class:`Interactor` defines common traits for screen interaction, including:
 
- * :attr:`pointer`: The cursor shape when the interactor is active
- * :attr:`event_state`: The object's event state, used for event dispatch
+* :attr:`pointer`: The cursor shape when the interactor is active
+* :attr:`event_state`: The object's event state, used for event dispatch
 
 Containers
 ~~~~~~~~~~
@@ -81,7 +81,7 @@ creating a context menu.
 Event Dispatch
 ~~~~~~~~~~~~~~
 
-The key methods of :class:`Interactor` are :meth:`dispatch` and 
+The key methods of :class:`Interactor` are :meth:`dispatch` and
 :meth:`\_dispatch_stateful_event`. There's a complex method resolution that
 occurs beween :class:`Interactor`, :class:`Component`, :class:`Container`
 (which is a subclass of :class:`Component`), and the Chaco-based subclasses of
@@ -90,17 +90,19 @@ Enable :class:`Component` and :class:`Container`.
 When a component gets an event, it tries to handle it in a standard way, which
 is to dispatch to:
 
- 1. its active tool
- 2. its overlays 
- 3. itself, so that any event handler methods on itself get called
- 4. its underlays
- 5. its listener tools
+1. its active tool
+2. its overlays
+3. itself, so that any event handler methods on itself get called
+4. its underlays
+5. its listener tools
 
 That logic is in :class:`Component`, in the :meth:`\_new_dispatch` method, which
 is called from :meth:`Component.dispatch` (:meth:`\_old_dispatch` will be
 removed in 3.0). If any of these handlers sets event.handled to True, event
 propagation stops. If an event gets as far as the listener tools, then all of
 them get the event.
+
+.. note::
 
   (The notion of an active tool is not used in current code, just older client
   code. Experience has shown that the notion of a tool promoting itself to be
@@ -124,6 +126,8 @@ include :class:`MouseEvent`, :class:`DragEvent`, :class:`KeyEvent`, and
 system with new kinds of events and new suffixes (as was done for multitouch). A
 disadvantage is that you don't necessarily get feedback when you misspell an
 event handler method name in its definition.
+
+.. note::
 
   (This scheme is difficult to implement when the number of states and events
   gets large. There's nothing to tell you if you've forgotten to implement one
@@ -157,6 +161,8 @@ system, and the container is responsible for offsetting the GC, and setting up
 the transform correctly. Likewise, when a component gets an event, it expects
 that event to be in the coordinate system of its parent container.
 
+.. note::
+
   (This introduces some complexity in trying to handle mouse event capture. If a
   tool or component captures the mouse, the top-level window has no idea what
   the coordinate system of that object is. It has to be able to ask an event,
@@ -178,11 +184,11 @@ plot without duplicating it.
 
 Layout
 ~~~~~~
-Containers are the sizers that do layout. Components within containers can 
+Containers are the sizers that do layout. Components within containers can
 declare that they are resizable, for example, but that doesn't matter if
 the container they are in doesn't do layout.
 
-The basic traits on :class:`Component` for layout are :attr:`resizable`, 
+The basic traits on :class:`Component` for layout are :attr:`resizable`,
 :attr:`aspect_ratio`, :attr:`auto_center`. For the :attr:`resizable` trait,
 you can specify which directions the component is resizable in. Components
 also have lists of overlays and underlays.
@@ -196,13 +202,13 @@ Rendering
 
 Every component can have several layers:
 
- * background
- * image (Chaco only, not Enable)
- * underlay
- * main layer (the actual component)
- * overlay
+* background
+* image (Chaco only, not Enable)
+* underlay
+* main layer (the actual component)
+* overlay
 
-These are defined by DEFAULT_DRAWING_ORDER, and stored in the 
+These are defined by DEFAULT_DRAWING_ORDER, and stored in the
 :attr:`drawing_order` trait.
 
 Complexity arises when you have multiple components in a container: How do
@@ -210,13 +216,13 @@ their layers affect each other? Do you want the "overlay" layer of a component
 to draw on top of all components? Do you want the "background" elements
 to be behind everything else?
 
-This is resolved by the :attr:`unified_draw` trait. If it is False (the 
+This is resolved by the :attr:`unified_draw` trait. If it is False (the
 default), the corresponding layers of all components are drawn in sequence. The
 container is responsible for calling the components to draw their layers in
 the correct sequence. If it is True, then all layers of the component are drawn
 in strict sequence. The point is the overall sequence at which a component
 with ``unified_draw==True`` is drawn is determined by its :attr:`draw_layer`
-trait, which by default is 'mainlayer'. 
+trait, which by default is 'mainlayer'.
 
 For example, if you want a plot to act as an overlay, you could set
 ``unified_draw==True`` and ``draw_layer=='overlay'``. These values tell the
@@ -227,8 +233,8 @@ the overlay; otherwise it draws as part of the background. By default,
 the border is drawn just inside the plot area; set :attr:`inset_border` to
 False to draw it just outside the plot area.
 
-Backbuffer 
-^^^^^^^^^^ 
+Backbuffer
+^^^^^^^^^^
 
 A backbuffer provides the ability to render into an offscreen buffer, which is
 blitted on every draw, until it is invalidated. Various traits such as
@@ -241,7 +247,7 @@ Users typically subclass Chaco :class:`PlotComponent`, but may need features
 from Enable :class:`Component`.
 
 
-Enable Container 
+Enable Container
 ----------------
 
 :class:`Container` is a subclass of Enable :class:`Component`. Containers can be

--- a/docs/source/enable_constraints_layout.rst
+++ b/docs/source/enable_constraints_layout.rst
@@ -14,26 +14,26 @@ Cassowary_ constraint solver to determine the layout of its child
 :class:`Component` instances. This is achieved by adding constraint variables
 to the :class:`Component` class which define a simple box model:
 
- * :attr:`layout_height`: The height of the component.
- * :attr:`layout_width`: The width of the component.
- * :attr:`left`: The left edge of the component.
- * :attr:`right`: The right edge of the component.
- * :attr:`top`: The top edge of the component.
- * :attr:`bottom`: The bottom edge of the component.
- * :attr:`h_center`: The vertical center line between the left and right edges
- * :attr:`v_center`: The  horizontal center line between the top and bottom edges
+* :attr:`layout_height`: The height of the component.
+* :attr:`layout_width`: The width of the component.
+* :attr:`left`: The left edge of the component.
+* :attr:`right`: The right edge of the component.
+* :attr:`top`: The top edge of the component.
+* :attr:`bottom`: The bottom edge of the component.
+* :attr:`h_center`: The vertical center line between the left and right edges
+* :attr:`v_center`: The  horizontal center line between the top and bottom edges
 
 Additionally, there are some constraints which only exist on
 :class:`ConstraintsContainer`:
 
- * :attr:`contents_height`: The height of the container.
- * :attr:`contents_width`: The width of the container.
- * :attr:`contents_left`: The left edge of the container.
- * :attr:`contents_right`: The right edge of the container.
- * :attr:`contents_top`: The top edge of the container.
- * :attr:`contents_bottom`: The bottom edge of the container.
- * :attr:`contents_h_center`: The vertical center line of the container.
- * :attr:`contents_v_center`: The  horizontal center line of the container.
+* :attr:`contents_height`: The height of the container.
+* :attr:`contents_width`: The width of the container.
+* :attr:`contents_left`: The left edge of the container.
+* :attr:`contents_right`: The right edge of the container.
+* :attr:`contents_top`: The top edge of the container.
+* :attr:`contents_bottom`: The bottom edge of the container.
+* :attr:`contents_h_center`: The vertical center line of the container.
+* :attr:`contents_v_center`: The  horizontal center line of the container.
 
 These variables can be used in linear inequality expressions which make up the
 layout constraints of a container:
@@ -171,10 +171,10 @@ controls the minimum size of a component when it's part of a contraints layout.
 Additionally, :class:`Component` defines some strength traits that can be used
 to fine tune the behavior of a component instance during layout. They are:
 
- * :attr:`hug_height`: How strongly a component prefers the height of its size hint when it could grow.
- * :attr:`hug_width`: How strongly a component prefers the width of its size hint when it could grow.
- * :attr:`resist_height`: How strongly a component resists its height being made smaller than its size hint.
- * :attr:`resist_width`: How strongly a component resists its width being made smaller than its size hint.
+* :attr:`hug_height`: How strongly a component prefers the height of its size hint when it could grow.
+* :attr:`hug_width`: How strongly a component prefers the width of its size hint when it could grow.
+* :attr:`resist_height`: How strongly a component resists its height being made smaller than its size hint.
+* :attr:`resist_width`: How strongly a component resists its width being made smaller than its size hint.
 
 The allow values for these strengths are: `'required'`, `'strong'`, `'medium'`,
 and `'weak'`.

--- a/docs/source/kiva.rst
+++ b/docs/source/kiva.rst
@@ -455,6 +455,7 @@ text_draw_mode:
     TEXT_FILL, TEXT_INVISIBLE (currently unused)
 pix_format:
     (NOTE: the strings in the dicts omit the ``pix_format_`` prefix)
+
     dicts:
         pix_format_string_map, pix_format_enum_map
     values:
@@ -469,6 +470,7 @@ interpolation:
         sinc256, blackman64, blackman100, blackman256
 marker:
     (NOTE: the strings in the dicts omit the ``marker_`` prefix)
+
     dicts:
         marker_string_map, marker_enum_map
     values:

--- a/docs/source/kiva.rst
+++ b/docs/source/kiva.rst
@@ -373,14 +373,19 @@ Primitive types
 ~~~~~~~~~~~~~~~
 The following conventions are used to describe input and output types:
 
-:color:
+color:
     Either a 3-tuple or 4-tuple. The represented color depends on the
     graphics context's pixel format.
-:rect: (origin_x, origin_y, width, height)
-:bool: an int that is 1 or 0
-:point_array: an array/sequence of length-2 arrays, e.g. ((x,y), (x2,y2),...)
-:rect_array: an array/sequence of rects ((x,y,w,h), (x2,y2,w2,h2), ...)
-:color_stop_array: an array/sequence of color stops ((offset,r,g,b,a),
+rect:
+    (origin_x, origin_y, width, height)
+bool:
+    an int that is 1 or 0
+point_array:
+    an array/sequence of length-2 arrays, e.g. ((x,y), (x2,y2),...)
+rect_array:
+    an array/sequence of rects ((x,y,w,h), (x2,y2,w2,h2), ...)
+color_stop_array:
+    an array/sequence of color stops ((offset,r,g,b,a),
     (offset2,r2,g2,b2,a2), ...) where offset is some number between 0 and 1
     inclusive and the entries are sorted from lowest offset to highest.
 
@@ -389,17 +394,25 @@ AffineMatrix
 All of the following member functions modify the instance on which they
 are called:
 
-:__init__(v0, v1, v2, v3, v4, v5): also __init__()
-:reset(): Sets this matrix to the identity
-:multiply(`AffineMatrix`): multiples this matrix by another
-:invert(): sets this matrix to the inverse of itself
-:flip_x(): mirrors around X
-:flip_y(): mirrors around Y
+__init__(v0, v1, v2, v3, v4, v5):
+    also __init__()
+reset():
+    Sets this matrix to the identity
+multiply(`AffineMatrix`):
+    multiples this matrix by another
+invert():
+    sets this matrix to the inverse of itself
+flip_x():
+    mirrors around X
+flip_y():
+    mirrors around Y
 
 The rest of the member functions return information about the matrix.
 
-:scale() -> float: returns the average scale of this matrix
-:determinant() -> float: returns the determinant
+scale() -> float:
+    returns the average scale of this matrix
+determinant() -> float:
+    returns the determinant
 
 The following factory methods are available in the top-level "agg" namespace
 to create specific kinds of :class:`AffineMatrix` instances:
@@ -414,8 +427,10 @@ to create specific kinds of :class:`AffineMatrix` instances:
 
 FontType
 ~~~~~~~~
-:__init__(name, size=12, family=0, style=0): constructs a :class:`FontType` instance
-:is_loaded() -> bool: returns True if a font was actually loaded
+__init__(name, size=12, family=0, style=0):
+    constructs a :class:`FontType` instance
+is_loaded() -> bool:
+    returns True if a font was actually loaded
 
 CompiledPath
 ~~~~~~~~~~~~
@@ -427,44 +442,52 @@ The following enumerations are represented by top-level constants in the "agg"
 namespace.  They are fundamentally integers.  Some of them also have dicts that
 map between their names and integer values
 
-:line_cap: CAP_BUTT, CAP_ROUND, CAP_SQUARE
-:line_join: JOIN_ROUND, JOIN_BEVEL, JOIN_MITER
+line_cap:
+    CAP_BUTT, CAP_ROUND, CAP_SQUARE
+line_join:
+    JOIN_ROUND, JOIN_BEVEL, JOIN_MITER
+draw_mode:
+    FILL, EOF_FILL, STROKE, FILL_STROKE, EOF_FILL_STROKE
 
-:draw_mode: FILL, EOF_FILL, STROKE, FILL_STROKE, EOF_FILL_STROKE
-
-:text_style: NORMAL, BOLD, ITALIC
-:text_draw_mode: TEXT_FILL, TEXT_INVISIBLE (currently unused)
-
-:pix_format: (NOTE: the strings in the dicts omit the ``pix_format_`` prefix)
-
-- dicts: pix_format_string_map, pix_format_enum_map
-- values: pix_format_gray8, pix_format_rgb555, pix_format_rgb565,
-    pix_format_rgb24, pix_format_bgr24, pix_format_rgba32, pix_format_argb32,
-    pix_format_abgr32, pix_format_bgra32
-
-:interpolation:
-
-- dicts: interp_enum_map, interp_string_map
-- values: nearest, bilinear, bicubic, spline16, spline36, sinc64, sinc144,
-    sinc256, blackman64, blackman100, blackman256
-
-:marker: (NOTE: the strings in the dicts omit the ``marker_`` prefix)
-
-- dicts: marker_string_map, marker_enum_map
-- values: marker_circle, marker_cross, marker_crossed_circle, marker_dash,
-    marker_diamond, marker_dot, marker_four_rays, marker_pixel,
-    marker_semiellipse_down, marker_semiellipse_left, marker_x,
-    marker_semiellipse_right, marker_semiellipse_up, marker_square,
-    marker_triangle_down, marker_triangle_left, marker_triangle_right,
-    marker_triangle_up
+text_style:
+    NORMAL, BOLD, ITALIC
+text_draw_mode:
+    TEXT_FILL, TEXT_INVISIBLE (currently unused)
+pix_format:
+    (NOTE: the strings in the dicts omit the ``pix_format_`` prefix)
+    dicts:
+        pix_format_string_map, pix_format_enum_map
+    values:
+        pix_format_gray8, pix_format_rgb555, pix_format_rgb565,
+        pix_format_rgb24, pix_format_bgr24, pix_format_rgba32, pix_format_argb32,
+        pix_format_abgr32, pix_format_bgra32
+interpolation:
+    dicts:
+        interp_enum_map, interp_string_map
+    values:
+        nearest, bilinear, bicubic, spline16, spline36, sinc64, sinc144,
+        sinc256, blackman64, blackman100, blackman256
+marker:
+    (NOTE: the strings in the dicts omit the ``marker_`` prefix)
+    dicts:
+        marker_string_map, marker_enum_map
+    values:
+        marker_circle, marker_cross, marker_crossed_circle, marker_dash,
+        marker_diamond, marker_dot, marker_four_rays, marker_pixel,
+        marker_semiellipse_down, marker_semiellipse_left, marker_x,
+        marker_semiellipse_right, marker_semiellipse_up, marker_square,
+        marker_triangle_down, marker_triangle_left, marker_triangle_right,
+        marker_triangle_up
 
 path_cmd and path_flags are low-level Agg path attributes.  See the Agg
 documentation for more information about them.  We just pass them through in Kiva.
 
-:path_cmd: path_cmd_curve3, path_cmd_curve4, path_cmd_end_poly,
+path_cmd:
+    path_cmd_curve3, path_cmd_curve4, path_cmd_end_poly,
     path_cmd_line_to, path_cmd_mask, path_cmd_move_to, path_cmd_stop
 
-:path_flags: path_flags, path_flags_ccw, path_flags_close, path_flags_cw,
+path_flags:
+    path_flags, path_flags_ccw, path_flags_close, path_flags_cw,
     path_flags_mask, path_flags_none
 
 
@@ -473,8 +496,8 @@ Graphics Context
 
 Construction
 ~~~~~~~~~~~~
-:__init__(size, pix_format): Size is a tuple (width, height), pix_format
-    is a string.
+__init__(size, pix_format):
+    Size is a tuple (width, height), pix_format is a string.
 
 State functions
 ~~~~~~~~~~~~~~~
@@ -485,15 +508,18 @@ State functions
 :set_line_width(float):
 :set_line_join(line_join):
 :set_line_cap(line_cap):
-:set_line_dash(array): array is an even-length tuple of floats that represents
+:set_line_dash(array):
+    array is an even-length tuple of floats that represents
     the width of each dash and gap in the dash pattern.
 :set_fill_color(color):
 :get_fill_color() -> color:
-:linear_gradient(x1, y1, x2, y2, color_stop_array, spread_method, units): spread_method
+:linear_gradient(x1, y1, x2, y2, color_stop_array, spread_method, units):
+    spread_method
     is one of the following strings: pad, reflect, repeat. units is one of the
     following strings: userSpaceOnUse, objectBoundingBox. This method modifies
     the current fill pattern.
-:radial_gradient(cx, cy, r, fx, fy, color_stop_array, spread_method, units): same
+:radial_gradient(cx, cy, r, fx, fy, color_stop_array, spread_method, units):
+    same
     arguments as linear gradient. The direction of the gradient is from the focus
     point to the center point.
 :set_alpha(float):
@@ -518,7 +544,8 @@ Clipping functions
 :clip_to_rect(rect):
 :clip_to_rects(rect_array):
 :clip(): clips using the current path
-:even_odd_clip(): modifies the current clipping path using the even-odd rule to
+:even_odd_clip():
+    modifies the current clipping path using the even-odd rule to
     calculate the intersection of the current path and the current clipping path.
 
 Path functions
@@ -532,10 +559,12 @@ Path functions
 :lines(point_array):
 :rect(x, y, w, h):
 :rects(rect_array):
-:curve_to(x1, y1, x2, y2, end_x, end_y): draws a cubic bezier curve with
+:curve_to(x1, y1, x2, y2, end_x, end_y):
+    draws a cubic bezier curve with
     control points (x1,y1) and (x2,y2) that ends at point (end_x, end_y)
 
-:quad_curve_to(cp_x, cp_y, end_x, end_y): draws a quadratic bezier curve from
+:quad_curve_to(cp_x, cp_y, end_x, end_y):
+    draws a quadratic bezier curve from
     the current point using control point (cp_x, cp_y) and ending at
     (end_x, end_y)
 


### PR DESCRIPTION
Turn on Enthought style if available; some clean-up to look better.

Aim is to be included before next release so style can be consistent with other projects.