### PR TITLE
Replace use of tempfile.mktemp with tempfile.NamedTemporaryFile 

### DIFF
--- a/examples/kiva/compiled_path.py
+++ b/examples/kiva/compiled_path.py
@@ -33,20 +33,17 @@ def compiled_path():
     gc.set_stroke_color((0, 0, 1, 1))
     gc.draw_path_at_points(locs, path, STROKE)
 
-    with tempfile.NamedTemporaryFile(suffix='.jpg', delete=False) as fid:
-        file_path = fid.name
-
-    gc.save(file_path)
-
-    return file_path
+    with tempfile.NamedTemporaryFile(suffix='.jpg') as fid:
+        gc.save(fid.name)
+        image = Image.from_file(fid.name, resist_width='weak',
+                                resist_height='weak')
+    return image
 
 
 class Demo(DemoFrame):
 
     def _create_component(self):
-        file_path = compiled_path()
-        image = Image.from_file(file_path, resist_width='weak',
-                                resist_height='weak')
+        image = compiled_path()
 
         container = ConstraintsContainer(bounds=[500, 500])
         container.add(image)

--- a/examples/kiva/compiled_path.py
+++ b/examples/kiva/compiled_path.py
@@ -33,7 +33,8 @@ def compiled_path():
     gc.set_stroke_color((0, 0, 1, 1))
     gc.draw_path_at_points(locs, path, STROKE)
 
-    file_path = tempfile.mktemp(suffix='.jpg')
+    with tempfile.NamedTemporaryFile(suffix='.jpg', delete=False) as fid:
+        file_path = fid.name
 
     gc.save(file_path)
 

--- a/examples/kiva/dash.py
+++ b/examples/kiva/dash.py
@@ -34,20 +34,19 @@ def dash(sz=(1000, 1000)):
     gc.close_path()
     gc.draw_path()
     t2 = perf_counter()
-    with tempfile.NamedTemporaryFile(suffix='.bmp', delete=False) as fid:
-        file_path = fid.name
-    gc.save(file_path)
+    with tempfile.NamedTemporaryFile(suffix='.bmp') as fid:
+        gc.save(fid.name)
+        image = Image.from_file(fid.name, resist_width='weak',
+                                resist_height='weak')
     tot_time = t2 - t1
     print('time:', tot_time)
-    return file_path
+    return image
 
 
 class Demo(DemoFrame):
 
     def _create_component(self):
-        file_path = dash()
-        image = Image.from_file(file_path, resist_width='weak',
-                                resist_height='weak')
+        image = dash()
 
         container = ConstraintsContainer(bounds=[500, 500])
         container.add(image)

--- a/examples/kiva/dash.py
+++ b/examples/kiva/dash.py
@@ -34,7 +34,8 @@ def dash(sz=(1000, 1000)):
     gc.close_path()
     gc.draw_path()
     t2 = perf_counter()
-    file_path = tempfile.mktemp(suffix='.bmp')
+    with tempfile.NamedTemporaryFile(suffix='.bmp', delete=False) as fid:
+        file_path = fid.name
     gc.save(file_path)
     tot_time = t2 - t1
     print('time:', tot_time)

--- a/examples/kiva/ellipse.py
+++ b/examples/kiva/ellipse.py
@@ -34,7 +34,8 @@ def ellipse():
     gc.rect(95, 95, 10, 10)
     gc.fill_path()
     draw_ellipse(gc, 100, 100, 35.0, 25.0, pi / 6)
-    file_path = tempfile.mktemp(suffix='.bmp')
+    with tempfile.NamedTemporaryFile(suffix='.bmp', delete=False) as fid:
+        file_path = fid.name
     gc.save(file_path)
     return file_path
 

--- a/examples/kiva/ellipse.py
+++ b/examples/kiva/ellipse.py
@@ -34,18 +34,17 @@ def ellipse():
     gc.rect(95, 95, 10, 10)
     gc.fill_path()
     draw_ellipse(gc, 100, 100, 35.0, 25.0, pi / 6)
-    with tempfile.NamedTemporaryFile(suffix='.bmp', delete=False) as fid:
-        file_path = fid.name
-    gc.save(file_path)
-    return file_path
+    with tempfile.NamedTemporaryFile(suffix='.bmp') as fid:
+        gc.save(fid.name)
+        image = Image.from_file(fid.name, resist_width='weak',
+                                resist_height='weak')
+    return image
 
 
 class Demo(DemoFrame):
 
     def _create_component(self):
-        file_path = ellipse()
-        image = Image.from_file(file_path, resist_width='weak',
-                                resist_height='weak')
+        image = ellipse()
 
         container = ConstraintsContainer(bounds=[500, 500])
         container.add(image)

