### PR TITLE
Travis config: remove mesa-common-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ addons:
     - libfreetype6-dev
     - libcairo2-dev
     - libglu1-mesa-dev
-    - mesa-common-dev
 
 env:
   global:


### PR DESCRIPTION
Followup to #353: from experimentation on other repositories, it looks as though the `mesa-common-dev` package isn't needed.