### PR TITLE
CI failures on wx + python 2.7 + win are expected

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,18 @@ environment:
 
   matrix:
     - RUNTIME: '2.7'
-      TOOLKITS: "null pyqt wx"
+      TOOLKITS: "null pyqt"
+    - RUNTIME: '2.7'
+      TOOLKITS: "wx"
     - RUNTIME: '3.5'
       TOOLKITS: "null pyqt pyqt5"
     - RUNTIME: '3.6'
       TOOLKITS: "null pyqt pyqt5"
+
+matrix:
+  allow_failures:
+    - RUNTIME: '2.7'
+      TOOLKITS: "wx"
 
 branches:
   only:


### PR DESCRIPTION
I missed this in #347 
The errors are ignored by travis and now by appveyor as well.