--- a/examples/kiva/gradient.py
+++ b/examples/kiva/gradient.py
@@ -85,17 +85,16 @@ def gradient():
     gc = GraphicsContext((500, 500))
     gc.scale_ctm(1.25, 1.25)
     draw(gc)
-    with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as fid:
-        file_path = fid.name
-    gc.save(file_path, file_format='png')
-    return file_path
+    with tempfile.NamedTemporaryFile(suffix='.png') as fid:
+        gc.save(fid.name, file_format='png')
+        image = Image.from_file(fid.name, resist_width='weak',
+                                resist_height='weak')
+    return image
 
 
 class Demo(DemoFrame):
     def _create_component(self):
-        file_path = gradient()
-        image = Image.from_file(file_path, resist_width='weak',
-                                resist_height='weak')
+        image = gradient()
 
         container = ConstraintsContainer(bounds=[500, 500])
         container.add(image)

--- a/examples/kiva/gradient.py
+++ b/examples/kiva/gradient.py
@@ -85,7 +85,8 @@ def gradient():
     gc = GraphicsContext((500, 500))
     gc.scale_ctm(1.25, 1.25)
     draw(gc)
-    file_path = tempfile.mktemp(suffix='.png')
+    with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as fid:
+        file_path = fid.name
     gc.save(file_path, file_format='png')
     return file_path
 

--- a/examples/kiva/rect.py
+++ b/examples/kiva/rect.py
@@ -11,7 +11,8 @@ def rect():
     gc.clear()
     gc.rect(100, 100, 300, 300)
     gc.draw_path()
-    file_path = tempfile.mktemp(suffix='.bmp')
+    with tempfile.NamedTemporaryFile(suffix='.bmp', delete=False) as fid:
+        file_path = fid.name
     gc.save(file_path)
     return file_path
 

--- a/examples/kiva/rect.py
+++ b/examples/kiva/rect.py
@@ -11,17 +11,16 @@ def rect():
     gc.clear()
     gc.rect(100, 100, 300, 300)
     gc.draw_path()
-    with tempfile.NamedTemporaryFile(suffix='.bmp', delete=False) as fid:
-        file_path = fid.name
-    gc.save(file_path)
-    return file_path
+    with tempfile.NamedTemporaryFile(suffix='.bmp') as fid:
+        gc.save(fid.name)
+        image = Image.from_file(fid.name, resist_width='weak',
+                                resist_height='weak')
+    return image
 
 
 class Demo(DemoFrame):
     def _create_component(self):
-        file_path = rect()
-        image = Image.from_file(file_path, resist_width='weak',
-                                resist_height='weak')
+        image = rect()
 
         container = ConstraintsContainer(bounds=[500, 500])
         container.add(image)

--- a/examples/kiva/simple.py
+++ b/examples/kiva/simple.py
@@ -17,17 +17,16 @@ def simple():
     gc.set_fill_color((0, 0, 1))
     gc.rect(0, 0, 30, 30)
     gc.draw_path()
-    with tempfile.NamedTemporaryFile(suffix='.bmp', delete=False) as fid:
-        file_path = fid.name
-    gc.save(file_path)
-    return file_path
+    with tempfile.NamedTemporaryFile(suffix='.bmp') as fid:
+        gc.save(fid.name)
+        image = Image.from_file(fid.name, resist_width='weak',
+                                resist_height='weak')
+    return image
 
 
 class Demo(DemoFrame):
     def _create_component(self):
-        file_path = simple()
-        image = Image.from_file(file_path, resist_width='weak',
-                                resist_height='weak')
+        image = simple()
 
         container = ConstraintsContainer(bounds=[500, 500])
         container.add(image)

--- a/examples/kiva/simple.py
+++ b/examples/kiva/simple.py
@@ -17,7 +17,8 @@ def simple():
     gc.set_fill_color((0, 0, 1))
     gc.rect(0, 0, 30, 30)
     gc.draw_path()
-    file_path = tempfile.mktemp(suffix='.bmp')
+    with tempfile.NamedTemporaryFile(suffix='.bmp', delete=False) as fid:
+        file_path = fid.name
     gc.save(file_path)
     return file_path
 

--- a/examples/kiva/simple2.py
+++ b/examples/kiva/simple2.py
@@ -12,9 +12,6 @@ def simple():
     gc.rect(99, 100, 300, 300)
     gc.draw_path()
 
-    with tempfile.NamedTemporaryFile(suffix='.bmp') as fid:
-        gc.save(fid.name)
-
     # directly manipulate the underlying Numeric array.
     # The color tuple is expressed as BGRA.
     gc.bmp_array[:99, :100] = (139, 60, 71, 255)

--- a/examples/kiva/simple2.py
+++ b/examples/kiva/simple2.py
@@ -16,7 +16,8 @@ def simple():
     # directly manipulate the underlying Numeric array.
     # The color tuple is expressed as BGRA.
     gc.bmp_array[:99, :100] = (139, 60, 71, 255)
