### PR TITLE
Remove some unnecessary empty return statements

### DIFF
--- a/enable/abstract_overlay.py
+++ b/enable/abstract_overlay.py
@@ -71,7 +71,6 @@ class AbstractOverlay(Component):
         for overlay in self.overlays:
             if overlay.visible or overlay.invisible_layout:
                 overlay.do_layout(component)
-        return
 
     def _draw(self, gc, view_bounds=None, mode="normal"):
         """ Draws the component, paying attention to **draw_order**.
@@ -80,7 +79,6 @@ class AbstractOverlay(Component):
         """
         if self.component is not None:
             self.overlay(self.component, gc, view_bounds, mode)
-        return
 
     def _request_redraw(self):
         """ Overrides Enable Component.
@@ -88,4 +86,3 @@ class AbstractOverlay(Component):
         if self.component is not None:
             self.component.request_redraw()
         super(AbstractOverlay, self)._request_redraw()
-        return

--- a/enable/abstract_window.py
+++ b/enable/abstract_window.py
@@ -139,7 +139,6 @@ class AbstractWindow(HasTraits):
             # Fixme: should use clip_to_rects
             update_union = sm.reduce(union_bounds, self._update_region)
             gc.clip_to_rect(*update_union)
-        return
 
     def _window_paint(self, event):
         "Do a GUI toolkit specific screen update"
@@ -179,7 +178,6 @@ class AbstractWindow(HasTraits):
         # Create a default component (if necessary):
         if self.component is None:
             self.component = Container()
-        return
 
     def _component_changed(self, old, new):
         if old is not None:
@@ -209,7 +207,6 @@ class AbstractWindow(HasTraits):
                     self.component.outer_height = size[1]
         self._update_region = None
         self.redraw()
-        return
 
     def component_bounds_changed(self, bounds):
         """
@@ -231,7 +228,6 @@ class AbstractWindow(HasTraits):
             self.mouse_owner = mouse_owner
             self.mouse_owner_transform = transform
             self.mouse_owner_dispatch_history = history
-        return
 
     def invalidate_draw(self, damaged_regions=None, self_relative=False):
         if damaged_regions is not None and self._update_region is not None \
@@ -424,7 +420,6 @@ class AbstractWindow(HasTraits):
     def redraw(self):
         """ Requests that the window be redrawn. """
         self._redraw()
-        return
 
     def cleanup(self):
         """ Clean up after ourselves.
@@ -480,7 +475,6 @@ class AbstractWindow(HasTraits):
         self._window_paint(event)
 
         self._update_region = []
-        return
 
     def __getstate__(self):
         attribs = ("component", "bgcolor", "overlay", "_scroll_origin")
@@ -548,8 +542,6 @@ class AbstractWindow(HasTraits):
             mouse_event = self._create_mouse_event(event)
             self._prev_event_handler.dispatch(mouse_event, "mouse_leave")
             self._prev_event_handler = None
-        return
-
 
     #---------------------------------------------------------------------------
     # Wire up the keyboard event handlers

--- a/enable/base.py
+++ b/enable/base.py
@@ -252,7 +252,6 @@ def subclasses_of ( klass ):
     for subclass in klass.__bases__:
         for result in subclasses_of( subclass ):
             yield result
-    return
 
 class IDroppedOnHandler:
     "Interface for draggable objects that handle the 'dropped_on' event"

--- a/enable/base_tool.py
+++ b/enable/base_tool.py
@@ -114,7 +114,6 @@ class BaseTool(Interactor):
             component = kwtraits["component"]
         super(BaseTool, self).__init__(**kwtraits)
         self.component = component
-        return
 
     def dispatch(self, event, suffix):
         """ Dispatches a mouse event based on the current event state.
@@ -122,7 +121,6 @@ class BaseTool(Interactor):
         Overrides enable.Interactor.
         """
         self._dispatch_stateful_event(event, suffix)
-        return
 
     def _dispatch_stateful_event(self, event, suffix):
         # Override the default enable.Interactor behavior of automatically
@@ -131,7 +129,6 @@ class BaseTool(Interactor):
         handler = getattr(self, self.event_state + "_" + suffix, None)
         if handler is not None:
             handler(event)
-        return
 
     #------------------------------------------------------------------------
     # Abstract methods that subclasses should implement
@@ -161,4 +158,3 @@ class BaseTool(Interactor):
         """
         # Compatibility with new AbstractController interface
         self._deactivate()
-        return

--- a/enable/canvas.py
+++ b/enable/canvas.py
@@ -135,7 +135,6 @@ class Canvas(Container):
         if not self.overlay_border and self.border_visible:
             # Tell _draw_border to ignore the self.overlay_border
             self._draw_border(gc, view_bounds, mode, force_draw=True)
-        return
 
     def _draw_underlay(self, gc, view_bounds=None, mode="default"):
         if self.draw_axes:

--- a/enable/compass.py
+++ b/enable/compass.py
@@ -109,7 +109,6 @@ class Compass(Component):
                 self.request_redraw()
                 break
         event.handled = True
-        return
 
     def normal_left_dclick(self, event):
         return self.normal_left_down(event)

--- a/enable/component.py
+++ b/enable/component.py
@@ -395,7 +395,6 @@ class Component(CoordinateBox, Interactor):
         else:
             super(Component, self).__init__(**traits)
             self._set_padding_traits(padding, padding_traits)
-        return
 
     def draw(self, gc, view_bounds=None, mode="default"):
         """ Draws the plot component.
@@ -425,7 +424,6 @@ class Component(CoordinateBox, Interactor):
             self.do_layout()
 
         self._draw(gc, view_bounds, mode)
-        return
 
     def draw_select_box(self, gc, position, bounds, width, dash,
                         inset, color, bgcolor, marker_size):
@@ -494,8 +492,6 @@ class Component(CoordinateBox, Interactor):
                             marker_size, marker_size)
                 gc.draw_path()
 
-        return
-
     def get_absolute_coords(self, *coords):
         """ Given coordinates relative to this component's origin, returns
         the "absolute" coordinates in the frame of the top-level parent
@@ -541,7 +537,6 @@ class Component(CoordinateBox, Interactor):
             view.request_redraw()
 
         self._request_redraw()
-        return
 
     def invalidate_draw(self, damaged_regions=None, self_relative=False):
         """ Invalidates any backbuffer that may exist, and notifies our parents
@@ -566,7 +561,6 @@ class Component(CoordinateBox, Interactor):
 
         if self._window is not None:
             self._window.invalidate_draw(damaged_regions=damaged_regions, self_relative=True)
-        return
 
     def invalidate_and_redraw(self):
         """Convenience method to invalidate our contents and request redraw"""
@@ -591,7 +585,6 @@ class Component(CoordinateBox, Interactor):
         """When a window viewing or containing a component is destroyed,
         cleanup is called on the component to give it the opportunity to
         delete any transient state it may have (such as backbuffers)."""
-        return
 
     def set_outer_position(self, ndx, val):
         """
@@ -604,7 +597,6 @@ class Component(CoordinateBox, Interactor):
             self.outer_x = val
         else:
             self.outer_y = val
-        return
 
     def set_outer_bounds(self, ndx, val):
         """
@@ -617,7 +609,6 @@ class Component(CoordinateBox, Interactor):
             self.outer_width = val
         else:
             self.outer_height = val
-        return
 
     #------------------------------------------------------------------------
     # Layout-related concrete methods
@@ -650,7 +641,6 @@ class Component(CoordinateBox, Interactor):
         for overlay in self.overlays:
             if overlay.visible or overlay.invisible_layout:
                 overlay.do_layout()
-        return
 
     def get_preferred_size(self):
         """ Returns the size (width,height) that is preferred for this component
@@ -696,7 +686,6 @@ class Component(CoordinateBox, Interactor):
             self.container.request_redraw()
         elif self._window:
             self._window.redraw()
-        return
 
     def _default_damaged_regions(self):
         """Returns the default damaged regions for this Component.  This consists
@@ -778,8 +767,6 @@ class Component(CoordinateBox, Interactor):
             for layer in self.draw_order:
                 self._dispatch_draw(layer, gc, view_bounds, mode)
 
-        return
-
     def _dispatch_draw(self, layer, gc, view_bounds, mode):
         """ Renders the named *layer* of this component.
 
@@ -797,7 +784,6 @@ class Component(CoordinateBox, Interactor):
         handler = getattr(self, "_draw_" + layer, None)
         if handler:
             handler(gc, view_bounds, mode)
-        return
 
     def _draw_border(self, gc, view_bounds=None, mode="default",
                      force_draw=False):
@@ -867,15 +853,12 @@ class Component(CoordinateBox, Interactor):
             # Tell _draw_border to ignore the self.overlay_border
             self._draw_border(gc, view_bounds, mode, force_draw=True)
 
-        return
-
     def _draw_overlay(self, gc, view_bounds=None, mode="normal"):
         """ Draws the overlay layer of a component.
         """
         for overlay in self.overlays:
             if overlay.visible:
                 overlay.overlay(self, gc, view_bounds, mode)
-        return
 
     def _draw_underlay(self, gc, view_bounds=None, mode="normal"):
         """ Draws the underlay layer of a component.
@@ -885,7 +868,6 @@ class Component(CoordinateBox, Interactor):
             # just overlays drawn at a different time in the rendering loop.
             if underlay.visible:
                 underlay.overlay(self, gc, view_bounds, mode)
-        return
 
     def _get_visible_border(self):
         """ Helper function to return the amount of border, if visible """
@@ -919,8 +901,6 @@ class Component(CoordinateBox, Interactor):
             self._old_dispatch(event, suffix)
         else:
             self._new_dispatch(event, suffix)
-        return
-
 
     def _new_dispatch(self, event, suffix):
         """ Dispatches a mouse event
@@ -972,8 +952,6 @@ class Component(CoordinateBox, Interactor):
         if not event.handled:
             for tool in self.tools:
                 tool.dispatch(event, suffix)
-
-        return
 
     def _old_dispatch(self, event, suffix):
         """ Dispatches a mouse event.
@@ -1028,7 +1006,6 @@ class Component(CoordinateBox, Interactor):
             tool._activate()
 
         self.invalidate_and_redraw()
-        return
 
     def _get_layout_needed(self):
         return self._layout_needed
@@ -1094,19 +1071,16 @@ class Component(CoordinateBox, Interactor):
         self.trait_set(bounds=[new_w, new_h], trait_change_notify=notify)
         if new_pos:
             self.trait_set(position=new_pos, trait_change_notify=notify)
-        return
 
     def _bounds_changed(self, old, new):
         self._enforce_aspect_ratio(notify=True)
         if self.container is not None:
             self.container._component_bounds_changed(self)
-        return
 
     def _bounds_items_changed(self, event):
         self._enforce_aspect_ratio(notify=True)
         if self.container is not None:
             self.container._component_bounds_changed(self)
-        return
 
     def _container_changed(self, old, new):
         # We don't notify our container of this change b/c the
@@ -1174,7 +1148,6 @@ class Component(CoordinateBox, Interactor):
             self.padding_top = val[2]
             self.padding_bottom = val[3]
             self.trait_property_changed("padding", old_padding, val)
-        return
 
     def _get_hpadding(self):
         return 2*self._get_visible_border() + self.padding_right + \

--- a/enable/component_editor.py
+++ b/enable/component_editor.py
@@ -59,7 +59,6 @@ class _ComponentEditor( Editor ):
         editor.
         """
         self._window.component = self.value
