### PR TITLE
WxPython 4 Fixes

### DIFF
--- a/enable/savage/svg/backends/wx/renderer.py
+++ b/enable/savage/svg/backends/wx/renderer.py
@@ -13,6 +13,7 @@ def _fixup_path_methods(path):
 
     path.__class__.AddRoundedRectangleEx = _new_add_rounded_rectangle
 
+
 class AbstractGradientBrush(object):
     """ Abstract base class for gradient brushes so they can be detected easily.
     """
@@ -56,7 +57,7 @@ class Renderer(NullRenderer):
 
     @staticmethod
     def createAffineMatrix(a,b,c,d,x,y):
-        return wx.GraphicsRenderer_GetDefaultRenderer().CreateMatrix(a,b,c,d,x,y)
+        return wx.GraphicsRenderer.GetDefaultRenderer().CreateMatrix(a,b,c,d,x,y)
 
     @staticmethod
     def createBrush(color_tuple):
@@ -64,7 +65,7 @@ class Renderer(NullRenderer):
 
     @staticmethod
     def createNativePen(pen):
-        return wx.GraphicsRenderer_GetDefaultRenderer().CreatePen(pen)
+        return wx.GraphicsRenderer.GetDefaultRenderer().CreatePen(pen)
 
     @staticmethod
     def createPen(color_tuple):
@@ -81,23 +82,23 @@ class Renderer(NullRenderer):
             color = wx.Colour(red*255, green*255, blue*255, opacity*255)
             return offset, color
 
-        if wx.VERSION > (2,9):        
+        if wx.VERSION[:2] > (2,9):
             # wxPython 2.9+ supports a collection of stops
             wx_stops = wx.GraphicsGradientStops()
             for stop in stops:
                 offset, color = convert_stop(stop)
                 wx_stops.Add(color, offset)
-        
+
             wx_renderer = wx.GraphicsRenderer.GetDefaultRenderer()
             return wx_renderer.CreateLinearGradientBrush(x1, y1, x2, y2, wx_stops)
-        
-        else:        
+
+        else:
             if len(stops) > 2:
                 warnings.warn("wxPython 2.8 only supports 2 gradient stops, but %d were specified" % len(stops))
-    
+
             start_offset, start_color = convert_stop(stops[0])
             end_offset, end_color = convert_stop(stops[1])
-    
+
             wx_renderer = wx.GraphicsRenderer.GetDefaultRenderer()
             return wx_renderer.CreateLinearGradientBrush(x1, y1, x2, y2,
                                                          start_color, end_color)
@@ -115,13 +116,13 @@ class Renderer(NullRenderer):
             color = wx.Colour(red*255, green*255, blue*255, opacity*255)
             return offset, color
 
-        if wx.VERSION > (2,9):        
+        if wx.VERSION[:2] > (2,9):
             # wxPython 2.9+ supports a collection of stops
             wx_stops = wx.GraphicsGradientStops()
             for stop in stops:
                 offset, color = convert_stop(stop)
                 wx_stops.Add(color, offset)
-    
+
             wx_renderer = wx.GraphicsRenderer.GetDefaultRenderer()
             return wx_renderer.CreateRadialGradientBrush(fx, fy, cx, cy, r, wx_stops)
 
@@ -129,15 +130,15 @@ class Renderer(NullRenderer):
 
             if len(stops) > 2:
                 warnings.warn("wxPython 2.8 only supports 2 gradient stops, but %d were specified" % len(stops))
-    
+
             start_offset, start_color = convert_stop(stops[0])
             end_offset, end_color = convert_stop(stops[-1])
-    
+
             if fx is None:
                 fx = cx
             if fy is None:
                 fy = cy
-    
+
             wx_renderer = wx.GraphicsRenderer.GetDefaultRenderer()
             return wx_renderer.CreateRadialGradientBrush(fx, fy, cx, cy, r,
                                                          start_color, end_color)
@@ -156,11 +157,11 @@ class Renderer(NullRenderer):
 
     @staticmethod
     def makeMatrix(*args):
-        return wx.GraphicsRenderer_GetDefaultRenderer().CreateMatrix(*args)
+        return wx.GraphicsRenderer.GetDefaultRenderer().CreateMatrix(*args)
 
     @staticmethod
     def makePath():
-        path = wx.GraphicsRenderer_GetDefaultRenderer().CreatePath()
+        path = wx.GraphicsRenderer.GetDefaultRenderer().CreatePath()
         _fixup_path_methods(path)
         return path
 

