### PR TITLE
re-adding wx as a supported combination in edmtool 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     - libfreetype6-dev
     - libcairo2-dev
     - libglu1-mesa-dev
+    - libsdl2-2.0-0
 
 env:
   global:

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -89,7 +89,7 @@ from contextlib import contextmanager
 import click
 
 supported_combinations = {
-    '3.6': {'pyqt', 'pyqt5', 'null'},
+    '3.6': {'pyqt', 'pyqt5', 'wx', 'null'},
 }
 
 dependencies = {
@@ -115,7 +115,8 @@ dependencies = {
 extra_dependencies = {
     'pyqt': {'pyqt'},
     'pyqt5': set(),
-    'wx': {'wxpython'},
+    # XXX once wxPython 4 is available in EDM, we will want it here
+    "wx": set(),
     'null': set()
 }
 
@@ -169,6 +170,20 @@ def install(runtime, toolkit, pillow, environment):
     # pip install pyqt5, because we don't have it in EDM yet
     if toolkit == 'pyqt5':
         commands.append("edm run -e {environment} -- pip install pyqt5==5.9.2")
+    elif toolkit == "wx":
+        if sys.platform == "darwin":
+            commands.append(
+                "edm run -e {environment} -- python -m pip install wxPython<4.1"  # noqa: E501
+            )
+        elif sys.platform == "linux":
+            # XXX this is mainly for TravisCI workers; need a generic solution
+            commands.append(
+                "edm run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04/ wxPython<4.1"  # noqa: E501
+            )
+        else:
+            commands.append(
+                "edm run -e {environment} -- python -m pip install wxPython"
+            )
 
     # No matter happens before, always install local source again or
     # we risk testing against an released enable.


### PR DESCRIPTION
This PR simply re-adds 'wx' to `supported_combinations` in edmtool.py.  Currently we still have a CI for wx and it is an allowed failure.  However, because wx is not in this list of supported_combinations, the CI just fails immediately with 
```
RuntimeError: Python 3.6, toolkit wx, and pillow pillow not supported by test environments
Command exited with code 1
```
without actually running any tests.  Even if they fail currently it is good for the tests to be exercised with CI to see if new failures are ever introduced.

Also, this PR lifts the installation pattern for wxPython 4 from pyface as it is not yet available in EDM.  