### PR TITLE
Defer imports from font_manager in font module

### DIFF
--- a/kiva/fonttools/font.py
+++ b/kiva/fonttools/font.py
@@ -10,7 +10,6 @@ import six
 import copy
 from kiva.constants import (DEFAULT, DECORATIVE, ROMAN, SCRIPT, SWISS, MODERN,
                             TELETYPE, NORMAL, ITALIC, BOLD, BOLD_ITALIC)
-from .font_manager import FontProperties, fontManager
 
 # Various maps used by str_to_font
 font_families = {
@@ -104,6 +103,8 @@ class Font(object):
         """ Returns the file name containing the font that most closely matches
         our font properties.
         """
+        from .font_manager import fontManager
+
         fp = self._make_font_props()
         return str(fontManager.findfont(fp))
 
@@ -118,6 +119,8 @@ class Font(object):
         """ Returns a font_manager.FontProperties object that encapsulates our
         font properties
         """
+        from .font_manager import FontProperties
+
         # XXX: change the weight to a numerical value
         if self.style == BOLD or self.style == BOLD_ITALIC:
             weight = "bold"


### PR DESCRIPTION
Deferring these imports means that a number of places where we need to import from `font` don't trigger the import time side-effect in the `font_manager` module.

This PR doesn't attempt to actually fix either of the issues #362 or #363 .