--- a/enable/savage/trait_defs/ui/wx/svg_button_editor.py
+++ b/enable/savage/trait_defs/ui/wx/svg_button_editor.py
@@ -63,7 +63,7 @@ class ButtonRenderPanel(RenderPanel):
     def GetBackgroundColour(self):
         bgcolor = copy.copy(WindowColor)
         if self.state == 'down':
-            red, green, blue = bgcolor.Get()
+            red, green, blue = bgcolor.Get()[:3]
             red -= 15
             green -= 15
             blue -= 15
@@ -76,7 +76,7 @@ class ButtonRenderPanel(RenderPanel):
         dc.Clear()
         dc.SetFont(wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT))
 
-        gc = wx.GraphicsContext_Create(dc)
+        gc = wx.GraphicsContext.Create(dc)
 
         if self.toggle_state and self.button.factory.toggle and \
                 not self.button.factory.toggle_filename:

--- a/enable/savage/trait_defs/ui/wx/wx_render_panel.py
+++ b/enable/savage/trait_defs/ui/wx/wx_render_panel.py
@@ -4,9 +4,10 @@ import wx
 from enable.savage.svg.backends.wx import renderer
 from traitsui.wx.constants import WindowColor
 
-class RenderPanel(wx.PyPanel):
+
+class RenderPanel(wx.Panel):
     def __init__(self, parent, document=None):
-        wx.PyPanel.__init__(self, parent)
+        super(RenderPanel, self).__init__(parent)
         self.lastRender = None
         self.document = document
         self.zoom_x = 100

--- a/enable/trait_defs/ui/wx/rgba_color_editor.py
+++ b/enable/trait_defs/ui/wx/rgba_color_editor.py
@@ -16,7 +16,7 @@ the wxPython user interface toolkit.
 import wx
 
 from enable.colors import color_table
-
+from enable.api import Label, Window
 from traits.api import Bool
 from traits.trait_base import SequenceTypes
 
@@ -31,14 +31,11 @@ from traitsui.wx.helper import position_window
 #-------------------------------------------------------------------------------
 
 # Standard color samples:
-color_choices = ( 0, 51, 102, 153, 204, 255 )
-color_samples = [ None ] * 216
-i             = 0
-for r in color_choices:
-    for g in color_choices:
-        for b in color_choices:
-            color_samples[i] = wx.Colour( r, g, b )
-            i += 1
+COLOR_CHOICES = ( 0, 51, 102, 153, 204, 255 )
+COLOR_SAMPLES = tuple([wx.Colour(r, g, b)
+                       for r in COLOR_CHOICES
+                       for g in COLOR_CHOICES
+                       for b in COLOR_CHOICES])
 
 #-------------------------------------------------------------------------------
 #  'ToolkitEditorFactory' class:
@@ -164,8 +161,6 @@ class SimpleColorEditor ( Editor ):
         """ Finishes initializing the editor by creating the underlying toolkit
             widget.
         """
-        from enable.api import Label
-        from enable.wx_backend import Window
         window = Window( parent,
                     component = Label( '', border_size = 1, font = 'modern 9' ) )
         self._swatch = window.component
@@ -314,8 +309,6 @@ class ReadonlyColorEditor ( ReadonlyEditor ):
         """ Finishes initializing the editor by creating the underlying toolkit
             widget.
         """
-        from enable.api import Label
-        from enable.wx_backend import Window
         window = Window( parent,
                     component = Label( '', border_size = 1, font = 'modern 9' ) )
         self._swatch = window.component
@@ -381,12 +374,13 @@ def color_editor_for ( editor, parent, update_handler = None ):
     # Add all of the color choice buttons:
     sizer2 = wx.GridSizer( 0, 12, 0, 0 )
 
-    for i in range( len( color_samples ) ):
+    for color_sample in COLOR_SAMPLES:
         control = wx.Button( panel, -1, '', size = wx.Size( 18, 18 ) )
-        control.SetBackgroundColour( color_samples[i] )
+        control.SetBackgroundColour( color_sample )
         control.update_handler = update_handler
-        wx.EVT_BUTTON( panel, control.GetId(),
-                       swatch_editor.update_object_from_swatch )
+        panel.Bind(wx.EVT_BUTTON,
+                   swatch_editor.update_object_from_swatch,
+                   id=control.GetId())
         sizer2.Add( control )
         editor.set_tooltip( control )
 