-        return
 
     def _get_initial_size(self):
         """ Compute the initial size of the component.

--- a/enable/container.py
+++ b/enable/container.py
@@ -107,7 +107,6 @@ class Container(Component):
         if 'intercept_events' in traits:
             warnings.warn("'intercept_events' is a deprecated trait",
                     warnings.DeprecationWarning)
-        return
 
     def add(self, *components):
         """ Adds components to this container """
@@ -170,7 +169,6 @@ class Container(Component):
         ndx = c.index(component)
         if len(c) > 1 and ndx != len(c) - 1:
             self._components = c[:ndx] + c[ndx+1:] + [component]
-        return
 
     def lower_component(self, component):
         """ Puts the indicated component to the very bottom of the Z-order """
@@ -183,7 +181,6 @@ class Container(Component):
         if self._components:
             for component in self._components:
                 component.cleanup(window)
-        return
 
     def compact(self):
         """
@@ -208,7 +205,6 @@ class Container(Component):
             self.position = [self.x + ll_x, self.y + ll_y]
 
         self.bounds = [ur_x - ll_x, ur_y - ll_y]
-        return
 
     #------------------------------------------------------------------------
     # Protected methods
@@ -281,8 +277,6 @@ class Container(Component):
             my_handler = getattr(self, "_draw_container_" + layer, None)
             if my_handler:
                 my_handler(gc, view_bounds, mode)
-
-        return
 
     def _draw_container(self, gc, mode="default"):
         "Draw the container background in a specified graphics context"
@@ -384,7 +378,6 @@ class Container(Component):
         warnings.warn("Containter._draw_overlays is deprecated.")
         for component in self.overlays:
             component.overlay(component, gc, view_bounds, mode)
-        return
 
     #------------------------------------------------------------------------
     # Property setters & getters
@@ -526,10 +519,6 @@ class Container(Component):
             if not event.handled:
                 self._container_handle_mouse_event(event, suffix)
 
-        return
-
-
-
     #------------------------------------------------------------------------
     # Event handlers
     #------------------------------------------------------------------------
@@ -540,7 +529,6 @@ class Container(Component):
             self.compact()
         else:
             pass
-        return
 
     def _window_resized(self, newsize):
         if newsize is not None:
@@ -556,7 +544,6 @@ class Container(Component):
                                              "resized", remove=True)
             else:
                 self._window.on_trait_change(self._window_resized, "resized")
-        return
 
     def _bounds_changed(self, old, new):
         # crappy... calling our parent's handler seems like a common traits
@@ -599,7 +586,6 @@ class Container(Component):
             self._draw_underlay(gc, view_bounds, mode)
             self._draw_children(gc, view_bounds, mode) #This was children_draw_mode
             self._draw_overlays(gc, view_bounds, mode)
-        return
 
     def _draw_children(self, gc, view_bounds=None, mode="normal"):
 
@@ -618,4 +604,3 @@ class Container(Component):
                         continue
                 with gc:
                     component.draw(gc, new_bounds, mode)
-        return

--- a/enable/coordinate_box.py
+++ b/enable/coordinate_box.py
@@ -150,14 +150,12 @@ class CoordinateBox(HasTraits):
 
     def _set_x(self, val):
         self.position[0] = val
-        return
 
     def _get_y(self):
         return self.position[1]
 
     def _set_y(self, val):
         self.position[1] = val
-        return
 
     def _get_width(self):
         return self.bounds[0]
@@ -173,7 +171,6 @@ class CoordinateBox(HasTraits):
         old_value = self.bounds[0]
         self.bounds[0] = val
         self.trait_property_changed('width', old_value, val)
-        return
 
     def _get_height(self):
         return self.bounds[1]
@@ -187,7 +184,6 @@ class CoordinateBox(HasTraits):
         old_value = self.bounds[1]
         self.bounds[1] = val
         self.trait_property_changed('height', old_value, val)
-        return
 
     def _get_x2(self):
         if self.bounds[0] == 0:
@@ -196,7 +192,6 @@ class CoordinateBox(HasTraits):
 
     def _set_x2(self, val):
         self.position[0] = val - self.bounds[0] + 1
-        return
 
     def _old_set_x2(self, val):
         new_width = val - self.position[0] + 1
@@ -204,7 +199,6 @@ class CoordinateBox(HasTraits):
             raise RuntimeError("Attempted to set negative component width.")
         else:
             self.bounds[0] = new_width
-        return
 
     def _get_y2(self):
         if self.bounds[1] == 0:
@@ -213,7 +207,6 @@ class CoordinateBox(HasTraits):
 
     def _set_y2(self, val):
         self.position[1] = val - self.bounds[1] + 1
-        return
 
     def _old_set_y2(self, val):
         new_height = val - self.position[1] + 1
@@ -221,7 +214,6 @@ class CoordinateBox(HasTraits):
             raise RuntimeError("Attempted to set negative component height.")
         else:
             self.bounds[1] = new_height
-        return
 
     if ENABLE_CONSTRAINTS:
 

--- a/enable/drawing/drag_box.py
+++ b/enable/drawing/drag_box.py
@@ -81,14 +81,10 @@ class DragBox(Box):
         self.start_y = event.y
         self._set_bounds(event)
 
-        return
-
     def normal_mouse_move (self, event):
         """ Handle the mouse moving in the 'normal' state. """
 
         self.pointer = self.normal_pointer
-
-        return
 
     #### 'drawing' state #####################################################
 
@@ -106,9 +102,6 @@ class DragBox(Box):
 
         self.complete = True
         self._set_bounds(event)
-
-        return
-
 
     ##########################################################################
     # Private interface

--- a/enable/drawing/drag_line.py
+++ b/enable/drawing/drag_line.py
@@ -28,7 +28,6 @@ class DragLine(DrawingTool):
         self.line.vertex_color = self.vertex_color
         self.line.points = []
         self.event_state = "normal"
-        return
 
     #------------------------------------------------------------------------
     # "complete" state
@@ -38,7 +37,6 @@ class DragLine(DrawingTool):
         """ Draw the completed line. """
         self.line.line_dash = None
         self.line._draw_mainlayer(gc)
-        return
 
     #------------------------------------------------------------------------
     # "drawing" state
@@ -47,7 +45,6 @@ class DragLine(DrawingTool):
     def drawing_draw(self, gc):
         self.line.line_dash = (4.0, 2.0)
         self.line._draw_mainlayer(gc)
-        return
 
     def drawing_left_up(self, event):
         """ Handle the left mouse button coming up in the 'drawing' state. """
@@ -56,7 +53,6 @@ class DragLine(DrawingTool):
         self.request_redraw()
         self.complete = True
         event.handled = True
-        return
 
     def drawing_mouse_move(self, event):
         """ Handle the mouse moving in 'drawing' state. """
@@ -65,7 +61,6 @@ class DragLine(DrawingTool):
         if last_point != (event.x + self.x, event.y - self.y):
             self.line.points.append((event.x + self.x, event.y - self.y))
             self.request_redraw()
-        return
 
     #------------------------------------------------------------------------
     # "normal" state
@@ -79,4 +74,3 @@ class DragLine(DrawingTool):
         event.window.set_pointer('pencil')
         event.handled = True
         self.request_redraw()
-        return

--- a/enable/drawing/drag_polygon.py
+++ b/enable/drawing/drag_polygon.py
@@ -49,7 +49,6 @@ class DragPolygon(DrawingTool):
         self.vertex_size = 0
         self.poly.model.points = []
         self.event_state = "normal"
-        return
 
     ###########################################################################
     # 'Component' interface.
@@ -62,13 +61,11 @@ class DragPolygon(DrawingTool):
         with gc:
             self.poly.border_dash = None
             self.poly._draw_closed(gc)
-        return
 
     def complete_left_down ( self, event ):
         """ Draw a new polygon. """
         self.reset()
         self.normal_left_down( event )
-        return
 
     def complete_right_down ( self, event ):
         """ Do the context menu if available. """
@@ -77,7 +74,6 @@ class DragPolygon(DrawingTool):
                 menu = self.menu.create_menu(event.window.control)
                 ### FIXME : The call to _flip_y is necessary but inappropriate.
                 menu.show(event.x, event.window._flip_y(event.y))
-        return
 
     #### 'drawing' state ######################################################
 
@@ -87,7 +83,6 @@ class DragPolygon(DrawingTool):
         with gc:
             self.poly.border_dash = (4.0, 2.0)
             self.poly._draw_open(gc)
-        return
 
     def drawing_left_up ( self, event ):
         """ Handle the left mouse button coming up in 'drawing' state. """
@@ -99,8 +94,6 @@ class DragPolygon(DrawingTool):
 
         self.complete = True
 
-        return
-
     def drawing_mouse_move ( self, event ):
         """ Handle the mouse moving in 'drawing' state. """
 
@@ -110,8 +103,6 @@ class DragPolygon(DrawingTool):
         if last_point != (event.x + self.x, event.y - self.y):
             self.poly.model.points.append((event.x + self.x, event.y - self.y))
             self.request_redraw()
-
-        return
 
     #### 'normal' state #######################################################
 
@@ -125,11 +116,7 @@ class DragPolygon(DrawingTool):
 
         self.request_redraw()
 
-        return
-
     def normal_mouse_move ( self, event ):
         """ Handle the mouse moving in the 'normal' state. """
 
         self.pointer = self.normal_pointer
-
-        return

--- a/enable/drawing/drag_segment.py
+++ b/enable/drawing/drag_segment.py
@@ -43,7 +43,6 @@ class DragSegment(DrawingTool):
         self.line.vertex_color = self.vertex_color
         self.line.points = []
         self.event_state = "normal"
-        return
 
     #------------------------------------------------------------------------
     # "complete" state
@@ -54,7 +53,6 @@ class DragSegment(DrawingTool):
         self.line.line_dash = None
         self.line._draw_mainlayer(gc)
         self.request_redraw()
-        return
 
     #------------------------------------------------------------------------
     # "drawing" state
@@ -63,7 +61,6 @@ class DragSegment(DrawingTool):
     def drawing_draw(self, gc):
         self.line.line_dash = (4.0, 2.0)
         self.line._draw_mainlayer(gc)
-        return
 
     def drawing_mouse_move(self, event):
         """ Handle the mouse moving in drawing state. """
@@ -71,7 +68,6 @@ class DragSegment(DrawingTool):
         self.line.points[-1] = (event.x, event.y)
         self.updated = self
         self.request_redraw()
-        return
 
     def drawing_left_up(self, event):
         """ Handle the left mouse button coming up in the 'drawing' state. """
@@ -79,7 +75,6 @@ class DragSegment(DrawingTool):
         event.window.set_pointer(self.complete_pointer)
         self.request_redraw()
         self.complete = True
-        return
 
     #------------------------------------------------------------------------
     # "normal" state
@@ -98,8 +93,6 @@ class DragSegment(DrawingTool):
         event.window.set_pointer(self.drawing_pointer)
 
         self.request_redraw()
-        return
 
     def normal_mouse_move(self, event):
         event.window.set_pointer(self.normal_pointer)
-        return

--- a/enable/drawing/drawing_canvas.py
+++ b/enable/drawing/drawing_canvas.py
@@ -48,7 +48,6 @@ class Button(Component):
             self.draw_up(gc, view_bounds)
         else:
             self.draw_down(gc, view_bounds)
-        return
 
     def draw_up(self, gc, view_bounds):
         with gc:
@@ -56,7 +55,6 @@ class Button(Component):
             gc.set_stroke_color(self.border_color_)
             gc.draw_rect((int(self.x), int(self.y), int(self.width)-1, int(self.height)-1), FILL_STROKE)
             self._draw_label(gc)
