### PR TITLE
Add dclick option to test assistant

### DIFF
--- a/enable/testing.py
+++ b/enable/testing.py
@@ -169,8 +169,7 @@ class EnableTestAssistant(KivaTestAssistant):
         return event
 
     def mouse_down(self, interactor, x, y, button='left', window=None,
-                   alt_down=False, control_down=False, shift_down=False,
-                   dclick=False):
+                   alt_down=False, control_down=False, shift_down=False):
         """ Send a mouse button down event to the interactor.
 
         Parameters
@@ -203,8 +202,57 @@ class EnableTestAssistant(KivaTestAssistant):
             The button is pressed while `shift` is down. Default value is
             False.
 
-        dclick : boolean, optional
-            If True, 'dclick' event is dispatched instead of single mouse down
+        Returns
+        -------
+        event : MouseEvent
+            The event instance after it has be processed by the `interactor`.
+
+        """
+        window = self.create_mock_window() if window is None else window
+        event_attributes = {'x': x, 'y': y,
+                            'alt_down': alt_down,
+                            'control_down': control_down,
+                            'shift_down': shift_down,
+                            '{0}_down'.format(button): True,
+                            'window': window}
+        event = self.create_mouse_event(**event_attributes)
+        self._mouse_event_dispatch(interactor, event,
+                                   '{0}_down'.format(button))
+        return event
+
+    def mouse_dclick(self, interactor, x, y, button='left', window=None,
+                     alt_down=False, control_down=False, shift_down=False):
+        """ Send a mouse double-click event to the interactor.
+
+        Parameters
+        ----------
+        interactor : Interactor
+            The interactor (or subclass) where to dispatch the event.
+
+        x : float
+            The x coordinates of the mouse position
+
+        y : float
+            The y coordinates of the mouse position
+
+        button : {'left', 'right'}, optional
+            The mouse button for which to simulate a press (down) action.
+
+        window : AbstractWindow, optional
+            The enable AbstractWindow to associate with the event. Default
+            is to create a mock class instance. If the window has a mouse
+            owner then that interactor is used.
+
+        alt_down : boolean, optional
+            The button is pressed while `alt` is down. Default value is False.
+
+        control_down : boolean, optional
+            The button is pressed while `control` is down. Default value is
+            False.
+
+        shift_down : boolean, optional
+            The button is pressed while `shift` is down. Default value is
+            False.
 
         Returns
         -------
@@ -220,9 +268,8 @@ class EnableTestAssistant(KivaTestAssistant):
                             '{0}_down'.format(button): True,
                             'window': window}
         event = self.create_mouse_event(**event_attributes)
-        kind = 'dclick' if dclick else 'down'
         self._mouse_event_dispatch(interactor, event,
-                                   '{0}_{1}'.format(button, kind))
+                                   '{0}_dclick'.format(button))
         return event
 
     def mouse_move(self, interactor, x, y, window=None,

--- a/enable/testing.py
+++ b/enable/testing.py
@@ -169,7 +169,8 @@ class EnableTestAssistant(KivaTestAssistant):
         return event
 
     def mouse_down(self, interactor, x, y, button='left', window=None,
-                   alt_down=False, control_down=False, shift_down=False):
+                   alt_down=False, control_down=False, shift_down=False,
+                   dclick=False):
         """ Send a mouse button down event to the interactor.
 
         Parameters
@@ -202,6 +203,9 @@ class EnableTestAssistant(KivaTestAssistant):
             The button is pressed while `shift` is down. Default value is
             False.
 
+        dclick : boolean, optional
+            If True, 'dclick' event is dispatched instead of single mouse down
+
         Returns
         -------
         event : MouseEvent
@@ -216,8 +220,9 @@ class EnableTestAssistant(KivaTestAssistant):
                             '{0}_down'.format(button): True,
                             'window': window}
         event = self.create_mouse_event(**event_attributes)
