### PR TITLE
Pass file object into TTCollection and close when done

### DIFF
--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -721,7 +721,8 @@ def createFontList(fontfiles, fontext='ttf'):
             _, ext = os.path.splitext(fpath)
             try:
                 if ext.lower() == ".ttc":
-                    with TTCollection(six.text_type(fpath)) as collection:
+                    with open(fpath, "rb") as f:
+                        collection = TTCollection(f)
                         try:
                             props = []
                             for font in collection.fonts:

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -721,19 +721,19 @@ def createFontList(fontfiles, fontext='ttf'):
             _, ext = os.path.splitext(fpath)
             try:
                 if ext.lower() == ".ttc":
-                    collection = TTCollection(six.text_type(fpath))
-                    try:
-                        props = []
-                        for font in collection.fonts:
-                            props.append(ttfFontProperty(fpath, font))
-                        fontlist.extend(props)
-                        continue
-                    except Exception:
-                        logger.error(
-                            "Could not covert font to FontEntry for file %s",
-                            fpath, exc_info=True
-                        )
-                        continue
+                    with TTCollection(six.text_type(fpath)) as collection:
+                        try:
+                            props = []
+                            for font in collection.fonts:
+                                props.append(ttfFontProperty(fpath, font))
+                            fontlist.extend(props)
+                            continue
+                        except Exception:
+                            logger.error(
+                                "Could not covert font to FontEntry for file %s",
+                                fpath, exc_info=True
+                            )
+                            continue
                 else:
                     font = TTFont(six.text_type(fpath))
             except (RuntimeError, TTLibError):

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -686,6 +686,9 @@ def createFontList(fontfiles, fontext='ttf'):
     fontlist = []
     #  Add fonts from list of known font files.
     seen = {}
+
+    font_entry_err_msg = "Could not covert font to FontEntry for file %s"
+
     for fpath in fontfiles:
         logger.debug("createFontDict %s", fpath)
         fname = os.path.split(fpath)[1]
@@ -712,10 +715,7 @@ def createFontList(fontfiles, fontext='ttf'):
             try:
                 prop = afmFontProperty(fpath, font)
             except Exception:
-                logger.error(
-                    "Could not covert font to FontEntry for file %s", fpath,
-                    exc_info=True
-                )
+                logger.error(font_entry_err_msg, fpath, exc_info=True)
                 continue
         else:
             _, ext = os.path.splitext(fpath)
@@ -730,9 +730,7 @@ def createFontList(fontfiles, fontext='ttf'):
                             continue
                         except Exception:
                             logger.error(
-                                "Could not covert font to FontEntry for file %s",
-                                fpath, exc_info=True
-                            )
+                                font_entry_err_msg, fpath, exc_info=True)
                             continue
                 else:
                     font = TTFont(six.text_type(fpath))
@@ -748,10 +746,7 @@ def createFontList(fontfiles, fontext='ttf'):
             try:
                 prop = ttfFontProperty(fpath, font)
             except Exception:
-                logger.error(
-                    "Could not covert font to FontEntry for file %s", fpath,
-                    exc_info=True
-                )
+                logger.error(font_entry_err_msg, fpath, exc_info=True)
                 continue
 
         fontlist.append(prop)


### PR DESCRIPTION
As of fonttools 4.1, we can use `TTCollection` as a context manager directly, but we are currently using 3.29 with EDM. However, we can pass an open file object directly into `TTCollection` rather than the file path.

Also includes a tiny refactor to remove duplicated logging error message strings. 

Closes #377