### PR TITLE
Fix test failures when run against TraitsUI 7.1.0

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -103,10 +103,8 @@ dependencies = {
     "pyparsing",
     "swig",
     "traits",
-    # Avoiding traitsui 7.1.0 for now due to private imports
-    # in test suite (see enthought/enable#425)
-    "traitsui==7.0.1-1",
-    "pyface==7.0.1-1",
+    "traitsui",
+    "pyface",
     "pypdf2",
     "swig",
     "unittest2",

--- a/enable/tests/_testing.py
+++ b/enable/tests/_testing.py
@@ -1,0 +1,61 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+""" This module contains utilities for testing within Enable.
+
+This is not a public module and should not to be used outside of Enable.
+"""
+import unittest
+
+from traits.etsconfig.api import ETSConfig
+
+
+def is_wx():
+    """ Return true if the toolkit backend is wx. """
+    return ETSConfig.toolkit == "wx"
+
+
+def is_qt():
+    """ Return true if the toolkit backend is Qt
+    (that includes Qt4 or Qt5, etc.)
+    """
+    return ETSConfig.toolkit.startswith("qt")
+
+
+def is_null():
+    """ Return true if the toolkit backend is null.
+    """
+    return ETSConfig.toolkit == "null"
+
+
+skip_if_null = unittest.skipIf(
+    is_null(),
+    "Test not working on the 'null' backend"
+)
+
+skip_if_not_qt = unittest.skipIf(not is_qt(), "Test only for qt")
+
+
+skip_if_not_wx = unittest.skipIf(not is_wx(), "Test only for wx")
+
+
+def get_dialog_size(ui_control):
+    """Return the size of the dialog.
+    Return a tuple (width, height) with the size of the dialog in pixels.
+    E.g.:
+        >>> get_dialog_size(ui.control)
+    """
+
+    if is_wx():
+        return ui_control.GetSize()
+
+    elif is_qt():
+        return ui_control.size().width(), ui_control.size().height()
+
+    raise RuntimeError("Unable to compute dialog size. Unknown toolkit.")

--- a/enable/tests/qt4/mouse_wheel_test_case.py
+++ b/enable/tests/qt4/mouse_wheel_test_case.py
@@ -2,7 +2,7 @@
 from unittest import TestCase
 
 from traits.api import Any
-from traitsui.tests._tools import skip_if_not_qt4
+from enable.tests._testing import skip_if_not_qt4
 
 from enable.container import Container
 from enable.base_tool import BaseTool

--- a/enable/tests/qt4/mouse_wheel_test_case.py
+++ b/enable/tests/qt4/mouse_wheel_test_case.py
@@ -2,7 +2,7 @@
 from unittest import TestCase
 
 from traits.api import Any
-from enable.tests._testing import skip_if_not_qt4
+from enable.tests._testing import skip_if_not_qt
 
 from enable.container import Container
 from enable.base_tool import BaseTool
@@ -19,7 +19,7 @@ class MouseEventTool(BaseTool):
         self.event = event
 
 
-@skip_if_not_qt4
+@skip_if_not_qt
 class MouseWheelTestCase(TestCase):
 
     def setUp(self):

--- a/enable/tests/qt4/scrollbar_test.py
+++ b/enable/tests/qt4/scrollbar_test.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 import unittest
 
-from enable.tests._testing import skip_if_not_qt4
+from enable.tests._testing import skip_if_not_qt
 from pyface.gui import GUI
 
 from enable.container import Container
@@ -13,7 +13,7 @@ except Exception:
     NativeScrollBar = None
 
 
-@skip_if_not_qt4
+@skip_if_not_qt
 class ScrollBarTest(unittest.TestCase):
 
     def setUp(self):

--- a/enable/tests/qt4/scrollbar_test.py
+++ b/enable/tests/qt4/scrollbar_test.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 import unittest
 
-from traitsui.tests._tools import skip_if_not_qt4
+from enable.tests._testing import skip_if_not_qt4
 from pyface.gui import GUI
 
 from enable.container import Container

--- a/enable/tests/test_assistant_test_case.py
+++ b/enable/tests/test_assistant_test_case.py
@@ -3,12 +3,10 @@ try:
 except ImportError:
     import mock
 import nose
-from unittest import skipIf
-
-from traits.etsconfig.api import ETSConfig
 
 from enable.component import Component
 from enable.testing import EnableTestAssistant, _MockWindow
+from enable.tests._testing import skip_if_null
 
 
 def test_mouse_move():
@@ -41,7 +39,7 @@ def test_mouse_dclick():
     component.normal_left_dclick.assert_called_once()
 
 
-@skipIf(ETSConfig.toolkit == "null", "Skipping null tookit")
+@skip_if_null
 def test_mouse_move_real_window():
     from enable.api import Window
 
@@ -61,7 +59,7 @@ def test_mouse_move_real_window():
     # try to set the pointer position
 
 
-@skipIf(ETSConfig.toolkit == "null", "Skipping null tookit")
+@skip_if_null
 def test_mouse_move_real_window_mocked_position():
     from enable.api import Window
 

--- a/enable/tests/test_component_editor.py
+++ b/enable/tests/test_component_editor.py
@@ -8,7 +8,7 @@ from traits.trait_types import Any
 from traitsui.item import Item
 from traitsui.view import View
 
-from traitsui.tests._tools import get_dialog_size, skip_if_null
+from enable.tests._testing import get_dialog_size, skip_if_null
 
 ITEM_WIDTH, ITEM_HEIGHT = 700, 200
 

--- a/enable/tests/tools/hover_tool_test_case.py
+++ b/enable/tests/tools/hover_tool_test_case.py
@@ -15,7 +15,7 @@ from enable.component import Component
 from enable.testing import EnableTestAssistant
 from enable.tools.hover_tool import HoverTool
 
-from traitsui.tests._tools import skip_if_null
+from enable.tests._testing import skip_if_null
 
 
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')

--- a/enable/tests/wx/mouse_wheel_test_case.py
+++ b/enable/tests/wx/mouse_wheel_test_case.py
@@ -7,7 +7,7 @@ except ImportError:
     from mock import MagicMock
 
 from traits.api import Any
-from traitsui.tests._tools import skip_if_not_wx
+from enable.tests._testing import skip_if_not_wx
 
 from enable.container import Container
 from enable.base_tool import BaseTool

--- a/kiva/tests/_testing.py
+++ b/kiva/tests/_testing.py
@@ -1,0 +1,25 @@
+# (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+""" This module contains utilities for testing within Kiva.
+
+This is not a public module and should not to be used outside of Kiva.
+"""
+
+import unittest
+
+from traits.etsconfig.api import ETSConfig
+
+
+def is_wx():
+    """ Return true if the toolkit backend is wx. """
+    return ETSConfig.toolkit == "wx"
+
+
+skip_if_not_wx = unittest.skipIf(not is_wx(), "Test only for wx")

--- a/kiva/tests/test_quartz.py
+++ b/kiva/tests/test_quartz.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import sys
 
-from traitsui.tests._tools import skip_if_not_wx
+from kiva.tests._testing import skip_if_not_wx
 
 
 def test_quartz_importable():


### PR DESCRIPTION
Fixes #425

This PR reimplemented a few trivial test utility functions to be used within Enable and Kiva such that tests no longer import from private modules of TraitsUI. See also #443 on to what extent enable/kiva should depend on Pyface/TraitsUI. Dependency is a worse enemy to repeating oneself. The test utilities are so simple that reimplementing them is a cheap cost to enable looser coupling among the packages. 