-        return
 
     def draw_down(self, gc, view_bounds):
         with gc:
@@ -64,7 +62,6 @@ class Button(Component):
             gc.set_stroke_color(self.border_color_)
             gc.draw_rect((int(self.x), int(self.y), int(self.width)-1, int(self.height)-1), FILL_STROKE)
             self._draw_label(gc, color=self.down_label_color_)
-        return
 
     def _draw_label(self, gc, color=None):
         if self.label != "":
@@ -76,14 +73,12 @@ class Button(Component):
             gc.set_stroke_color(color)
             gc.show_text(self.label, (self.x+(self.width-w-x)/2,
                                   self.y+(self.height-h-y)/2))
-        return
 
     def normal_left_down(self, event):
         self.button_state = "down"
         self._got_mousedown = True
         self.request_redraw()
         event.handled = True
-        return
 
     def normal_left_up(self, event):
         self.button_state = "up"
@@ -91,7 +86,6 @@ class Button(Component):
         self.request_redraw()
         self.perform(event)
         event.handled = True
-        return
 
 
 class ToolbarButton(Button):
@@ -106,7 +100,6 @@ class ToolbarButton(Button):
         if toolbar:
             self.toolbar = toolbar
             toolbar.add(self)
-        return
 
 
 class DrawingCanvasToolbar(Container):
@@ -134,7 +127,6 @@ class DrawingCanvasToolbar(Container):
             button.x = self.button_spacing + self._last_button_position
             self._last_button_position += button.width + self.button_spacing * 2
             button.y = int((self.height - button.height) / 2)
-        return
 
     def _canvas_changed(self, old, new):
         if old:
@@ -144,18 +136,14 @@ class DrawingCanvasToolbar(Container):
         if new:
             new.on_trait_change(self._canvas_bounds_changed, "bounds")
             new.on_trait_change(self._canvas_bounds_changed, "bounds_items")
-        return
 
     def _canvas_bounds_changed(self):
         self.width = self.canvas.width
         self.y = self.canvas.height - self.height
-        return
 
     def _dispatch_stateful_event(self, event, suffix):
         super(DrawingCanvasToolbar, self)._dispatch_stateful_event(event, suffix)
         event.handled = True
-        return
-
 
 
 class DrawingCanvas(Container):
@@ -200,7 +188,6 @@ class DrawingCanvas(Container):
             tool.dispatch(event, suffix)
 
         super(DrawingCanvas, self).dispatch(event, suffix)
-        return
 
     def activate(self, tool):
         """
@@ -208,7 +195,6 @@ class DrawingCanvas(Container):
         current active tool back into the list of tools.
         """
         self.active_tool = tool
-        return
 
     def _draw_container_mainlayer(self, gc, view_bounds=None, mode="default"):
         active_tool = self.active_tool
@@ -222,7 +208,6 @@ class DrawingCanvas(Container):
                 active_tool.draw(gc, view_bounds, mode)
 
             self.toolbar.draw(gc, view_bounds, mode)
-        return
 
     def _draw_container_background(self, gc, view_bounds=None, mode="default"):
         if self.bgcolor not in ("clear", "transparent", "none"):
@@ -230,7 +215,6 @@ class DrawingCanvas(Container):
                 gc.set_antialias(False)
                 gc.set_fill_color(self.bgcolor_)
                 gc.draw_rect((int(self.x), int(self.y), int(self.width)-1, int(self.height)-1), FILL)
-        return
 
     #------------------------------------------------------------------------
     # Event listeners
@@ -238,4 +222,3 @@ class DrawingCanvas(Container):
 
     def _tools_items_changed(self):
         self.request_redraw()
-        return

--- a/enable/drawing/drawing_tool.py
+++ b/enable/drawing/drawing_tool.py
@@ -38,13 +38,11 @@ class DrawingTool(Component):
         self.reset()
         self.request_redraw()
         self.normal_left_down(event)
-        return
 
     def _draw_mainlayer(self, gc, view_bounds, mode="default"):
         draw_func = getattr(self, self.event_state + "_draw", None)
         if draw_func:
             draw_func(gc)
-        return
 
     def request_redraw(self):
         if self.container is not None:
@@ -53,4 +51,3 @@ class DrawingTool(Component):
             self.canvas.request_redraw()
         else:
             pass
-        return

--- a/enable/drawing/point_line.py
+++ b/enable/drawing/point_line.py
@@ -35,7 +35,6 @@ class PointLine(DrawingTool):
     def add_point(self, point):
         """ Add the point. """
         self.line.points.append(point)
-        return
 
     def get_point(self, index):
         """ Get the point at the specified index. """
@@ -44,12 +43,10 @@ class PointLine(DrawingTool):
     def set_point(self, index, point):
         """ Set the point at the specified index to point. """
         self.line.points[index] = point
-        return
 
     def remove_point(self, index):
         """ Remove the point with the specified index. """
         del self.line.points[index]
-        return
 
     #------------------------------------------------------------------------
     # DrawingTool interface
@@ -58,7 +55,6 @@ class PointLine(DrawingTool):
     def reset(self):
         self.line.points = []
         self.event_state = "normal"
-        return
 
     #------------------------------------------------------------------------
     # "complete" state
@@ -69,7 +65,6 @@ class PointLine(DrawingTool):
         self.line.line_dash = None
         with gc:
             self.line._draw_mainlayer(gc)
-        return
 
     def complete_left_down(self, event):
         """ Handle the left mouse button going down in the 'complete' state. """
@@ -93,7 +88,6 @@ class PointLine(DrawingTool):
                     event.window.set_pointer(self.move_cursor)
                     self.event_state = 'drag_point'
                     self.request_redraw()
-        return
 
     def complete_mouse_move(self, event):
         """ Handle the mouse moving in the 'complete' state. """
@@ -108,7 +102,6 @@ class PointLine(DrawingTool):
             event.handled = False
             event.window.set_pointer(self.normal_cursor)
         self.request_redraw()
-        return
 
     #------------------------------------------------------------------------
     # "drag" state
@@ -117,13 +110,11 @@ class PointLine(DrawingTool):
     def drag_point_draw(self, gc):
         """ Draw the polygon in the 'drag_point' state. """
         self.line._draw_mainlayer(gc)
-        return
 
     def drag_point_left_up(self, event):
         """ Handle the left mouse coming up in the 'drag_point' state. """
         self.event_state = 'complete'
         self.updated = self
-        return
 
     def drag_point_mouse_move(self, event):
         """ Handle the mouse moving in the 'drag_point' state. """
@@ -133,7 +124,6 @@ class PointLine(DrawingTool):
         if dragged_point != (event.x, event.y):
             self.set_point(self._dragged, (event.x, event.y))
             self.request_redraw()
-        return
 
     #------------------------------------------------------------------------
     # "incomplete" state
@@ -145,7 +135,6 @@ class PointLine(DrawingTool):
             gc.set_fill_color((0, 0, 0, 0))
             gc.rect(50, 50, 100, 100)
         self.line._draw_mainlayer(gc)
-        return
 
     def incomplete_left_dclick(self, event):
         """ Handle a left double-click in the incomplete state. """
@@ -156,14 +145,12 @@ class PointLine(DrawingTool):
         self.event_state = 'complete'
         self.complete = True
         self.request_redraw()
-        return
 
     def incomplete_left_down(self, event):
         """ Handle the left mouse button coming up in incomplete state. """
         # Add the point.
         self.add_point((event.x, event.y))
         self.updated = self
-        return
 
     def incomplete_mouse_move(self, event):
         """ Handle the mouse moving in incomplete state. """
@@ -174,7 +161,6 @@ class PointLine(DrawingTool):
         if self.get_point(-1) != (event.x, event.y):
             self.set_point(-1, (event.x, event.y))
         self.request_redraw()
-        return
 
     #------------------------------------------------------------------------
     # "normal" state
@@ -191,12 +177,10 @@ class PointLine(DrawingTool):
         self.event_state = 'incomplete'
         self.updated = self
         self.line_dash = (4.0, 2.0)
-        return
 
     def normal_mouse_move(self, event):
         """ Handle the mouse moving in the 'normal' state. """
         event.window.set_pointer(self.drawing_cursor)
-        return
 
     #------------------------------------------------------------------------
     # Private interface

--- a/enable/drawing/point_polygon.py
+++ b/enable/drawing/point_polygon.py
@@ -24,7 +24,6 @@ class PointPolygon(DrawingTool):
     def reset(self):
         self.polygon.model.reset()
         self.event_state = "normal"
-        return
 
     #------------------------------------------------------------------------
     # "complete" state
@@ -34,7 +33,6 @@ class PointPolygon(DrawingTool):
         """ Draw a closed polygon. """
         self.polygon.border_dash = None
         self.polygon._draw_closed(gc)
-        return
 
     def complete_left_down(self, event):
         """ Handle the left mouse button coming up in the 'complete' state. """
@@ -57,7 +55,6 @@ class PointPolygon(DrawingTool):
                     self.event_state = 'drag_point'
 
                 self.request_redraw()
-        return
 
     def complete_mouse_move(self, event):
         """ Handle the mouse moving in the 'complete' state. """
@@ -73,7 +70,6 @@ class PointPolygon(DrawingTool):
             event.handled = False
             event.window.set_pointer('arrow')
         self.request_redraw()
-        return
 
     #------------------------------------------------------------------------
     # "drag_point" state
@@ -82,13 +78,11 @@ class PointPolygon(DrawingTool):
     def drag_point_draw(self, gc):
         """ Draw the polygon in the 'drag_point' state. """
         self.complete_draw(gc)
-        return
 
     def drag_point_left_up(self, event):
         """ Handle the left mouse coming up in the 'drag_point' state. """
         self.event_state = 'complete'
         self.request_redraw()
-        return
 
     def drag_point_mouse_move(self, event):
         """ Handle the mouse moving in the 'drag_point' state. """
@@ -101,7 +95,6 @@ class PointPolygon(DrawingTool):
             polygon.model.points[self._dragged] = \
                 (event.x + self.x, event.y - self.y)
             self.request_redraw()
-        return
 
     #------------------------------------------------------------------------
     # "incomplete" state
@@ -111,7 +104,6 @@ class PointPolygon(DrawingTool):
         """ Draw the polygon in the 'incomplete' state. """
         self.polygon.border_dash = (4.0, 2.0)
         self.polygon._draw_open(gc)
-        return
 
     def incomplete_left_dclick(self, event):
         """ Handle a left double-click in the incomplete state. """
@@ -124,7 +116,6 @@ class PointPolygon(DrawingTool):
         self.complete = True
 
         self.request_redraw()
-        return
 
     def incomplete_left_up(self, event):
         """ Handle the left mouse button coming up in incomplete state. """
@@ -141,7 +132,6 @@ class PointPolygon(DrawingTool):
             self.polygon.model.points.append((event.x + self.x, event.y - self.y))
 
         self.request_redraw()
-        return
 
     def incomplete_mouse_move(self, event):
         """ Handle the mouse moving in incomplete state. """
@@ -156,7 +146,6 @@ class PointPolygon(DrawingTool):
             self.polygon.model.points[-1] = (event.x + self.x, event.y - self.y)
 
         self.request_redraw()
-        return
 
     #------------------------------------------------------------------------
     # "normal" state
@@ -172,12 +161,10 @@ class PointPolygon(DrawingTool):
         self.polygon.model.points.append(pt)
         self.polygon.model.points.append(pt)
         self.event_state = 'incomplete'