@@ -397,10 +391,10 @@ def color_editor_for ( editor, parent, update_handler = None ):
                                100 - int( alpha * 100.0 ), 0, 100,
                                size  = wx.Size( 20, 40 ),
                                style = wx.SL_VERTICAL | wx.SL_AUTOTICKS )
-    slider.SetTickFreq( 10, 1 )
+    slider.SetTickFreq( 10 )
     slider.SetPageSize( 10 )
     slider.SetLineSize( 1 )
-    wx.EVT_SCROLL( slider, swatch_editor.update_object_from_scroll )
+    slider.Bind(wx.EVT_SCROLL, swatch_editor.update_object_from_scroll )
     sizer.Add( slider, 0, wx.EXPAND | wx.LEFT, 6 )
 
     # Set-up the layout:

--- a/enable/trait_defs/ui/wx/rgba_color_editor.py
+++ b/enable/trait_defs/ui/wx/rgba_color_editor.py
@@ -16,7 +16,8 @@ the wxPython user interface toolkit.
 import wx
 
 from enable.colors import color_table
-from enable.api import Label, Window
+from enable.label import Label
+from enable.window import Window
 from traits.api import Bool
 from traits.trait_base import SequenceTypes
 
@@ -31,7 +32,7 @@ from traitsui.wx.helper import position_window
 #-------------------------------------------------------------------------------
 
 # Standard color samples:
