### PR TITLE
Use PyQt5 from EDM instead of PyPI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,18 @@ addons:
     - libpng-dev
     - libfreetype6-dev
     - libcairo2-dev
+    # Qt dependencies
     - libglu1-mesa-dev
+    - libxkbcommon-x11-0
+    - libxcb-icccm4
+    - libxcb-image0
+    - libxcb-keysyms1
+    - libxcb-randr0
+    - libxcb-render-util0
+    - libxcb-xinerama0
+    - pulseaudio
+    - libpulse-mainloop-glib0
+    # Wx dependencies
     - libsdl2-2.0-0
 
 env:

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -122,7 +122,7 @@ source_dependencies = {
 
 extra_dependencies = {
     'pyqt': {'pyqt'},
-    'pyqt5': set(),
+    'pyqt5': {'pyqt5'},
     # XXX once wxPython 4 is available in EDM, we will want it here
     "wx": set(),
     'null': set()
@@ -183,10 +183,7 @@ def install(runtime, toolkit, pillow, environment, source):
          " --no-dependencies"),
     ]
 
-    # pip install pyqt5, because we don't have it in EDM yet
-    if toolkit == 'pyqt5':
-        commands.append("edm run -e {environment} -- pip install pyqt5==5.9.2")
-    elif toolkit == "wx":
+    if toolkit == "wx":
         if sys.platform == "darwin":
             commands.append(
                 "edm run -e {environment} -- python -m pip install wxPython<4.1"  # noqa: E501


### PR DESCRIPTION
fixes #431 

This PR simply installs pyqt5 from edm instead of pip.