-        return
 
     def normal_mouse_move(self, event):
         """ Handle the mouse moving in the 'normal' state. """
         event.window.set_pointer('pencil')
-        return
 
     #------------------------------------------------------------------------
     # private methods

--- a/enable/events.py
+++ b/enable/events.py
@@ -49,7 +49,6 @@ class BasicEvent(HasTraits):
         self.y = y
         if caller is not None:
             self.dispatch_history.append(caller)
-        return
 
     def pop(self, count=1, caller=None):
         """
@@ -64,7 +63,6 @@ class BasicEvent(HasTraits):
         if caller is not None:
             if caller == self.dispatch_history[-1]:
                 self.dispatch_history.pop()
-        return
 
     def offset_xy(self, origin_x, origin_y, caller=None):
         r"""
@@ -77,7 +75,6 @@ class BasicEvent(HasTraits):
         self.push_transform(affine.affine_from_translation(-origin_x, -origin_y))
         if caller is not None:
             self.dispatch_history.append(caller)
-        return
 
     def scale_xy(self, scale_x, scale_y, caller=None):
         """
@@ -93,7 +90,6 @@ class BasicEvent(HasTraits):
         self.push_transform(affine.affine_from_scale(1/scale_x, 1/scale_y))
         if caller is not None:
             self.dispatch_history.append(caller)
-        return
 
     def net_transform(self):
         """

--- a/enable/example_support.py
+++ b/enable/example_support.py
@@ -63,7 +63,6 @@ elif ETSConfig.toolkit == 'pyglet':
                     self.enable_win = window
                 else:
                     self.enable_win = None
-            return
 
         def _create_component(self):
             """ Create and return a component which is typically a

--- a/enable/graphics_context.py
+++ b/enable/graphics_context.py
@@ -30,7 +30,6 @@ class EnableGCMixin(object):
         if "window" in kwargs:
             self.window = kwargs.pop("window")
         super(EnableGCMixin, self).__init__(*args, **kwargs)
-        return
 
     def clip_to_rect(self, x, y, width, height):
         if getattr(self, "corner_pixel_origin", True):
@@ -44,7 +43,6 @@ class EnableGCMixin(object):
         self.clip_to_rect(*bounds)
         self.set_fill_color(color)
         self.draw_rect(bounds, FILL)
-        return
 
     def clear_clip_region(self, color, update_region):
         "Clip and clear a Kiva graphics context to a specified region and color"
@@ -56,7 +54,6 @@ class EnableGCMixin(object):
             self.begin_path()
             self.rect(*bounds)
         self.fill_path()
-        return
 
     def alpha(self, alpha):
         raise NotImplementedError(
@@ -79,7 +76,7 @@ class EnableGCMixin(object):
                     self.draw_image(image,(x0, y, idx, idy))
                     x0 += idx
                 y += idy
-        return
+
 
 # Define a GraphicsContextEnable that subclasses whatever the Kiva backend's
 # GraphicsContext is.

--- a/enable/interactor.py
+++ b/enable/interactor.py
@@ -110,4 +110,3 @@ class Interactor(HasTraits):
             handler(event)
             if self.auto_handle_event:
                 event.handled = True
-        return

--- a/enable/label.py
+++ b/enable/label.py
@@ -72,7 +72,6 @@ class Label(Component):
             kwtraits['text'] = text
         HasTraits.__init__(self, **kwtraits)
         self._bounding_box = [0,0]
-        return
 
     def _calc_line_positions(self, gc):
         if not self._position_cache_valid:
@@ -132,7 +131,6 @@ class Label(Component):
             self._line_ypos = y_pos
 
             self._position_cache_valid = True
-        return
 
     def get_width_height(self, gc):
         """ Returns the width and height of the label, in the rotated frame of
@@ -219,8 +217,6 @@ class Label(Component):
 
                 gc.show_text(line)
                 gc.translate_ctm(-x_offset, -y_offset)
-
-        return
 
     def _font_changed(self):
         self._position_cache_valid = False

--- a/enable/overlay_container.py
+++ b/enable/overlay_container.py
@@ -20,4 +20,3 @@ class OverlayContainer(Container):
         """ Actually performs a layout (called by do_layout()).
         """
         simple_container_do_layout(self)
-        return

--- a/enable/primitives/annotater.py
+++ b/enable/primitives/annotater.py
@@ -33,7 +33,6 @@ class Annotater(Component):
         self.window.mouse_owner = self
         self._cur_x, self._cur_y = event.x, event.y
         self._start_x, self._start_y = event.x, event.y
-        return
 
     def _left_up_changed(self, event):
         event.handled = True
@@ -45,7 +44,6 @@ class Annotater(Component):
                                abs(self._start_y - event.y))
         self._start_x = self._start_y = self._cur_x = self._cur_y = None
         self.redraw()
-        return
 
     def _mouse_move_changed(self, event):
         event.handled = True
@@ -55,7 +53,6 @@ class Annotater(Component):
             if (x != self._cur_x) or (y != self._cur_y):
                 self._cur_x, self._cur_y = x, y
                 self.redraw()
-        return
 
     #---------------------------------------------------------------------------
     # "Component" interface

--- a/enable/primitives/box.py
+++ b/enable/primitives/box.py
@@ -38,4 +38,3 @@ class Box(Component):
                     gc.set_stroke_color(border_color)
                     gc.set_line_width(bs)
                     gc.draw_rect((x + bsh, y + bsh, dx - bs, dy - bs), STROKE)
-        return

--- a/enable/primitives/line.py
+++ b/enable/primitives/line.py
@@ -53,7 +53,6 @@ class Line(Component):
         self.points = []
         self.event_state = 'normal'
         self.updated = self
-        return
 
     #--------------------------------------------------------------------------
     # 'Component' interface
@@ -82,8 +81,6 @@ class Line(Component):
                 # Draw the vertices.
                 self._draw_points(gc)
 
-        return
-
     #--------------------------------------------------------------------------
     # Private interface
     #--------------------------------------------------------------------------
@@ -109,4 +106,3 @@ class Line(Component):
                     for x, y in offset_points:
                         gc.draw_rect((x-offset, y-offset,
                                      self.vertex_size, self.vertex_size), FILL)
-        return

--- a/enable/primitives/polygon.py
+++ b/enable/primitives/polygon.py
@@ -23,7 +23,6 @@ class PolygonModel(HasTraits):
 
     def reset(self):
         self.points = []
-        return
 
 
 class Polygon(Component):
@@ -89,7 +88,6 @@ class Polygon(Component):
         "Reset the polygon to the initial state"
         self.model.reset()
         self.event_state = 'normal'
-        return
 
     #--------------------------------------------------------------------------
     # 'Component' interface
@@ -98,7 +96,6 @@ class Polygon(Component):
     def _draw_mainlayer(self, gc, view_bounds=None, mode="normal"):
         "Draw the component in the specified graphics context"
         self._draw_closed(gc)
-        return
 
     #--------------------------------------------------------------------------
     # Protected interface
@@ -148,8 +145,6 @@ class Polygon(Component):
             # Draw the vertices.
             self._draw_vertices(gc)
 
-        return
-
     def _draw_open ( self, gc ):
         "Draw this polygon as an open polygon"
 
@@ -170,7 +165,6 @@ class Polygon(Component):
 
             # Draw the vertices.
             self._draw_vertices(gc)
-        return
 
     def _draw_vertices(self, gc):
         "Draw the vertices of the polygon."
@@ -191,4 +185,3 @@ class Polygon(Component):
             for x, y in offset_points:
                 gc.draw_rect((x - offset, y - offset,
                              self.vertex_size, self.vertex_size), FILL)
-        return

--- a/enable/primitives/shape.py
+++ b/enable/primitives/shape.py
@@ -59,8 +59,6 @@ class Shape(Component):
 
         print('normal_key_pressed', event.character)
 
-        return
-
     def normal_left_down(self, event):
         """ Event handler. """
 
@@ -79,8 +77,6 @@ class Shape(Component):
             if len(siblings) > 1:
                 siblings.remove(self)
                 siblings.append(self)
-
-        return
 
     def moving_mouse_move(self, event):
         """ Event handler. """
@@ -105,8 +101,6 @@ class Shape(Component):
         self.position = [left, bottom]
         self.request_redraw()
 
-        return
-
     def moving_left_up(self, event):
         """ Event handler. """
 
@@ -117,14 +111,10 @@ class Shape(Component):
 
         self.request_redraw()
 
-        return
-
     def moving_mouse_leave(self, event):
         """ Event handler. """
 
         self.moving_left_up(event)
-
-        return
 
     ###########################################################################
     # 'Shape' interface
@@ -170,8 +160,6 @@ class Shape(Component):
             gc.set_text_position(x+(dx-tw)/2, y+(dy-th)/2)
 
             gc.show_text(self.text)
-
-        return
 
     def _get_fill_color(self, event_state):
         """ Return the fill color based on the event state. """

--- a/enable/pyglet_backend/window.py
+++ b/enable/pyglet_backend/window.py
@@ -46,7 +46,6 @@ class PygletMouseEvent(object):
             self.alt_pressed = bool(modifiers & key.MOD_ALT)
         else:
             self.shift_pressed = self.ctrl_pressed = self.alt_pressed = False
-        return
 
 
 class PygletWindow(window.Window):
@@ -309,8 +308,6 @@ class Window(AbstractWindow):
         if pos is not None:
             self.control.set_location(*pos)
 
-        return
-
     def _flip_y(self, y):
         """ Convert from a Kiva to a Pyglet y-coordinate.
         Since pyglet uses the same convention as Kiva, this is a no-op.
@@ -334,7 +331,6 @@ class Window(AbstractWindow):
             if "v" in component.resizable:
                 component.outer_y = 0
                 component.outer_height = height
-        return
 
     def _capture_mouse(self):
         "Capture all future mouse events"
@@ -439,7 +435,6 @@ class Window(AbstractWindow):
                           "Enable's Pyglet backend." % pointer)
             cursor = self.control.get_system_mouse_cursor(POINTER_MAP["arrow"])
             self.control.set_mouse_cursor(cursor)
-        return
 
     def set_timer_interval(self, component, interval):
         """ Set up or cancel a timer for a specified component.  To cancel the
@@ -474,7 +469,6 @@ class Window(AbstractWindow):
         self.component.draw(gc, view_bounds=(0, 0, size[0], size[1]))
         self._update_region = []
         #self.control.flip()
-        return
 
     def _window_paint(self, event):
         "Do a backend-specific screen update"

--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -348,7 +348,6 @@ class _Window(AbstractWindow):
         if result not in DRAG_RESULTS_MAP:
             raise RuntimeError("Unknown drag result '%s'" % result)
         self._drag_result = DRAG_RESULTS_MAP[result]
-        return
 
     def _capture_mouse ( self ):
         "Capture all future mouse events"

--- a/enable/qt4/scrollbar.py
+++ b/enable/qt4/scrollbar.py
@@ -119,7 +119,6 @@ class NativeScrollBar(Component):
             self._control.hide()
             self._control.deleteLater()
             self._control = None
-        return
 
     def __del__(self):
         # Pray that we do not participate in a cycle.
@@ -246,22 +245,18 @@ class NativeScrollBar(Component):
         self.scroll_position = max(min(self.scroll_position, high-page_size), low)
         self._scroll_updated = True
         self.request_redraw()
-        return
 
     def _range_items_changed(self):
         self._range_changed()
