### PR TITLE
Small fixes for Examples

### DIFF
--- a/enable/savage/trait_defs/ui/qt4/svg_editor.py
+++ b/enable/savage/trait_defs/ui/qt4/svg_editor.py
@@ -22,7 +22,7 @@
 #  Imports:
 #-------------------------------------------------------------------------------
 
-from six import StringIO
+from six import BytesIO
 from xml.etree.cElementTree import ElementTree
 
 from enable.savage.svg.document import SVGDocument
@@ -63,8 +63,8 @@ class SVGEditor(Editor):
         value = self.value
 
         if isinstance(value, SVGDocument):
-            string_io = StringIO()
-            ElementTree(value.tree).write(string_io)
-            value = string_io.getvalue()
+            bytes_io = BytesIO()
+            ElementTree(value.tree).write(bytes_io)
+            value = bytes_io.getvalue()
 
         self.control.load(QtCore.QByteArray(value))

--- a/examples/kiva_explorer.py
+++ b/examples/kiva_explorer.py
@@ -9,6 +9,7 @@ import time
 
 from traits.api import Any, Code, Float, Instance, Property, Str
 from traitsui.api import HSplit, ModelView, UItem, VGroup, View
+
 from enable.api import Component, ComponentEditor
 
 
@@ -82,7 +83,7 @@ class ScriptedComponent(Component):
         code = self._compile_script()
         if code is not None:
             self._draw_code = code
-        self.request_redraw()
+            self.request_redraw()
 
     def __draw_code_default(self):
         code = self._compile_script()
@@ -113,14 +114,16 @@ class ScriptedComponentView(ModelView):
                     'model.error',
                     visible_when="model.error != ''",
                     style='readonly',
-                    height=100)
+                    height=100,
+                )
             ),
             VGroup(
-                UItem('model', editor=ComponentEditor()),
-                UItem('model.fps_display', height=20)
+                UItem('model', editor=ComponentEditor(), springy=True),
+                UItem('model.fps_display', style='readonly'),
             ),
         ),
-        resizable=True
+        resizable=True,
+        title='Kiva Explorer',
     )
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes a couple of small issues found when working with the examples:

- the savage static demo didn't work on Python 3 because the XML writer expected bytes, not str.
- error reporting was broken in the KivaExplorer, and the timing editor was an editable field.

This fixes both issues.