+        kind = 'dclick' if dclick else 'down'
         self._mouse_event_dispatch(interactor, event,
-                                   '{0}_down'.format(button))
+                                   '{0}_{1}'.format(button, kind))
         return event
 
     def mouse_move(self, interactor, x, y, window=None,

--- a/enable/tests/test_assistant_test_case.py
+++ b/enable/tests/test_assistant_test_case.py
@@ -37,7 +37,7 @@ def test_mouse_dclick():
     test_assistant = EnableTestAssistant()
     component = Component(bounds=[100, 200])
     component.normal_left_dclick = mock.Mock()
-    test_assistant.mouse_down(component, x=0, y=0, dclick=True)
+    test_assistant.mouse_dclick(component, x=0, y=0)
     component.normal_left_dclick.assert_called_once()
 
 

--- a/enable/tests/test_assistant_test_case.py
+++ b/enable/tests/test_assistant_test_case.py
@@ -3,8 +3,9 @@ try:
 except ImportError:
     import mock
 import nose
+from unittest import skipIf
 
-from traitsui.tests._tools import skip_if_null
+from traitsui.tests._tools import is_null
 
 from enable.component import Component
 from enable.testing import EnableTestAssistant, _MockWindow
@@ -23,7 +24,24 @@ def test_mouse_move():
     assert not event.shift_down
     nose.tools.assert_equal(event.window.get_pointer_position(), (10, 20))
 
-@skip_if_null
+
+def test_mouse_down():
+    test_assistant = EnableTestAssistant()
+    component = Component(bounds=[100, 200])
+    component.normal_left_down = mock.Mock()
+    test_assistant.mouse_down(component, x=0, y=0)
+    component.normal_left_down.assert_called_once()
+
+
+def test_mouse_dclick():
+    test_assistant = EnableTestAssistant()
+    component = Component(bounds=[100, 200])
+    component.normal_left_dclick = mock.Mock()
+    test_assistant.mouse_down(component, x=0, y=0, dclick=True)
+    component.normal_left_dclick.assert_called_once()
+
+
+@skipIf(is_null(), "Test not working on the 'null' backend")
 def test_mouse_move_real_window():
     from enable.api import Window
 
@@ -42,7 +60,8 @@ def test_mouse_move_real_window():
     # can't test pointer position, not set, but if we get here it didn't
     # try to set the pointer position
 
-@skip_if_null
+
+@skipIf(is_null(), "Test not working on the 'null' backend")
 def test_mouse_move_real_window_mocked_position():
     from enable.api import Window
 
@@ -50,7 +69,7 @@ def test_mouse_move_real_window_mocked_position():
     component = Component(bounds=[100, 200])
 
     with mock.patch.object(Window, 'get_pointer_position',
-                            return_value=None):
+                           return_value=None):
         window = Window(None, component=component)
         event = test_assistant.mouse_move(component, 10, 20, window)
 

--- a/enable/tests/test_assistant_test_case.py
+++ b/enable/tests/test_assistant_test_case.py
@@ -5,7 +5,7 @@ except ImportError:
 import nose
 from unittest import skipIf
 
-from traitsui.tests._tools import is_null
+from traits.etsconfig.api import ETSConfig
 
 from enable.component import Component
 from enable.testing import EnableTestAssistant, _MockWindow
@@ -41,7 +41,7 @@ def test_mouse_dclick():
     component.normal_left_dclick.assert_called_once()
 
 
-@skipIf(is_null(), "Test not working on the 'null' backend")
+@skipIf(ETSConfig.toolkit == "null", "Skipping null tookit")
 def test_mouse_move_real_window():
     from enable.api import Window
 
@@ -61,7 +61,7 @@ def test_mouse_move_real_window():
     # try to set the pointer position
 
 
-@skipIf(is_null(), "Test not working on the 'null' backend")
+@skipIf(ETSConfig.toolkit == "null", "Skipping null tookit")
 def test_mouse_move_real_window_mocked_position():
     from enable.api import Window
 


### PR DESCRIPTION
- Adds `dclick` option to `EnableTestAssistant.mouse_down`
- Fixes import failure in associated test module
- Adds tests for `EnableTestAssistant.mouse_down`

Closes #438 