-        return
 
     def _mouse_wheel_changed(self, event):
         # FIXME: convert to Qt.
         event.handled  = True
         self.scroll_position += (event.mouse_wheel * self.range[3] * self.mouse_wheel_speed)
-        return
 
     def _scroll_position_changed(self):
         self._scroll_updated = True
         self.request_redraw()
-        return
 
     def _bounds_changed(self, old, new):
         super(NativeScrollBar, self)._bounds_changed(old, new)

--- a/enable/render_controllers.py
+++ b/enable/render_controllers.py
@@ -21,7 +21,6 @@ class RenderController(AbstractRenderController):
                 func = getattr(component, "_draw_" + layer, None)
                 if func:
                     func(gc, view_bounds, mode)
-        return
 
 
 class OldEnableRenderController(AbstractRenderController):
@@ -38,7 +37,6 @@ class OldEnableRenderController(AbstractRenderController):
         component._draw_background(gc, view_bounds, mode)
         component._draw(gc, view_bounds, mode)
         component._draw_border(gc, view_bounds, mode)
-        return
 
 
 class OldChacoRenderController(AbstractRenderController):
@@ -78,7 +76,6 @@ class OldChacoRenderController(AbstractRenderController):
 
                 else:
                     self._do_draw(component, gc, view_bounds, mode)
-        return
 
     def _do_draw(self, component, gc, view_bounds=None, mode="normal"):
         pass

--- a/enable/scrollbar.py
+++ b/enable/scrollbar.py
@@ -115,7 +115,6 @@ class ScrollBar ( Component ):
     def __low_set(self, low):
         ignore, high, page_size, line_size = self.range
         self.range =(low, high, page_size, line_size)
-        return
 
     def __high_get(self):
         return self.range[1]
@@ -151,7 +150,6 @@ class ScrollBar ( Component ):
         self._scrolling = self._zone = NO_SCROLL
         self._line_up_suffix = self._line_down_suffix = self._slider_suffix = ''
         self._style_changed(self.style)
-        return
 
     def _init_images(self):
         "One time initialization of the scrollbar images"
@@ -176,18 +174,15 @@ class ScrollBar ( Component ):
         h_width   = sm.reduce(lambda a, b: a + sb_image[b].width(),
                             [ 'aleft', 'aright' ], hs_width)
         h_height  = sb_image[ 'htrack' ].height()
-        return
 
     def _range_changed(self):
         "Handle any of the range elements values being changed"
         low, high, page_size, line_size = self.range
         self.position = max(min(self.position, high - page_size), low)
         self.redraw()
-        return
 
     def _position_changed(self):
         self.redraw()
-        return
 
     def _style_changed(self, style):
         "Handle the orientation style being changed"
@@ -203,7 +198,6 @@ class ScrollBar ( Component ):
             self.min_height     = self.max_height = h_height
             self.stretch_width  = 1.0
             self.stretch_height = 0.0
-        return
 
     def _draw(self, gc):
         "Draw the contents of the control"
@@ -212,7 +206,6 @@ class ScrollBar ( Component ):
                 self._draw_vertical(gc)
             else:
                 self._draw_horizontal(gc)
-        return
 
     def _draw_vertical(self, gc):
         "Draw a vertical scrollbar"
@@ -252,7 +245,6 @@ class ScrollBar ( Component ):
                                  (s_dy - vbottom_dy - vtop_dy - vmid_dy) / 2.0),
                                  dx, vmid_dy))
             self._info =(t_y, s_y, s_y + s_dy, u_y)
-        return
 
     def _draw_horizontal(self, gc):
         "Draw a horizontal scroll bar"
@@ -292,7 +284,6 @@ class ScrollBar ( Component ):
                                  (s_dx - hleft_dx - hright_dx - hmid_dx) / 2.0),
                                  y, hmid_dx, dy))
             self._info =(t_x, s_x, s_x + s_dx, r_x)
-        return
 
     def _get_zone(self, event):
         "Determine which scrollbar zone the mouse pointer is over"
@@ -320,7 +311,6 @@ class ScrollBar ( Component ):
                 return
             self.position = position
         setattr(self, self._event_name, True)
-        return
 
     def _set_zone_suffix(self, zone, suffix):
         "Set a particular zone's image suffix"
@@ -329,8 +319,6 @@ class ScrollBar ( Component ):
             if suffix_name != '':
                 setattr(self, suffix_name, suffix)
                 self.redraw()
-        return
-
 
     #---------------------------------------------------------------------------
     #  Handle mouse events:
@@ -360,11 +348,9 @@ class ScrollBar ( Component ):
                 self._scroll()
                 self._in_zone       = True
                 self.timer_interval = 0.5
-        return
 
     def _left_dclick_changed(self, event):
         self._left_down_changed(event)
-        return
 
     def _left_up_changed(self, event):
         event.handled = True
@@ -380,7 +366,6 @@ class ScrollBar ( Component ):
             if zone == NO_SCROLL:
                 self.window.mouse_owner = None
             self.scroll_done = True
-        return
 
     def _mouse_move_changed(self, event):
         event.handled = True
@@ -403,13 +388,11 @@ class ScrollBar ( Component ):
             self._set_zone_suffix(zone, '_over')
             self._zone = zone
             self.window.mouse_owner = [ self, None ][ zone == NO_SCROLL ]
-        return
 
     def _mouse_wheel_changed(self, event):
         "Scrolls when the mouse scroll wheel is spun"
         event.handled  = True
         self.position += (event.mouse_wheel * self.page_size) / 20
-        return
 
     def _timer_changed(self):
         "Handle timer events"
@@ -417,4 +400,3 @@ class ScrollBar ( Component ):
             self.timer_interval = 0.1
             if self._in_zone:
                 self._scroll()
-        return

--- a/enable/scrolled.py
+++ b/enable/scrolled.py
@@ -120,7 +120,6 @@ class Scrolled(Container):
         self.component = component
         Container.__init__( self, **traits )
         self._viewport_component_changed()
-        return
 
     def update_bounds(self):
         self._layout_needed = True
@@ -128,7 +127,6 @@ class Scrolled(Container):
             self._hsb._widget_moved = True
         if self._vsb is not None:
             self._vsb._widget_moved = True
-        return
 
     def sb_height(self):
         """ Returns the standard scroll bar height
@@ -166,7 +164,6 @@ class Scrolled(Container):
         self.update_from_viewport()
         self.request_redraw()
 
-
     #---------------------------------------------------------------------------
     # Trait event handlers
     #---------------------------------------------------------------------------
@@ -191,7 +188,6 @@ class Scrolled(Container):
                             viewport.view_bounds[ndx], ticksize) )
 
         return ranges
-
 
     def update_from_viewport(self):
         """ Repositions the scrollbars based on the current position/bounds of
@@ -224,49 +220,38 @@ class Scrolled(Container):
         if not self._hsb_generates_events:
             self._hsb_generates_events = True
 
-        return
-
     def _layout_and_draw(self):
         self._layout_needed = True
         self.request_redraw()
 
     def _component_position_changed(self, component):
         self._layout_needed = True
-        return
 
     def _bounds_changed_for_component(self):
         self._layout_needed = True
         self.update_from_viewport()
         self.request_redraw()
-        return
 
     def _bounds_items_changed_for_component(self):
         self.update_from_viewport()
-        return
 
     def _position_changed_for_component(self):
         self.update_from_viewport()
-        return
 
     def _position_items_changed_for_component(self):
         self.update_from_viewport()
-        return
 
     def _view_bounds_changed_for_viewport_component(self):
         self.update_from_viewport()
-        return
 
     def _view_bounds_items_changed_for_viewport_component(self):
         self.update_from_viewport()
-        return
 
     def _view_position_changed_for_viewport_component(self):
         self.update_from_viewport()
-        return
 
     def _view_position_items_changed_for_viewport_component(self):
         self.update_from_viewport()
-        return
 
     def _component_bounds_items_handler(self, object, event):
         if event.added != event.removed:
@@ -275,7 +260,6 @@ class Scrolled(Container):
     def _component_bounds_handler(self, object, name, old, new):
         if old == None or new == None or old[0] != new[0] or old[1] != new[1]:
             self.update_bounds()
-        return
 
     def _component_changed ( self, old, new ):
         if old is not None:
@@ -291,7 +275,6 @@ class Scrolled(Container):
         new.on_trait_change(self._component_bounds_handler, 'bounds')
         new.on_trait_change(self._component_bounds_items_handler, 'bounds_items')
         self._layout_needed = True
-        return
 
     def _bgcolor_changed ( self ):
         self._layout_and_draw()
@@ -320,11 +303,9 @@ class Scrolled(Container):
 
     def _alternate_vsb_changed(self, old, new):
         self._component_update(old, new)
-        return
 
     def _leftcomponent_changed(self, old, new):
         self._component_update(old, new)
-        return
 
     def _component_update(self, old, new):
         """ Generic function to manage adding and removing components """
@@ -332,7 +313,6 @@ class Scrolled(Container):
             self.remove(old)
         if new is not None:
             self.add(new)
-        return
 
     def _bounds_changed ( self, old, new ):
         Component._bounds_changed( self, old, new )
@@ -341,7 +321,6 @@ class Scrolled(Container):
     def _bounds_items_changed(self, event):
         Component._bounds_items_changed(self, event)
         self.update_bounds()
-
 
     #---------------------------------------------------------------------------
     # Protected methods
@@ -463,7 +442,6 @@ class Scrolled(Container):
             pass
 
         self._layout_needed = False
-        return
 
     def _release_sb ( self, sb ):
         if sb is not None:
@@ -495,7 +473,6 @@ class Scrolled(Container):
                 viewport.trait_setq(
                     view_position=[position, viewport.view_position[1]]
                 )
-        return
 
     def _handle_vertical_scroll(self, position):
         if self._sb_bounds_frozen:
@@ -512,7 +489,6 @@ class Scrolled(Container):
                 viewport.trait_setq(
                     view_position=[viewport.view_position[0], position]
                 )
-        return
 
     def _mouse_thumb_changed(self, object, attrname, event):
         if event == "down" and not self.continuous_drag_update:
@@ -561,7 +537,6 @@ class Scrolled(Container):
                     right_edge-left_edge, top_edge-bottom_edge)
             gc.stroke_path()
 
-
     #---------------------------------------------------------------------------
     # Mouse event handlers
     #---------------------------------------------------------------------------
@@ -578,7 +553,6 @@ class Scrolled(Container):
             elif self._vsb:
                 self._vsb._mouse_wheel_changed(event)
             event.handled = True
-        return
 
     #---------------------------------------------------------------------------
     # Persistence

--- a/enable/simple_layout.py
+++ b/enable/simple_layout.py
@@ -90,4 +90,3 @@ def simple_container_do_layout(container, components=None):
     # Tell all of our components to do a layout
     for component in components:
         component.do_layout()
-    return

--- a/enable/slider.py
+++ b/enable/slider.py
@@ -468,7 +468,6 @@ class Slider(Component):
 
         event.handled = True
         self.event_state = "dragging"
-        return
 
     def _mouse_released(self, event):
         self.event_state = "normal"
@@ -505,5 +504,3 @@ class Slider(Component):
                 self._cached_endcap_size = int(self.height * self._endcap_percent)
             else:
                 self._cached_endcap_size = int(self.width * self._endcap_percent)
-
-        return

--- a/enable/stacked_layout.py
+++ b/enable/stacked_layout.py
@@ -151,4 +151,3 @@ def stack_layout(container, components, align):
         component.outer_position = position
         component.outer_bounds = bounds
         component.do_layout()
-    return