-COLOR_CHOICES = ( 0, 51, 102, 153, 204, 255 )
+COLOR_CHOICES = (0, 51, 102, 153, 204, 255)
 COLOR_SAMPLES = tuple([wx.Colour(r, g, b)
                        for r in COLOR_CHOICES
                        for g in COLOR_CHOICES

--- a/enable/wx/base_window.py
+++ b/enable/wx/base_window.py
@@ -140,12 +140,12 @@ class LessSuckyDropTarget(PythonDropTarget):
 class BaseWindow(AbstractWindow):
 
     # Screen scroll increment amount:
-    scroll_incr = ( wx.SystemSettings_GetMetric( wx.SYS_SCREEN_Y )
+    scroll_incr = ( wx.SystemSettings.GetMetric( wx.SYS_SCREEN_Y )
                     or 768 ) / 20
 
     # Width/Height of standard scrollbars:
-    scrollbar_dx = wx.SystemSettings_GetMetric( wx.SYS_VSCROLL_X )
-    scrollbar_dy = wx.SystemSettings_GetMetric( wx.SYS_HSCROLL_Y )
+    scrollbar_dx = wx.SystemSettings.GetMetric( wx.SYS_VSCROLL_X )
+    scrollbar_dy = wx.SystemSettings.GetMetric( wx.SYS_HSCROLL_Y )
 
     _cursor_color = Any  # PZW: figure out the correct type for this...
 
@@ -172,37 +172,37 @@ class BaseWindow(AbstractWindow):
         self.control = control = self._create_control(parent, wid, pos, size)
 
         # Set up the 'erase background' event handler:
-        wx.EVT_ERASE_BACKGROUND( control, self._on_erase_background )
+        control.Bind(wx.EVT_ERASE_BACKGROUND, self._on_erase_background )
 
         # Set up the 'paint' event handler:
-        wx.EVT_PAINT( control, self._paint )
-        wx.EVT_SIZE(  control, self._on_size )
+        control.Bind(wx.EVT_PAINT, self._paint)
+        control.Bind(wx.EVT_SIZE, self._on_size)
 
         # Set up mouse event handlers:
-        wx.EVT_LEFT_DOWN(     control, self._on_left_down )
-        wx.EVT_LEFT_UP(       control, self._on_left_up )
-        wx.EVT_LEFT_DCLICK(   control, self._on_left_dclick )
-        wx.EVT_MIDDLE_DOWN(   control, self._on_middle_down )
-        wx.EVT_MIDDLE_UP(     control, self._on_middle_up )
-        wx.EVT_MIDDLE_DCLICK( control, self._on_middle_dclick )
-        wx.EVT_RIGHT_DOWN(    control, self._on_right_down )
-        wx.EVT_RIGHT_UP(      control, self._on_right_up )
-        wx.EVT_RIGHT_DCLICK(  control, self._on_right_dclick )
-        wx.EVT_MOTION(        control, self._on_mouse_move )
-        wx.EVT_ENTER_WINDOW(  control, self._on_window_enter )
-        wx.EVT_LEAVE_WINDOW(  control, self._on_window_leave )
-        wx.EVT_MOUSEWHEEL(    control, self._on_mouse_wheel )
+        control.Bind(wx.EVT_LEFT_DOWN, self._on_left_down)
+        control.Bind(wx.EVT_LEFT_UP, self._on_left_up)
+        control.Bind(wx.EVT_LEFT_DCLICK, self._on_left_dclick)
+        control.Bind(wx.EVT_MIDDLE_DOWN, self._on_middle_down)
+        control.Bind(wx.EVT_MIDDLE_UP, self._on_middle_up)
+        control.Bind(wx.EVT_MIDDLE_DCLICK, self._on_middle_dclick)
+        control.Bind(wx.EVT_RIGHT_DOWN, self._on_right_down)
+        control.Bind(wx.EVT_RIGHT_UP, self._on_right_up)
+        control.Bind(wx.EVT_RIGHT_DCLICK, self._on_right_dclick)
+        control.Bind(wx.EVT_MOTION, self._on_mouse_move)
+        control.Bind(wx.EVT_ENTER_WINDOW, self._on_window_enter)
+        control.Bind(wx.EVT_LEAVE_WINDOW, self._on_window_leave)
+        control.Bind(wx.EVT_MOUSEWHEEL, self._on_mouse_wheel)
 
         # Handle key up/down events:
-        wx.EVT_KEY_DOWN( control, self._on_key_pressed )
-        wx.EVT_KEY_UP(   control, self._on_key_released )
-        wx.EVT_CHAR(     control, self._on_character )
+        control.Bind(wx.EVT_KEY_DOWN, self._on_key_pressed )
+        control.Bind(wx.EVT_KEY_UP, self._on_key_released )
+        control.Bind(wx.EVT_CHAR, self._on_character )
 
         # Attempt to allow wxPython drag and drop events to be mapped to
         # Enable drag events:
 
         # Handle window close and cleanup
-        wx.EVT_WINDOW_DESTROY(control, self._on_close)
+        control.Bind(wx.EVT_WINDOW_DESTROY, self._on_close)
 
         if PythonDropTarget is not None:
             control.SetDropTarget( LessSuckyDropTarget( self ) )
@@ -215,37 +215,37 @@ class BaseWindow(AbstractWindow):
 
         return
 
-    def _create_control(self, parent, wid, pos = wx.DefaultPosition,
-                        size = wx.DefaultSize):
-        return wx.Window(parent, wid, pos, size, style = wx.CLIP_CHILDREN |
-                           wx.WANTS_CHARS)
-
+    def _create_control(self, parent, wid, pos=wx.DefaultPosition, size=wx.DefaultSize):
+        if parent is None:
+            # pab hack in order to avoid that the wx.Window crash!
+            parent = wx.Frame(None)
+        return wx.Window(parent, wid, pos, size, style=wx.CLIP_CHILDREN | wx.WANTS_CHARS)
 
     def _on_close(self, event):
         # Might be scrollbars or other native components under
         # us that are generating this event
         if event.GetWindow() == self.control:
             self._gc = None
-            wx.EVT_ERASE_BACKGROUND(self.control, None)
-            wx.EVT_PAINT(self.control, None)
-            wx.EVT_SIZE(self.control, None)
-            wx.EVT_LEFT_DOWN(self.control, None)
-            wx.EVT_LEFT_UP(self.control, None)
-            wx.EVT_LEFT_DCLICK(self.control, None)
-            wx.EVT_MIDDLE_DOWN(self.control, None)
-            wx.EVT_MIDDLE_UP(self.control, None)
-            wx.EVT_MIDDLE_DCLICK(self.control, None)
-            wx.EVT_RIGHT_DOWN(self.control, None)
-            wx.EVT_RIGHT_UP(self.control, None)
-            wx.EVT_RIGHT_DCLICK(self.control, None)
-            wx.EVT_MOTION(self.control, None)
-            wx.EVT_ENTER_WINDOW(self.control, None)
-            wx.EVT_LEAVE_WINDOW(self.control, None)
-            wx.EVT_MOUSEWHEEL(self.control, None)
-            wx.EVT_KEY_DOWN(self.control, None)
-            wx.EVT_KEY_UP(self.control, None)
-            wx.EVT_CHAR(self.control, None)
-            wx.EVT_WINDOW_DESTROY(self.control, None)
+            self.control.Bind(wx.EVT_ERASE_BACKGROUND, None)
+            self.control.Bind(wx.EVT_PAINT, None)
+            self.control.Bind(wx.EVT_SIZE, None)
+            self.control.Bind(wx.EVT_LEFT_DOWN, None)
+            self.control.Bind(wx.EVT_LEFT_UP, None)
+            self.control.Bind(wx.EVT_LEFT_DCLICK, None)
+            self.control.Bind(wx.EVT_MIDDLE_DOWN, None)
+            self.control.Bind(wx.EVT_MIDDLE_UP, None)
+            self.control.Bind(wx.EVT_MIDDLE_DCLICK, None)
+            self.control.Bind(wx.EVT_RIGHT_DOWN, None)
+            self.control.Bind(wx.EVT_RIGHT_UP, None)
+            self.control.Bind(wx.EVT_RIGHT_DCLICK, None)
+            self.control.Bind(wx.EVT_MOTION, None)
+            self.control.Bind(wx.EVT_ENTER_WINDOW, None)
+            self.control.Bind(wx.EVT_LEAVE_WINDOW, None)
+            self.control.Bind(wx.EVT_MOUSEWHEEL, None)
+            self.control.Bind(wx.EVT_KEY_DOWN, None)
+            self.control.Bind(wx.EVT_KEY_UP, None)
+            self.control.Bind(wx.EVT_CHAR, None)
+            self.control.Bind(wx.EVT_WINDOW_DESTROY, None)
             self.control.SetDropTarget(None)
             self.control = None
             self.component.cleanup(self)
@@ -262,7 +262,7 @@ class BaseWindow(AbstractWindow):
         pass
 
     def _on_size ( self, event ):
-        dx, dy = self.control.GetSizeTuple()
+        dx, dy = self.control.GetSize()
 
         # do nothing if the new and old sizes are the same
         if (self.component.outer_width, self.component.outer_height) == (dx, dy):
@@ -370,7 +370,7 @@ class BaseWindow(AbstractWindow):
             # Note: The following code fixes a bug in wxPython that returns
             # 'mouse_wheel' events in screen coordinates, rather than window
             # coordinates:
-            if float(wx.VERSION_STRING[:3]) < 2.8:
+            if wx.VERSION[:2] < (2, 8):
                 if mouse_wheel != 0 and sys.platform == "win32":
                     x, y = self.control.ScreenToClientXY( x, y )
             return MouseEvent(
@@ -426,7 +426,7 @@ class BaseWindow(AbstractWindow):
         "Get the size of the underlying toolkit control"
         result = None
         if self.control:
-            result = self.control.GetSizeTuple()
+            result = self.control.GetSize()
         return result
 
     def _window_paint ( self, event):

--- a/enable/wx/constants.py
+++ b/enable/wx/constants.py
@@ -124,8 +124,8 @@ key_symbols = [
     wx.WXK_NUMPAD7,
     wx.WXK_NUMPAD8,
     wx.WXK_NUMPAD9,
-    wx.WXK_NEXT,
-    wx.WXK_PRIOR,
+    wx.WXK_PAGEDOWN,  # Formerly: wx.WXK_NEXT
+    wx.WXK_PAGEUP,  # Formerly: wx.WXK_PRIOR
     wx.WXK_PAUSE,
     wx.WXK_PRINT,
     wx.WXK_RIGHT,
@@ -139,13 +139,12 @@ key_symbols = [
 ]
 
 
-
 if len(key_symbols) != len(key_names):
     warnings.warn("The WX toolkit backend keymap is out of sync!")
 
 KEY_MAP = dict(zip(key_symbols, key_names))
 
-if tuple(float(v) for v in wx.__version__.split('.')) < (2, 9, 4):
+if wx.VERSION[:3] < (2, 9, 4):
     mouse_wheel_axes = [0, 1]
 else:
     mouse_wheel_axes = [wx.MOUSE_WHEEL_VERTICAL, wx.MOUSE_WHEEL_HORIZONTAL]

--- a/kiva/trait_defs/ui/wx/kiva_font_editor.py
+++ b/kiva/trait_defs/ui/wx/kiva_font_editor.py
@@ -41,11 +41,12 @@ class ToolkitEditorFactory ( EditorFactory ):
     #   Returns a Font's 'face name':
     #---------------------------------------------------------------------------
 
-    def face_name ( self, font ):
+    @staticmethod
+    def face_name(font):
         """ Returns a Font's typeface name.
         """
         face_name = font.face_name
-        if type( face_name ) in SequenceTypes:
+        if isinstance(face_name, SequenceTypes):
             face_name = face_name[0]
 
         return face_name
@@ -107,7 +108,7 @@ class ToolkitEditorFactory ( EditorFactory ):
 
         weight    = { kc.BOLD:   ' Bold'   }.get( font.weight, '' )
         style     = { kc.ITALIC: ' Italic' }.get( font.style,  '' )
-        underline = [ '', ' Underline' ][ font.underline != 0 ]
+        underline = ' Underline' if font.underline != 0 else ''
 
         return '%s point %s%s%s%s' % (
                font.size, self.face_name( font ), style, weight, underline )
@@ -115,12 +116,13 @@ class ToolkitEditorFactory ( EditorFactory ):
     #---------------------------------------------------------------------------
     #  Returns a list of all available font facenames:
     #---------------------------------------------------------------------------
-
-    def all_facenames ( self ):
+    @staticmethod
+    def all_facenames():
         """ Returns a list of all available font typeface names.
         """
-        facenames = list(fontManager.ttfdict.keys())
+        facenames = sorted({f.name for f in fontManager.ttflist})
         return facenames
 
-def KivaFontEditor (*args, **traits):
+
+def KivaFontEditor(*args, **traits):
     return ToolkitEditorFactory (*args, **traits)

--- a/kiva/trait_defs/ui/wx/kiva_font_editor.py
+++ b/kiva/trait_defs/ui/wx/kiva_font_editor.py
@@ -41,8 +41,7 @@ class ToolkitEditorFactory ( EditorFactory ):
     #   Returns a Font's 'face name':
     #---------------------------------------------------------------------------
 
-    @staticmethod
-    def face_name(font):
+    def face_name(self, font):
         """ Returns a Font's typeface name.
         """
         face_name = font.face_name
@@ -116,12 +115,11 @@ class ToolkitEditorFactory ( EditorFactory ):
     #---------------------------------------------------------------------------
     #  Returns a list of all available font facenames:
     #---------------------------------------------------------------------------
-    @staticmethod
-    def all_facenames():
+
+    def all_facenames(self):
         """ Returns a list of all available font typeface names.
         """
-        facenames = sorted({f.name for f in fontManager.ttflist})
-        return facenames
+        return sorted({f.name for f in fontManager.ttflist})
 
 
 def KivaFontEditor(*args, **traits):


### PR DESCRIPTION
**NOTE:** This was pulled in from #401 to make review a bit easier.

Resolves #399

* Made `wx.VERSION` comparison more robust
* Made the test examples run on windows and using wx:
  * Replaced deprecated `wx.EVT_XXX(panel, handler)` with `panel.Bind(wx.EVT_XXX, handler)` in  `rgba_color_editor.py`
  * Replaced faulty `slider.SetTickFreq( 10, 1 )` with `slider.SetTickFreq(10)` in `rgba_color_editor.py`
  * Fixed the failing `ToolkitEditorFactory.all_facenames` method in `kiva_font_editor.py`
  * Replaced deprecated `wx.PyPanel` with `wx.Panel`
  * Changed `from enable.wx_backend import Window` to `from enable.api import Window` and moved all imports to the top of the file.
  * Replaced call to `wx.SystemSettings_GetMetric` with `wx.SystemSettings.GetMetric`
  * Replaced call to deprecated `wx.EVT_XXXX( control, self._on_XXXX)` with `control.Bind(wx.EVT_ERASE_BACKGROUND, self._on_XXXXX)`
  * Fixed a bug in `BaseWindow._create_control`:
    If `parent` is None it is set to `wx.Frame(None)` in order to avoid crash in the unit tests.
  * Replaced `wx.WXK_PRIOR` and `wx.WXK_NEXT` (which does not exist on wxpython4)
    with `wx.WXK_PAGEUP` and `wx.WXK_PAGEDOWN`

Fixes #399 replaced:
* `wx.GraphicsRenderer_GetDefaultRenderer` with `wx.GraphicsRenderer.GetDefaultRenderer`
* `wx.GraphicsContext_Create` with `wx.GraphicsContext.Create`