### PR TITLE
Nose captures logs!

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -182,8 +182,8 @@ def test(runtime, toolkit, pillow, environment):
     environ = environment_vars.get(toolkit, {}).copy()
     environ['PYTHONUNBUFFERED'] = "1"
     commands = [
-        "edm run -e {environment} -- coverage run -m nose.core enable -v",
-        "edm run -e {environment} -- coverage run -a -m nose.core kiva -v",
+        "edm run -e {environment} -- coverage run -m nose.core enable -v --nologcapture",
+        "edm run -e {environment} -- coverage run -a -m nose.core kiva -v --nologcapture",
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong traitsui


### PR DESCRIPTION
Nose was capturing logs when running the test suite, which is why we werent seeing the kiva font manager related logs/tracebacks on the enable test runs but we were seeing them in other package test runs!

(I checked the following packages and they make sure that nose doesnt capture logs - traits, traitsui, pyface. chaco doesn't use nose anymore.)