--- a/enable/tests/component_test_case.py
+++ b/enable/tests/component_test_case.py
@@ -10,7 +10,6 @@ class ComponentTestCase(unittest.TestCase):
         self.assertTrue(c.position[1] == c.y)
         self.assertTrue(c.x == 0.0)
         self.assertTrue(c.y == 0.0)
-        return
 
     def test_bounds(self):
         c = Component(bounds=[50.0, 60.0])
@@ -20,7 +19,6 @@ class ComponentTestCase(unittest.TestCase):
         self.assertTrue(c.bounds[1] == 60.0)
         self.assertTrue(c.x2 == c.x + 50.0 - 1)
         self.assertTrue(c.y2 == c.y + 60.0 - 1)
-        return
 
     def test_get_outer_position(self):
         c = Component(bounds=[50.0, 60.0], padding=10, border_visible=False)
@@ -34,7 +32,6 @@ class ComponentTestCase(unittest.TestCase):
         self.assertTrue(c.outer_height == 80)
         self.assertTrue(c.outer_bounds[0] == 70)
         self.assertTrue(c.outer_bounds[1] == 80)
-        return
 
     def test_set_outer_position(self):
         c = Component(bounds=[50.0, 60.0], padding=10, border_visible=False)
@@ -60,8 +57,6 @@ class ComponentTestCase(unittest.TestCase):
         self.assertTrue(c.y2 == 89)
         self.assertTrue(c.y == 30)
 
