### PR TITLE
Use the correct env name `TOOLKITS`in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ matrix:
   - env: RUNTIME=2.7 TOOLKITS="wx" PILLOW='pillow'
   - env: RUNTIME=3.5 TOOLKITS="null pyqt pyqt5" PILLOW='pillow'
   - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5" PILLOW='pillow'
-  - env: RUNTIME=2.7 TOOLKIT=null PILLOW='pillow<3.0.0'
-  - env: RUNTIME=3.5 TOOLKIT=null PILLOW='pillow<3.0.0'
-  - env: RUNTIME=3.6 TOOLKIT=null PILLOW='pillow<3.0.0'
+  - env: RUNTIME=2.7 TOOLKITS=null PILLOW='pillow<3.0.0'
+  - env: RUNTIME=3.5 TOOLKITS=null PILLOW='pillow<3.0.0'
+  - env: RUNTIME=3.6 TOOLKITS=null PILLOW='pillow<3.0.0'
   allow_failures:
   - env: RUNTIME=2.7 TOOLKITS="wx" PILLOW='pillow'
   fast_finish: true


### PR DESCRIPTION
In PR #348 I broke the travis config for three jobs, which didnt use the updated `TOOLKITS` env var and were instead using the old `TOOLKIT` env var, which doesnt get picked up by the CI jobs.