### PR TITLE
Add source click option used on cron jobs to install pyface, traitsui, and traits from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   global:
     - INSTALL_EDM_VERSION=3.0.1
       PYTHONUNBUFFERED="1"
+    - TRAVIS_EVENT_TYPE="cron"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
   global:
     - INSTALL_EDM_VERSION=3.0.1
       PYTHONUNBUFFERED="1"
-    - TRAVIS_EVENT_TYPE="cron"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,13 @@ before_install:
   - export PATH="${HOME}/edm/bin:/usr/lib/ccache:${PATH}"
   - edm install -y wheel click coverage
 install:
-  - for toolkit in ${TOOLKITS}; do edm run -- python ci/edmtool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --pillow=${PILLOW} || exit; done
+  - for toolkit in ${TOOLKITS}; do
+        if [[ ${TRAVIS_EVENT_TYPE} == "cron" ]] ; then
+          edm run -- python ci/edmtool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --pillow=${PILLOW} --source || exit;
+        else
+          edm run -- python ci/edmtool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --pillow=${PILLOW} || exit;
+        fi;
+    done
 script:
   - for toolkit in ${TOOLKITS}; do edm run -- python ci/edmtool.py test --runtime=${RUNTIME} --toolkit=${toolkit} --pillow=${PILLOW} || exit; done
 

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -114,6 +114,7 @@ dependencies = {
 
 # Dependencies we install from source for cron tests
 source_dependencies = {
+    "apptools",
     "pyface",
     "traits",
     "traitsui",

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -112,6 +112,13 @@ dependencies = {
     "unittest2",
 }
 
+# Dependencies we install from source for cron tests
+source_dependencies = {
+    "pyface",
+    "traits",
+    "traitsui",
+}
+
 extra_dependencies = {
     'pyqt': {'pyqt'},
     'pyqt5': set(),
@@ -140,6 +147,9 @@ if sys.platform == 'darwin':
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 
+github_url_fmt = "git+http://github.com/enthought/{0}.git#egg={0}"
+
+
 @click.group()
 def cli():
     pass
@@ -150,7 +160,12 @@ def cli():
 @click.option('--toolkit', default='null')
 @click.option('--pillow', default='pillow')
 @click.option('--environment', default=None)
-def install(runtime, toolkit, pillow, environment):
+@click.option(
+    "--source/--no-source",
+    default=False,
+    help="Install ETS packages from source",
+)
+def install(runtime, toolkit, pillow, environment, source):
     """ Install project and dependencies into a clean EDM environment.
 
     """
@@ -179,6 +194,26 @@ def install(runtime, toolkit, pillow, environment):
 
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)
+
+    if source:
+        # Remove EDM ETS packages and install them from source
+        cmd_fmt = (
+            "edm plumbing remove-package "
+            "--environment {environment} --force "
+        )
+        commands = [cmd_fmt + source_pkg for source_pkg in source_dependencies]
+        execute(commands, parameters)
+        source_pkgs = [
+            github_url_fmt.format(pkg) for pkg in source_dependencies
+        ]
+        commands = [
+            "python -m pip install {pkg} --no-deps".format(pkg=pkg)
+            for pkg in source_pkgs
+        ]
+        commands = [
+            "edm run -e {environment} -- " + command for command in commands
+        ]
+        execute(commands, parameters)
     click.echo('Done install')
 
 


### PR DESCRIPTION
fixes #407 

This PR makes it so that cron jobs install `pyface`, `traitsui`, and `traits` from source by adding a `--source` click option used in the install function in `edmtool.py`.

This follows what is done in other ets projects (e.g https://github.com/enthought/envisage/blob/8245931f7e3dfcb6513bfb7dc2ae9b10ca6f89a1/etstool.py#L255-L273)

Note that based on the comment
```
# Avoiding traitsui 7.1.0 for now due to private imports
# in test suite (see enthought/enable#425)
"traitsui==7.0.1-1",
```
and the issue #425 I expect that CI will currently fail for these cron jobs, but that is what we want so that these kinds of issues can be detected early. 