-        return
-
     def test_border(self):
         c = Component(bounds=[50.0, 60.0],
                       position=[20, 20],
@@ -70,12 +65,11 @@ class ComponentTestCase(unittest.TestCase):
         self.assertTrue(c.outer_y == 10)
         self.assertTrue(c.outer_bounds[0] == 70)
         self.assertTrue(c.outer_bounds[1] == 80)
-        return
 
     def check_container(self):
         c = Component()
         self.assertTrue(c.container is None)
-        return
+
 
 if __name__ == "__main__":
     import nose

--- a/enable/tests/container_test_case.py
+++ b/enable/tests/container_test_case.py
@@ -12,7 +12,6 @@ class EnableUnitTest(unittest.TestCase):
         """
         for dim, val in dims.items():
             self.assertTrue( getattr(obj, dim) == val )
-        return
 
 
 class ContainerTestCase(EnableUnitTest):
@@ -49,7 +48,6 @@ class ContainerTestCase(EnableUnitTest):
         container.remove(components[0])
         container.remove(components[0])
         self.assertTrue(len(container.components) == 0)
-        return
 
     def test_position(self):
         container = self.create_simple_components()
@@ -57,12 +55,10 @@ class ContainerTestCase(EnableUnitTest):
         self.assertTrue(components[0].position == [20,10])
         self.assertTrue(components[1].position == [40,10])
         self.assertTrue(components[2].position == [60,10])
-        return
 
     def test_position_bounds(self):
         container = Container(bounds=[100.0, 100.0])
         self.assert_dims(container, x=0.0, y=0.0, width=100.0, height=100.0)
-        return
 
     def test_auto_size(self):
         container = Container(bounds=[100.0, 100.0])
@@ -91,7 +87,6 @@ class ContainerTestCase(EnableUnitTest):
         # Delete the second component
         container.remove(c2)
         self.assert_dims(container, x=10.0, y=10.0, width=49.0, height=59.0)
-        return
 
 
 if __name__ == "__main__":

--- a/enable/tests/coordinate_box_test_case.py
+++ b/enable/tests/coordinate_box_test_case.py
@@ -9,7 +9,6 @@ class CoordinateBoxTestCase(unittest.TestCase):
         self.assertTrue(c.position[1] == c.y)
         self.assertTrue(c.x == 0.0)
         self.assertTrue(c.y == 0.0)
-        return
 
     def check_bounds(self):
         c = CoordinateBox(bounds=[50.0, 60.0])
@@ -19,7 +18,6 @@ class CoordinateBoxTestCase(unittest.TestCase):
         self.assertTrue(c.bounds[1] == 60.0)
         self.assertTrue(c.x2 == 49.0)
         self.assertTrue(c.y2 == 59.0)
-        return
 
     def check_is_in(self):
         c = CoordinateBox(x=10, y=20)
@@ -30,7 +28,7 @@ class CoordinateBoxTestCase(unittest.TestCase):
         self.assertTrue(c.is_in(15, 50))
         self.assertTrue(not c.is_in(0, 0))
         self.assertTrue(not c.is_in(10, 10))
-        return
+
 
 if __name__ == "__main__":
     import nose

--- a/enable/tests/event_transform_test_case.py
+++ b/enable/tests/event_transform_test_case.py
@@ -21,7 +21,6 @@ class EnableUnitTest(unittest.TestCase):
         """
         for dim, val in dims.items():
             self.assertTrue( getattr(obj, dim) == val )
-        return
 
 class TestComponent(Component):
     """ A component used for testing event handling.  Most notably, it
@@ -100,7 +99,6 @@ class EventTransformTestCase(EnableUnitTest):
         self.assertTrue(comp.last_event.y == 55)
         self.assertTrue(inner_container.last_event.x == 105)
         self.assertTrue(inner_container.last_event.y == 105)
-        return
 
     def test_viewport_container(self):
         """ Tests event handling of viewports (scaling and translation) """
@@ -148,7 +146,6 @@ class EventTransformTestCase(EnableUnitTest):
         self.assertTrue(container.last_event.y == 75)
         self.assertTrue(comp.last_event.x == 25)
         self.assertTrue(comp.last_event.y == 25)
-        return
 
     def test_mouse_capture(self):
         """ Tests saving the event's net_transform as well as the dispatch
@@ -186,8 +183,6 @@ class EventTransformTestCase(EnableUnitTest):
         new_pos = comp.captured_event_pos
         self.assertTrue(new_pos[0] == old_pos[0] + 2)
         self.assertTrue(new_pos[1] == old_pos[1] + 2)
-
-        return
 
 
 if __name__ == "__main__":

--- a/enable/text_field_grid.py
+++ b/enable/text_field_grid.py
@@ -98,7 +98,6 @@ class TextFieldGrid(Container):
             gc.line_to(x, self.y + self.height)
             gc.stroke_path()
             x = x + self.cell_padding + self.cell_width
-        return
 
     def _position_cells(self):
         y = 0

--- a/enable/text_grid.py
+++ b/enable/text_grid.py
@@ -89,7 +89,6 @@ class TextGrid(Component):
     def __init__(self, **kwtraits):
         super(Component, self).__init__(**kwtraits)
         self.selected_cells = []
-        return
 
     #------------------------------------------------------------------------
     # AbstractComponent interface
@@ -143,8 +142,6 @@ class TextGrid(Component):
                         gc.set_text_position(x, y)
                         gc.show_text(text)
 
-        return
-
     #------------------------------------------------------------------------
     # Private methods
     #------------------------------------------------------------------------
@@ -169,7 +166,6 @@ class TextGrid(Component):
             gc.move_to(self.x, y)
             gc.line_to(self.x+self.width, y)
             gc.stroke_path()
-        return
 
     def _compute_cell_sizes(self):
         if not self._cache_valid:
@@ -193,7 +189,6 @@ class TextGrid(Component):
             self._cached_cell_size = (max_w, max_h)
             self._text_offset = array([-min_l, -min_d])
             self._cache_valid = True
-        return
 
     def _compute_positions(self):
 
@@ -215,7 +210,6 @@ class TextGrid(Component):
         # We have to reverse the y-axis (e.g. the 0th row needs to be at the
         # highest y-position).
         self._cached_cell_coords = tmp[:,::-1]
-        return
 
     def _update_bounds(self):
         if self.string_array is not None and len(self.string_array.shape) == 2:

--- a/enable/tools/drag_tool.py
+++ b/enable/tools/drag_tool.py
@@ -126,7 +126,6 @@ class DragTool(BaseTool):
             BaseTool._dispatch_stateful_event(self, event, suffix)
         else:
             event.handled = True
-        return
 
     def _cancel_drag(self, event):
         self._drag_state = "nondrag"

--- a/enable/tools/move_tool.py
+++ b/enable/tools/move_tool.py
@@ -35,7 +35,6 @@ class MoveTool(DragTool):
                 self.component.container.raise_component(self.component)
             event.window.set_mouse_owner(self, event.net_transform())
             event.handled = True
-        return
 
     def dragging(self, event):
         if self.component:
@@ -47,6 +46,3 @@ class MoveTool(DragTool):
             self.component.request_redraw()
             self._prev_pos = (event.x, event.y)
             event.handled = True
-        return
-
-

--- a/enable/tools/toolbars/toolbar_buttons.py
+++ b/enable/tools/toolbars/toolbar_buttons.py
@@ -55,19 +55,16 @@ class Button(Component):
             self.draw_up(gc, view_bounds)
         else:
             self.draw_down(gc, view_bounds)
-        return
 
     def draw_up(self, gc, view_bounds):
         with gc:
             gc.set_fill_color(self.color_)
             self._draw_actual_button(gc)
-        return
 
     def draw_down(self, gc, view_bounds):
         with gc:
             gc.set_fill_color(self.down_color_)
             self._draw_actual_button(gc)
-        return
 
     def _draw_actual_button(self, gc):
         gc.set_stroke_color(self.border_color_)
@@ -114,20 +111,16 @@ class Button(Component):
             y_pos = self.y + (self.height-h-y)/2 + text_offset
             gc.show_text_at_point(self.label, x_pos, y_pos)
 
-        return
-
     def normal_left_down(self, event):
         self.button_state = "down"
         self.request_redraw()
         event.handled = True
-        return
 
     def normal_left_up(self, event):
         self.button_state = "up"
         self.request_redraw()
         self.perform(event)
         event.handled = True
-        return
 
     def _recompute_font_metrics(self):
         if self.label != "":
@@ -148,4 +141,3 @@ class SampleButtonButton(Button):
 
     def perform(self, event):
         print("this button is a sample")
-        return

--- a/enable/tools/toolbars/viewport_toolbar.py
+++ b/enable/tools/toolbars/viewport_toolbar.py
@@ -78,13 +78,11 @@ class ViewportToolbar(Container, AbstractOverlay):
         with gc:
             gc.clip_to_rect(c.x, c.y, c.width, c.height)
             Container._draw(self, gc, view_bounds)
-        return
 
     def add_button(self, button):
         self.add(button)
         button.toolbar_overlay = self
         self._layout_needed = True
-        return
 
 
 class HoverToolbar(ViewportToolbar):
@@ -97,11 +95,8 @@ class HoverToolbar(ViewportToolbar):
         if not event.handled:
             if self.is_in(event.x, event.y):
                 event.handled = True
-        return
 
     def _container_handle_mouse_event(self, event, suffix):
         if not self.is_in(event.x, event.y) and self.component.auto_hide:
             self.component.remove_toolbar()
             self.component.request_redraw()
-        return
-

--- a/enable/tools/traits_tool.py
+++ b/enable/tools/traits_tool.py
@@ -102,4 +102,3 @@ class TraitsTool(BaseTool):
             event.handled = True
             self.component.active_tool = None
             item.request_redraw()
-        return

--- a/enable/tools/viewport_pan_tool.py
+++ b/enable/tools/viewport_pan_tool.py
@@ -62,7 +62,6 @@ class ViewportPanTool(DragTool):
         event.window.set_pointer(self.drag_pointer)
         event.window.set_mouse_owner(self, event.net_transform())
         event.handled = True
-        return
 
     def dragging(self, event):
         """ Handles the mouse being moved when the tool is in the 'panning'
@@ -96,7 +95,6 @@ class ViewportPanTool(DragTool):
 
         self._original_xy = (event.x, event.y)
         self.component.request_redraw()
-        return
 
     def drag_end(self, event):
         if self._auto_constrain:
@@ -106,4 +104,3 @@ class ViewportPanTool(DragTool):
         if event.window.mouse_owner == self:
             event.window.set_mouse_owner(None)
         event.handled = True
-        return

--- a/enable/tools/viewport_zoom_tool.py
+++ b/enable/tools/viewport_zoom_tool.py
@@ -150,7 +150,6 @@ class ViewportZoomTool(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         else:
             self._orig_position = self.component.view_position
             self._orig_bounds = self.component.view_bounds
-        return
 
     def enable(self, event=None):
         """ Provides a programmatic way to enable this tool, if
@@ -164,7 +163,6 @@ class ViewportZoomTool(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         self._enabled = True
         if event and event.window:
             event.window.set_pointer(self.pointer)
-        return
 
     def disable(self, event=None):
         """ Provides a programmatic way to enable this tool, if **always_on**
@@ -179,7 +177,6 @@ class ViewportZoomTool(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
             self.component.active_tool = None
         if event and event.window:
             event.window.set_pointer("arrow")
-        return
 
     def reset(self, event=None):
         """ Resets the tool to normal state, with no start or end position.
@@ -206,7 +203,6 @@ class ViewportZoomTool(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
             # interfere with.
             if self.drag_button == "left":
                 self._start_select(event)
-        return
 
     def normal_right_down(self, event):
         """ Handles the right mouse button being pressed while the tool is
@@ -217,7 +213,6 @@ class ViewportZoomTool(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         if self.always_on or self._enabled:
             if self.drag_button == "right":
                 self._start_select(event)
-        return
 
     def normal_mouse_wheel(self, event):
         """ Handles the mouse wheel being used when the tool is in the 'normal'
@@ -260,11 +255,9 @@ class ViewportZoomTool(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
 
             event.handled = True
             self.component.request_redraw()
-        return
 
     def _component_changed(self):
         self._reset_state_to_current()
-        return
 
     #------------------------------------------------------------------------
     # Implementation of PlotComponent interface

--- a/enable/viewable.py
+++ b/enable/viewable.py
@@ -16,7 +16,6 @@ class Viewable(HasTraits):
     def request_redraw(self):
         # This overrides the default Component request_redraw by asking
         # all of the views to redraw themselves.
-        return
 
     def draw(self, gc, view_bounds=None, mode="default"):
         if len(self.viewports) > 0:
@@ -24,4 +23,3 @@ class Viewable(HasTraits):
                 view.draw(gc, view_bounds, mode)
         else:
             super(Viewable, self).draw(gc, view_bounds, mode)
-        return

--- a/enable/viewable.py
+++ b/enable/viewable.py
@@ -16,6 +16,7 @@ class Viewable(HasTraits):
     def request_redraw(self):
         # This overrides the default Component request_redraw by asking
         # all of the views to redraw themselves.
+        return
 
     def draw(self, gc, view_bounds=None, mode="default"):
         if len(self.viewports) > 0:

--- a/enable/viewport.py
+++ b/enable/viewport.py
@@ -124,7 +124,6 @@ class Viewport(Component):
                                 region[2], region[3]] for region in damaged_regions]
         super(Viewport, self).invalidate_draw(damaged_regions=damaged_regions,
                                               self_relative=self_relative)
-        return
 
     def cleanup(self, window):
         """When a window viewing or containing a component is destroyed,
@@ -238,8 +237,6 @@ class Viewport(Component):
                                       clipped_view[2] / self.zoom, clipped_view[3] / self.zoom)
                         self.component.draw(gc, new_bounds, mode=mode)
 
-        return
-
     def _do_layout(self):
         if self.initiate_layout:
             self.component.bounds = list(self.component.get_preferred_size())
@@ -247,7 +244,6 @@ class Viewport(Component):
 
         else:
             super(Viewport, self)._do_layout()
-        return
 
     def _dispatch_stateful_event(self, event, suffix):
         if isinstance(self.component, Component):
@@ -257,9 +253,6 @@ class Viewport(Component):
                 self.component.dispatch(event, suffix)
             finally:
                 event.pop(caller=self)
-
-        return
-
 
     #------------------------------------------------------------------------
     # Event handlers
@@ -290,7 +283,6 @@ class Viewport(Component):
             self.component.view_bounds = (llx, lly,
                                           llx + self.view_bounds[0]-1,
                                           lly + self.view_bounds[1]-1)
-        return
 
     def _component_changed(self, old, new):
         if (old is not None) and (self in old.viewports):

--- a/enable/vtk_backend/vtk_window.py
+++ b/enable/vtk_backend/vtk_window.py
@@ -219,7 +219,6 @@ class EnableVTKWindow(AbstractWindow, CoordinateBox):
             meth()
         else:
             warnings.warn("Unable to pass through mouse event '%s' to vtkInteractionStyle" % eventname)
-        return
 
     def _vtk_mouse_button_event(self, vtk_obj, eventname):
         """ Dispatces to self._handle_mouse_event """
@@ -530,7 +529,6 @@ class EnableVTKWindow(AbstractWindow, CoordinateBox):
             self.padding_top = val[2]
             self.padding_bottom = val[3]
             self.trait_property_changed("padding", old_padding, val)
-        return
 
     def _get_hpadding(self):
         return 2*self._get_visible_border() + self.padding_right + \

--- a/enable/wx/base_window.py
+++ b/enable/wx/base_window.py
@@ -55,7 +55,6 @@ class EnableTimer ( wx.Timer ):
     def __init__ ( self ):
         wx.Timer.__init__( self )
         self._work_list = []
-        return
 
     def schedule ( self, component, interval ):
         "Schedule a timer event for a specified component"
@@ -67,7 +66,6 @@ class EnableTimer ( wx.Timer ):
                 del work_list[i]
                 break
         self.reschedule( component, interval )
-        return
 
     def reschedule ( self, component, interval ):
         "Reshedule a recurring timer event for a component"
@@ -80,7 +78,6 @@ class EnableTimer ( wx.Timer ):
                 break
         else:
             work_list.append( new_item )
-        return
 
     def cancel ( self, component ):
         "Cancel any pending timer events for a component"
@@ -107,7 +104,6 @@ class EnableTimer ( wx.Timer ):
             for component, interval, ignore in reschedule:
                 self.reschedule( component, interval )
                 component.timer = True
-        return
 
 
 class LessSuckyDropTarget(PythonDropTarget):
@@ -213,8 +209,6 @@ class BaseWindow(AbstractWindow):
         # here to initialize our bounds.
         self._on_size(None)
 
-        return
-
     def _create_control(self, parent, wid, pos=wx.DefaultPosition, size=wx.DefaultSize):
         if parent is None:
             # pab hack in order to avoid that the wx.Window crash!
@@ -252,7 +246,6 @@ class BaseWindow(AbstractWindow):
             self.component.parent = None
             self.component.window = None
             self.component = None
-        return
 
     def _flip_y ( self, y ):
         "Convert from a Kiva to a wxPython y coordinate"
@@ -282,21 +275,18 @@ class BaseWindow(AbstractWindow):
                 self.component.outer_height = dy
 
         self.control.Refresh()
-        return
 
     def _capture_mouse ( self ):
         "Capture all future mouse events"
         if not self._mouse_captured:
             self._mouse_captured = True
             self.control.CaptureMouse()
-        return
 
     def _release_mouse ( self ):
         "Release the mouse capture"
         if self._mouse_captured:
             self._mouse_captured = False
             self.control.ReleaseMouse()
-        return
 
     def _on_key_pressed(self, event):
         handled = self._handle_key_event('key_pressed', event)
@@ -420,7 +410,6 @@ class BaseWindow(AbstractWindow):
             rect.SetHeight( int( yt - yb ) )
             if self.control:
                 self.control.Refresh(False, rect)
-        return
 
     def _get_control_size ( self ):
         "Get the size of the underlying toolkit control"
@@ -439,14 +428,12 @@ class BaseWindow(AbstractWindow):
         if type( ptr ) is int:
             POINTER_MAP[ pointer ] = ptr = wx.StockCursor( ptr )
         self.control.SetCursor( ptr )
-        return
 
     def set_tooltip ( self, tooltip ):
         "Set the current tooltip for the window"
         wx.ToolTip_Enable( False )
         self.control.SetToolTip( wx.ToolTip( tooltip ) )
         wx.ToolTip_Enable( True )
-        return
 
     def set_timer_interval ( self, component, interval ):
         """ Set up or cancel a timer for a specified component.  To cancel the
@@ -460,12 +447,10 @@ class BaseWindow(AbstractWindow):
             if system_timer is None:
                 system_timer = EnableTimer()
             system_timer.schedule( component, interval )
-        return
 
     def _set_focus ( self ):
         "Sets the keyboard focus to this window"
         self.control.SetFocus()
-        return
 
     def screen_to_window(self, x, y):
         pt = wx.Point(x,y)
@@ -482,7 +467,6 @@ class BaseWindow(AbstractWindow):
         if result not in DRAG_RESULTS_MAP:
             raise RuntimeError("Unknown drag result '%s'" % result)
         self._drag_result = DRAG_RESULTS_MAP[result]
-        return
 
     def wx_dropped_on ( self, x, y, drag_object, drop_result ):
         "Handle wxPython drag and drop events"
@@ -525,7 +509,6 @@ class BaseWindow(AbstractWindow):
                                      start_event = default_start_event,
                                      window = self )
         self.component.dispatch(drag_leave_event, "drag_leave")
-        return
 
     def create_menu ( self, menu_definition, owner ):
         "Create a wxMenu from a string description"
@@ -534,4 +517,3 @@ class BaseWindow(AbstractWindow):
     def popup_menu ( self, menu, x, y ):
         "Pop-up a wxMenu at a specified location"
         self.control.PopupMenuXY( menu.menu, int(x), int( self._flip_y(y) ) )
-        return

--- a/enable/wx/cairo.py
+++ b/enable/wx/cairo.py
@@ -46,4 +46,3 @@ class Window(BaseWindow):
             pixel_map.draw_to_wxwindow(control, 0, 0)
 
         control._dc = None
-        return

--- a/enable/wx/image.py
+++ b/enable/wx/image.py
@@ -62,7 +62,6 @@ class Window(BaseWindow):
             wdc.DrawBitmap(bmp, 0, 0)
 
         control._dc = None
-        return
 
 
 def font_metrics_provider():

--- a/enable/wx/quartz.py
+++ b/enable/wx/quartz.py
@@ -99,7 +99,6 @@ class Window(BaseWindow):
         self.component.draw(gc, view_bounds=(0, 0, size[0], size[1]))
         self._window_paint(event)
         gc.end()
-        return
 
 
 def font_metrics_provider():

--- a/enable/wx/scrollbar.py
+++ b/enable/wx/scrollbar.py
@@ -114,7 +114,6 @@ class NativeScrollBar(Component):
         """
         if self._control:
             self._control.Destroy()
-        return
 
     #------------------------------------------------------------------------
     # Protected methods
@@ -122,7 +121,6 @@ class NativeScrollBar(Component):
 
     def __del__(self):
         self.destroy()
-        return
 
     def _get_abs_coords(self, x, y):
         return self.container.get_absolute_coords(x, y)
@@ -164,7 +162,6 @@ class NativeScrollBar(Component):
         self._last_widget_height = int(y_size)
         self._scroll_updated = False
         self._widget_moved = False
-        return
 
     def _create_control(self, window, wxpos, wxthumbsize, wxrange):
         if self.orientation == 'horizontal':
@@ -202,14 +199,12 @@ class NativeScrollBar(Component):
         window = event.GetWindow()
         if window:
             window.SetFocus()
-        return
 
     def _wx_scroll_handler(self, event):
         """Handle wx scroll events"""
         # If the user moved the scrollbar, set the scroll position, but don't
         # tell wx to move the scrollbar.  Doing so causes jerkiness
         self.scroll_position = self._wx_to_enable_pos(self._control.GetThumbPosition())
-        return
 
     def _enable_to_wx_spec(self, enable_spec):
         """
@@ -249,21 +244,17 @@ class NativeScrollBar(Component):
         self.scroll_position = max(min(self.scroll_position, high-page_size), low)
         self._scroll_updated = True
         self.request_redraw()
-        return
 
     def _range_items_changed(self):
         self._range_changed()
-        return
 
     def _mouse_wheel_changed(self, event):
         event.handled  = True
         self.scroll_position += (event.mouse_wheel * self.range[3] * self.mouse_wheel_speed)
-        return
 
     def _scroll_position_changed(self):
         self._scroll_updated = True
         self.request_redraw()
-        return
 
     def _bounds_changed(self, old, new):
         super(NativeScrollBar, self)._bounds_changed(old, new)

--- a/examples/enable/basic_move.py
+++ b/examples/enable/basic_move.py
@@ -41,8 +41,6 @@ class Box(Component):
                     self.outer_height)
             gc.stroke_path()
 
