### PR TITLE
Make CI green again and remove Python 3.5 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,8 @@ env:
 
 matrix:
   include:
-  - env: RUNTIME=3.5 TOOLKITS="null pyqt pyqt5" PILLOW='pillow'
   - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5" PILLOW='pillow'
   - env: RUNTIME=3.6 TOOLKITS="wx" PILLOW='pillow'
-  - env: RUNTIME=3.5 TOOLKITS=null PILLOW='pillow<3.0.0'
   - env: RUNTIME=3.6 TOOLKITS=null PILLOW='pillow<3.0.0'
   allow_failures:
   - env: RUNTIME=3.6 TOOLKITS="wx" PILLOW='pillow'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
     - libpng-dev
     - libfreetype6-dev
     - libcairo2-dev
+    - liblzma-dev
     - libglu1-mesa-dev
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
 
 env:
   global:
-    - INSTALL_EDM_VERSION=2.0.0
+    - INSTALL_EDM_VERSION=3.0.1
       PYTHONUNBUFFERED="1"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ addons:
     - libpng-dev
     - libfreetype6-dev
     - libcairo2-dev
-    - liblzma-dev
     - libglu1-mesa-dev
 
 env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,6 @@ environment:
     INSTALL_EDM_VERSION: "3.0.1"
 
   matrix:
-    - RUNTIME: '3.5'
-      TOOLKITS: "null pyqt pyqt5"
     - RUNTIME: '3.6'
       TOOLKITS: "null pyqt pyqt5"
     - RUNTIME: '3.6'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
   global:
     PYTHONUNBUFFERED: "1"
-    INSTALL_EDM_VERSION: "2.0.0"
+    INSTALL_EDM_VERSION: "3.0.1"
 
   matrix:
     - RUNTIME: '3.5'

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -109,6 +109,8 @@ dependencies = {
     "chaco",
     "mayavi",
     "scipy",
+    # FIXME: We need to workaround libtiff 4.0.10-6 from EDM?
+    "libtiff==4.0.10-5",
 }
 
 extra_dependencies = {

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -162,7 +162,7 @@ def install(runtime, toolkit, pillow, environment):
         "edm install -y -e {environment} {packages}",
         "edm run -e {environment} -- pip install {pillow}",
         ("edm run -e {environment} -- pip install -r ci/requirements.txt"
-         " --no-dependencies --ignore-installed"),
+         " --no-dependencies --force-reinstall"),
     ]
 
     # pip install pyqt5, because we don't have it in EDM yet