-    file_path = tempfile.mktemp(suffix='.bmp')
+    with tempfile.NamedTemporaryFile(suffix='.bmp', delete=False) as fid:
+        file_path = fid.name
     gc.save(file_path)
 
     return file_path

--- a/examples/kiva/simple2.py
+++ b/examples/kiva/simple2.py
@@ -11,23 +11,23 @@ def simple():
     gc.set_fill_color((0, 0, 0))
     gc.rect(99, 100, 300, 300)
     gc.draw_path()
-    gc.save(tempfile.mktemp(suffix=".bmp"))
+
+    with tempfile.NamedTemporaryFile(suffix='.bmp') as fid:
+        gc.save(fid.name)
 
     # directly manipulate the underlying Numeric array.
     # The color tuple is expressed as BGRA.
     gc.bmp_array[:99, :100] = (139, 60, 71, 255)
-    with tempfile.NamedTemporaryFile(suffix='.bmp', delete=False) as fid:
-        file_path = fid.name
-    gc.save(file_path)
-
-    return file_path
+    with tempfile.NamedTemporaryFile(suffix='.bmp') as fid:
+        gc.save(fid.name)
+        image = Image.from_file(fid.name, resist_width='weak',
+                                resist_height='weak')
+    return image
 
 
 class Demo(DemoFrame):
     def _create_component(self):
-        file_path = simple()
-        image = Image.from_file(file_path, resist_width='weak',
-                                resist_height='weak')
+        image = simple()
 
         container = ConstraintsContainer(bounds=[500, 500])
         container.add(image)

--- a/examples/kiva/star.py
+++ b/examples/kiva/star.py
@@ -38,7 +38,8 @@ def stars():
     gc.set_fill_color((0.5, 0.5, 0.5, 0.4))
     gc.rect(150, 150, 200, 200)
     gc.fill_path()
-    file_path = tempfile.mktemp(suffix='.bmp')
+    with tempfile.NamedTemporaryFile(suffix='.bmp', delete=False) as fid:
+        file_path = fid.name
     gc.save(file_path)
     return file_path
 

--- a/examples/kiva/star.py
+++ b/examples/kiva/star.py
@@ -38,17 +38,16 @@ def stars():
     gc.set_fill_color((0.5, 0.5, 0.5, 0.4))
     gc.rect(150, 150, 200, 200)
     gc.fill_path()
-    with tempfile.NamedTemporaryFile(suffix='.bmp', delete=False) as fid:
-        file_path = fid.name
-    gc.save(file_path)
-    return file_path
+    with tempfile.NamedTemporaryFile(suffix='.bmp') as fid:
+        gc.save(fid.name)
+        image = Image.from_file(fid.name, resist_width='weak',
+                                resist_height='weak')
+    return image
 
 
 class Demo(DemoFrame):
     def _create_component(self):
-        file_path = stars()
-        image = Image.from_file(file_path, resist_width='weak',
-                                resist_height='weak')
+        image = stars()
 
         container = ConstraintsContainer(bounds=[500, 500])
         container.add(image)

--- a/examples/kiva/star1.py
+++ b/examples/kiva/star1.py
@@ -36,7 +36,8 @@ def stars():
     add_star(gc)
     gc.set_fill_color((0.0, 0.0, 1.0))
     gc.draw_path(constants.EOF_FILL_STROKE)
-    file_path = tempfile.mktemp(suffix='.bmp')
+    with tempfile.NamedTemporaryFile(suffix='.bmp', delete=False) as fid:
+        file_path = fid.name
     gc.save(file_path)
     return file_path
 

--- a/examples/kiva/star1.py
+++ b/examples/kiva/star1.py
@@ -36,10 +36,11 @@ def stars():
     add_star(gc)
     gc.set_fill_color((0.0, 0.0, 1.0))
     gc.draw_path(constants.EOF_FILL_STROKE)
-    with tempfile.NamedTemporaryFile(suffix='.bmp', delete=False) as fid:
-        file_path = fid.name
-    gc.save(file_path)
-    return file_path
+    with tempfile.NamedTemporaryFile(suffix='.bmp') as fid:
+        gc.save(fid.name)
+        image = Image.from_file(fid.name, resist_width='weak',
+                                resist_height='weak')
+    return image
 
 
 class Demo(DemoFrame):
@@ -50,9 +51,7 @@ class Demo(DemoFrame):
                        resizable=True)
 
     def _canvas_default(self):
-        file_path = stars()
-        image = Image.from_file(file_path, resist_width='weak',
-                                resist_height='weak')
+        image = stars()
 
         container = ConstraintsContainer(bounds=[500, 500])
         container.add(image)


### PR DESCRIPTION
fixes #398 

This PR replaces all uses of `tempfile.mktemp` as it is deprecated and unsafe.  