-        return
-
     def normal_key_pressed(self, event):
         print("Key:", event.character)
 
@@ -53,13 +51,11 @@ class Box(Component):
         self.offset_x = event.x - self.x
         self.offset_y = event.y - self.y
         event.handled = True
-        return
 
     def moving_mouse_move(self, event):
         self.position = [event.x - self.offset_x, event.y - self.offset_y]
         event.handled = True
         self.request_redraw()
-        return
 
     def moving_left_up(self, event):
         self.event_state = "normal"
@@ -67,12 +63,10 @@ class Box(Component):
         event.window.set_mouse_owner(None)
         event.handled = True
         self.request_redraw()
-        return
 
     def moving_mouse_leave(self, event):
         self.moving_left_up(event)
         event.handled = True
-        return
 
 
 class Demo(DemoFrame):

--- a/examples/enable/component_demo.py
+++ b/examples/enable/component_demo.py
@@ -34,7 +34,6 @@ class MyComponent(Component):
                   r)
         gc.line_to(b, h/2)
         gc.stroke_path()
-        return
 
     def normal_key_pressed(self, event):
         print("key pressed: ", event.character)

--- a/examples/enable/filled_container_demo.py
+++ b/examples/enable/filled_container_demo.py
@@ -40,8 +40,6 @@ class MyFilledContainer(Container):
             ty = self.y + self.height / 2.0 - th / 2.0
             gc.show_text_at_point("Container", tx, ty)
 
-        return
-
 
 class Circle(Component):
     """
@@ -65,7 +63,6 @@ class Circle(Component):
     def __init__(self, **traits):
         Component.__init__(self, **traits)
         self.pointer = self.normal_pointer
-        return
 
     def _draw_mainlayer(self, gc, view_bounds=None, mode="default"):
         with gc:
@@ -75,7 +72,6 @@ class Circle(Component):
             radius = min(dx / 2.0, dy / 2.0)
             gc.arc(x + dx / 2.0, y + dy / 2.0, radius, 0.0, 2 * 3.14159)
             gc.fill_path()
-        return
 
     def normal_left_down(self, event):
         self.event_state = "moving"
@@ -93,7 +89,6 @@ class Circle(Component):
         x, y = self.position
         self.prev_x = event.x
         self.prev_y = event.y
-        return
 
     def moving_mouse_move(self, event):
         self.position = [self.x + (event.x - self.prev_x),
@@ -101,7 +96,6 @@ class Circle(Component):
         self.prev_x = event.x
         self.prev_y = event.y
         self.request_redraw()
-        return
 
     def moving_left_up(self, event):
         self.event_state = "normal"
@@ -110,11 +104,9 @@ class Circle(Component):
         event.window.redraw()
         # Remove our shadow
         self.container.remove(self.shadow)
-        return
 
     def moving_mouse_leave(self, event):
         self.moving_left_up(event)
-        return
 
 
 class LightCircle(Component):
@@ -132,7 +124,6 @@ class LightCircle(Component):
             radius = min(dx / 2.0, dy / 2.0)
             gc.arc(x + dx / 2.0, y + dy / 2.0, radius, 0.0, 2 * 3.14159)
             gc.fill_path()
-        return
 
 
 class DashedCircle(Component):
@@ -153,7 +144,6 @@ class DashedCircle(Component):
             gc.set_stroke_color(self.color[0:3] + (self.color[3] * 0.8,))
             gc.set_line_dash(self.line_dash)
             gc.stroke_path()
-        return
 
 
 class Demo(DemoFrame):

--- a/examples/enable/primitives_demo.py
+++ b/examples/enable/primitives_demo.py
@@ -15,7 +15,6 @@ class ResetButton(ToolbarButton):
         if self.canvas and self.canvas.active_tool:
             self.canvas.active_tool.reset()
             self.canvas.request_redraw()
-        return
 
 
 class ActivateButton(ToolbarButton):
@@ -28,12 +27,10 @@ class ActivateButton(ToolbarButton):
         else:
             self.canvas.activate(self.tool)
             self.canvas.request_redraw()
-        return
 
     def _tool_changed(self, old, new):
         if new:
             new.reset()
-        return
 
 
 class Demo(DemoFrame):

--- a/examples/enable/scrolled_demo.py
+++ b/examples/enable/scrolled_demo.py
@@ -28,7 +28,6 @@ class Circle(Component):
     def __init__(self, **traits):
         Component.__init__(self, **traits)
         self.pointer = self.normal_pointer
-        return
 
     def _draw_mainlayer(self, gc, view_bounds=None, mode="default"):
         with gc:
@@ -38,7 +37,6 @@ class Circle(Component):
             radius = min(dx/2.0, dy/2.0)
             gc.arc(x+dx/2.0, y+dy/2.0, radius, 0.0, 2*3.14159)
             gc.fill_path()
-        return
 
     def normal_left_down(self, event):
         self.event_state = "moving"
@@ -56,12 +54,10 @@ class Circle(Component):
         x, y = self.position
         self.offset_x = event.x - x
         self.offset_y = event.y - y
-        return
 
     def moving_mouse_move(self, event):
         self.position = [event.x-self.offset_x, event.y-self.offset_y]
         self.request_redraw()
-        return
 
     def moving_left_up(self, event):
         self.event_state = "normal"
@@ -69,11 +65,9 @@ class Circle(Component):
         self.request_redraw()
         # Remove our shadow
         self.container.remove(self.shadow)
-        return
 
     def moving_mouse_leave(self, event):
         self.moving_left_up(event)
-        return
 
 
 class LightCircle(Component):
@@ -90,7 +84,6 @@ class LightCircle(Component):
             radius = min(dx/2.0, dy/2.0)
             gc.arc(x+dx/2.0, y+dy/2.0, radius, 0.0, 2*3.14159)
             gc.fill_path()
-        return
 
 
 class DashedCircle(Component):
@@ -110,7 +103,6 @@ class DashedCircle(Component):
             gc.set_stroke_color(self.color[0:3] + (self.color[3]*0.8,))
             gc.set_line_dash(self.line_dash)
             gc.stroke_path()
-        return
 
 
 class Demo(DemoFrame):

--- a/examples/enable/shapes/box.py
+++ b/examples/enable/shapes/box.py
@@ -20,5 +20,3 @@ class Box(Shape):
 
             # Draw the shape's text.
             self._draw_text(gc)
-
-        return

--- a/examples/enable/shapes/circle.py
+++ b/examples/enable/shapes/circle.py
@@ -40,8 +40,6 @@ class Circle(Shape):
             # Draw the shape's text.
             self._draw_text(gc)
 
-        return
-
     # 'Circle' interface.
     #--------------------
 

--- a/examples/enable/tools/button_tool.py
+++ b/examples/enable/tools/button_tool.py
@@ -66,7 +66,7 @@ class SelectableBox(Box):
                     gc.set_stroke_color(border_color)
                     gc.set_line_width(bs)
                     gc.draw_rect((x + bsh, y + bsh, dx - bs, dy - bs), STROKE)
-        return
+
 
 class MyFrame(DemoFrame):
     """ Example of using a ButtonTool

--- a/examples/enable/view_bounds_test.py
+++ b/examples/enable/view_bounds_test.py
@@ -16,7 +16,6 @@ class Box(Component):
             x, y = self.position
             gc.rect(x, y, dx, dy)
             gc.fill_path()
-        return
 
 
 class VerboseContainer(Container):

--- a/examples/kiva/gradient.py
+++ b/examples/kiva/gradient.py
@@ -78,8 +78,6 @@ def draw(gc):
                            "pad")
         gc.draw_path(constants.FILL)
 
-    return
-
 
 def gradient():
     gc = GraphicsContext((500, 500))

--- a/examples/kiva/qt4_simple.py
+++ b/examples/kiva/qt4_simple.py
@@ -50,7 +50,6 @@ class MyCanvas(Canvas):
                   r)
         gc.line_to(w/3, h/2)
         gc.stroke_path()
-        return
 
 
 if __name__ == "__main__":

--- a/examples/kiva/ui_gradient.py
+++ b/examples/kiva/ui_gradient.py
@@ -72,8 +72,6 @@ class MyCanvas(Component):
                                "pad", 'userSpaceOnUse')
             gc.fill_path()
 
-        return
-
 
 class Demo(DemoFrame):
     def _create_component(self):

--- a/kiva/basecore2d.py
+++ b/kiva/basecore2d.py
@@ -1036,8 +1036,6 @@ class GraphicsContextBase(AbstractGraphicsContext):
         """
 
         # This is not currently implemented in a device-independent way.
-        return
-
 
     def show_glyphs(self):
         """

--- a/kiva/cairo.py
+++ b/kiva/cairo.py
@@ -81,7 +81,6 @@ class PixelMap(object):
         window_dc.BeginDrawing()
         window_dc.DrawBitmap(bmp,x,y)
         window_dc.EndDrawing()
-        return
 
     def convert_to_rgbarray(self):
         pixels = numpy.frombuffer(self.surface.get_data(), numpy.uint8)
@@ -1237,7 +1236,6 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
             y = -y
         self.translate_ctm(x, y)
         component.draw(self, view_bounds=(0, 0, w, h))
-        return
 
     def save(self, filename, file_format=None):
         """ Save the GraphicsContext to a (PNG) file.

--- a/kiva/gl.py
+++ b/kiva/gl.py
@@ -249,7 +249,6 @@ class MRU(dict):
                     self.__order__ = self.__order__[1:] + [key]
                 else:
                     self.__order__.append(key)
-        return
 
 
 # Use a singleton for the font cache


### PR DESCRIPTION
This PR removes a number of unnecessary empty return statements from the codebase - from `enable`, from `kiva`, from the test suite and from the examples.

Apologies to the reviewer because this is quite an ugly PR to review. I checked each `return` statement to ensure that the empty statement is not part of conditional logic/early `return` from a function/method. Only empty `return`s at the end of functions/methods are removed.