@@ -170,7 +170,8 @@ def install(runtime, toolkit, pillow, environment):
         commands.append("edm run -e {environment} -- pip install pyqt5==5.9.2")
 
     commands.append(
-        "edm run -e {environment} -- pip install --force-reinstall " + ROOT
+        "edm run -e {environment} -- "
+        "pip install --force-reinstall --no-dependencies " + ROOT
     )
 
     click.echo("Creating environment '{environment}'".format(**parameters))

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -109,8 +109,6 @@ dependencies = {
     "chaco",
     "mayavi",
     "scipy",
-    # FIXME: We need to workaround libtiff 4.0.10-6 from EDM?
-    "libtiff==4.0.10-5",
 }
 
 extra_dependencies = {

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -89,6 +89,7 @@ from contextlib import contextmanager
 import click
 
 supported_combinations = {
+    '3.5': {'pyqt', 'pyqt5', 'null'},
     '3.6': {'pyqt', 'pyqt5', 'null'},
 }
 
@@ -105,8 +106,8 @@ dependencies = {
     "traits",
     # Avoiding traitsui 7.1.0 for now due to private imports
     # in test suite (see enthought/enable#425)
-    "traitsui==7.0.1-1",
-    "pyface==7.0.1-1",
+    "traitsui<=7.0.1-1",
+    "pyface<=7.0.1-1",
     "pypdf2",
     "swig",
     "unittest2",

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -89,7 +89,6 @@ from contextlib import contextmanager
 import click
 
 supported_combinations = {
-    '3.5': {'pyqt', 'pyqt5', 'null'},
     '3.6': {'pyqt', 'pyqt5', 'null'},
 }
 
@@ -106,8 +105,8 @@ dependencies = {
     "traits",
     # Avoiding traitsui 7.1.0 for now due to private imports
     # in test suite (see enthought/enable#425)
-    "traitsui<=7.0.1-1",
-    "pyface<=7.0.1-1",
+    "traitsui==7.0.1-1",
+    "pyface==7.0.1-1",
     "pypdf2",
     "swig",
     "unittest2",

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -89,11 +89,11 @@ from contextlib import contextmanager
 import click
 
 supported_combinations = {
-    '3.5': {'pyqt', 'pyqt5', 'null'},
     '3.6': {'pyqt', 'pyqt5', 'null'},
 }
 
 dependencies = {
+    "apptools",
     "six",
     "nose",
     "mock",
@@ -102,13 +102,14 @@ dependencies = {
     "pygments",
     "pyparsing",
     "swig",
-    "unittest2",
+    "traits",
+    # Avoiding traitsui 7.1.0 for now due to private imports
+    # in test suite (see enthought/enable#425)
+    "traitsui==7.0.1-1",
+    "pyface==7.0.1-1",
     "pypdf2",
     "swig",
-    # required by some demos
-    "chaco",
-    "mayavi",
-    "scipy",
+    "unittest2",
 }
 
 extra_dependencies = {
@@ -162,13 +163,15 @@ def install(runtime, toolkit, pillow, environment):
         "edm install -y -e {environment} {packages}",
         "edm run -e {environment} -- pip install {pillow}",
         ("edm run -e {environment} -- pip install -r ci/requirements.txt"
-         " --no-dependencies --force-reinstall"),
+         " --no-dependencies"),
     ]
 
     # pip install pyqt5, because we don't have it in EDM yet
     if toolkit == 'pyqt5':
         commands.append("edm run -e {environment} -- pip install pyqt5==5.9.2")
 
+    # No matter happens before, always install local source again or
+    # we risk testing against an released enable.
     commands.append(
         "edm run -e {environment} -- "
         "pip install --force-reinstall --no-dependencies " + ROOT

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -135,6 +135,10 @@ if sys.platform == 'darwin':
     dependencies.add('Cython')
 
 
+#: Path to the top-level source directory
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
 @click.group()
 def cli():
     pass
@@ -165,7 +169,9 @@ def install(runtime, toolkit, pillow, environment):
     if toolkit == 'pyqt5':
         commands.append("edm run -e {environment} -- pip install pyqt5==5.9.2")
 
-    commands.append("edm run -e {environment} -- python setup.py install")
+    commands.append(
+        "edm run -e {environment} -- pip install --force-reinstall " + ROOT
+    )
 
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -4,7 +4,7 @@ fonttools==3.28.0
 reportlab<=3.1
 kiwisolver ; python_version <= "2.7"
 https://bitbucket.org/pyglet/pyglet/get/pyglet-1.1.4.zip ; python_version <= "2.7"
-git+http://github.com/enthought/traits.git#egg=traits
-git+http://github.com/enthought/pyface.git#egg=pyface
-git+http://github.com/enthought/traitsui.git#egg=traitsui[demo]
-git+http://github.com/enthought/apptools.git#egg=apptools
+traits==6.1.0
+traitsui==6.1.0
+pyface==6.1.0
+apptools==4.5.0

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -4,7 +4,3 @@ fonttools==3.28.0
 reportlab<=3.1
 kiwisolver ; python_version <= "2.7"
 https://bitbucket.org/pyglet/pyglet/get/pyglet-1.1.4.zip ; python_version <= "2.7"
-traits==6.1.1
-traitsui==7.0.1
-pyface==7.0.1
-apptools==4.5.0

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -4,7 +4,7 @@ fonttools==3.28.0
 reportlab<=3.1
 kiwisolver ; python_version <= "2.7"
 https://bitbucket.org/pyglet/pyglet/get/pyglet-1.1.4.zip ; python_version <= "2.7"
-traits==6.1.0
-traitsui==6.1.0
-pyface==6.1.0
+traits==6.1.1
+traitsui==7.0.1
+pyface==7.0.1
 apptools==4.5.0

--- a/enable/tests/container_test_case.py
+++ b/enable/tests/container_test_case.py
@@ -39,7 +39,7 @@ class ContainerTestCase(EnableUnitTest):
         # Exercise set_components:
         new_list = [self.c1, self.c3]
         container.components = new_list
-        self.assertIs(container.components, new_list)
+        self.assertEqual(container.components, new_list)
 
     def test_add_remove(self):
         container = self.create_simple_components()

--- a/enable/tests/tools/hover_tool_test_case.py
+++ b/enable/tests/tools/hover_tool_test_case.py
@@ -23,7 +23,7 @@ if GuiTestAssistant.__name__ == "Unimplemented":
 
     # ensure null toolkit has an inheritable GuiTestAssistant
     # Note that without this definition, the test case fails as soon as it
-    # is instantiated, before it can be s
+    # is instantiated, before it can be skipped.
     class GuiTestAssistant(object):
         pass
 

--- a/enable/tests/tools/hover_tool_test_case.py
+++ b/enable/tests/tools/hover_tool_test_case.py
@@ -19,6 +19,13 @@ from traitsui.tests._tools import skip_if_null
 
 
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+if GuiTestAssistant.__name__ == "Unimplemented":
+
+    # ensure null toolkit has an inheritable GuiTestAssistant
+    # Note that without this definition, the test case fails as soon as it
+    # is instantiated, before it can be s
+    class GuiTestAssistant(object):
+        pass
 
 
 LOWER_BOUND = 50


### PR DESCRIPTION
This PR's goal is to make CI green again.

Closes #423
Closes #410

I tried my best to limit the scope of this PR, but it was difficult to achieve 😂 .

In summary:
- EDM version is upgraded to use RH7 repository.
- The test failure in #423 is fixed. The test was failing in the first place but the test was not run on CI before.
- Revert half of #386 which caused CI to be run against a released egg of enable instead of local source
- Fix test errors complaining about GuiTestAssistant not being implemented on null toolkit (see this [comment](https://github.com/enthought/enable/pull/405#issuecomment-642715980)).
- Pin dependencies on traits, traitsui, pyface, apptools to released versions.
- Install traits, traitsui, pyface and apptools from EDM, remove Python 3.5 from the CI matrix. (<-- this is a bit opportunistic)

Details:
- First commit makes sure the current source is exercised by CI and we get the same failure in #423
- The subsequent commit tried to resolve missing link for liblzma from libtiff. The issue affects the most recent libtiff egg for RH6 repository. Upgrading EDM in order to use the RH7 repository resolves this issue.
- Avoid #425 by pinning released versions of traits, traitsui, pyface and apptools. Further restrict to TraitsUI<7.1.0. I think the issue should be fixed separately
- Fix the error to do with GuiTestAssistant not being available on null toolkit. It came up in the build for #405 as well. Not sure why it only started occurring then.
- Revert half of #386 which installs dependencies for running demo examples (it brings in chaco, mayavi etc). Those dependencies bring in the released version of enable, and since then enable CI has not been testing the local source. We don't really need these dependencies for running tests nor for developing enable. It seems reasonable not to install it by default.

On this:

> - Install traits, traitsui, pyface and apptools from EDM, remove Python 3.5 from the CI matrix.

This is because many recent releases have not been built for EDM + Python 3.5 any more. Python 3.5 has already passed end-of-life (see #415 too). This step I can revert.
