### PR TITLE
Remove all from __future__ imports as we are dropping all python <3.6 support

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -76,8 +76,6 @@ how to run commands within an EDM enviornment.
 
 """
 
-from __future__ import print_function
-
 import glob
 import os
 import subprocess

--- a/enable/base.py
+++ b/enable/base.py
@@ -21,8 +21,6 @@ Enable package.
 #                     subclasses_of
 #-------------------------------------------------------------------------------
 
-from __future__ import generators
-
 # Major library imports
 import six.moves as sm
 

--- a/enable/canvas.py
+++ b/enable/canvas.py
@@ -1,7 +1,5 @@
 """ Defines the enable Canvas class """
 
-from __future__ import with_statement
-
 # Enthought library imports
 from traits.api import Bool, Trait, Tuple, List
 from kiva.constants import FILL

--- a/enable/colors.py
+++ b/enable/colors.py
@@ -1,6 +1,5 @@
 # This is a redirection file that determines what constitutes a color trait
 # in Chaco, and what constitutes the standard colors.
-from __future__ import absolute_import
 import sys
 
 from traits.etsconfig.api import ETSConfig

--- a/enable/compass.py
+++ b/enable/compass.py
@@ -1,6 +1,3 @@
-
-from __future__ import with_statement
-
 from numpy import array, pi
 
 # Enthought library imports

--- a/enable/component.py
+++ b/enable/component.py
@@ -1,7 +1,5 @@
 """ Defines the Component class """
 
-from __future__ import with_statement
-
 from uuid import uuid4
 
 # Enthought library imports

--- a/enable/container.py
+++ b/enable/container.py
@@ -1,7 +1,5 @@
 """ Defines the basic Container class """
 
-from __future__ import with_statement
-
 # Major library imports
 import warnings
 

--- a/enable/controls.py
+++ b/enable/controls.py
@@ -15,8 +15,6 @@
 #
 #-------------------------------------------------------------------------------
 
-from __future__ import with_statement
-
 # Major library imports
 import os.path
 

--- a/enable/drawing/drag_line.py
+++ b/enable/drawing/drag_line.py
@@ -1,7 +1,5 @@
 """ A drag drawn line. """
 
-from __future__ import with_statement
-
 from enable.api import Line
 from traits.api import Instance
 

--- a/enable/drawing/drag_polygon.py
+++ b/enable/drawing/drag_polygon.py
@@ -1,7 +1,5 @@
 """ A drag drawn polygon. """
 
-from __future__ import with_statement
-
 from enable.primitives.api import Polygon
 from enable.api import Pointer
 from pyface.action.api import MenuManager

--- a/enable/drawing/drawing_canvas.py
+++ b/enable/drawing/drawing_canvas.py
@@ -1,6 +1,3 @@
-
-from __future__ import with_statement
-
 from enable.api import Container, Component, ColorTrait
 from kiva.constants import FILL, FILL_STROKE
 from kiva.trait_defs.kiva_font_trait import KivaFont

--- a/enable/drawing/point_line.py
+++ b/enable/drawing/point_line.py
@@ -1,7 +1,5 @@
 """ A point-to-point drawn polygon. """
 
-from __future__ import with_statement
-
 from enable.api import cursor_style_trait, Line
 from traits.api import Event, Int, Instance
 

--- a/enable/example_application.py
+++ b/enable/example_application.py
@@ -14,9 +14,6 @@ in places where a DemoFrame is insufficient.
 
 """
 
-from __future__ import (division, absolute_import, print_function,
-                        unicode_literals)
-
 from pyface.api import ApplicationWindow, GUI
 
 class DemoApplication(ApplicationWindow):

--- a/enable/example_support.py
+++ b/enable/example_support.py
@@ -2,7 +2,6 @@
 Support class that wraps up the boilerplate toolkit calls that virtually all
 demo programs have to use.
 """
-from __future__ import absolute_import
 
 from traits.api import HasTraits, Instance
 from traits.etsconfig.api import ETSConfig

--- a/enable/graphics_context.py
+++ b/enable/graphics_context.py
@@ -1,6 +1,3 @@
-
-from __future__ import with_statement
-
 from kiva.constants import FILL
 
 # Relative imports

--- a/enable/label.py
+++ b/enable/label.py
@@ -1,8 +1,6 @@
 """ Defines the Label class.
 """
 
-from __future__ import with_statement
-
 # Major library imports
 from math import pi
 from numpy import asarray

--- a/enable/primitives/annotater.py
+++ b/enable/primitives/annotater.py
@@ -3,8 +3,6 @@ Define an Annotater component that allows a user to annotate an underlying
 component
 """
 
-from __future__ import with_statement
-
 from traits.api import Event, Trait, TraitPrefixList
 from traitsui.api import Group, View
 

--- a/enable/primitives/box.py
+++ b/enable/primitives/box.py
@@ -1,8 +1,6 @@
 """ Define a simple filled box component.
 """
 
-from __future__ import with_statement
-
 # Parent package imports
 from enable.api import border_size_trait, Component, transparent_color
 from enable.colors import ColorTrait

--- a/enable/primitives/image.py
+++ b/enable/primitives/image.py
@@ -1,8 +1,6 @@
 """ Defines the Image component class.
 """
 
-from __future__ import absolute_import
-
 # Enthought library imports
 from traits.api import Array, Bool, Enum, Instance, Property, cached_property
 

--- a/enable/primitives/line.py
+++ b/enable/primitives/line.py
@@ -1,7 +1,5 @@
 """ A line segment component. """
 
-from __future__ import with_statement
-
 from numpy import array, resize
 
 # Enthought library imports.

--- a/enable/primitives/shape.py
+++ b/enable/primitives/shape.py
@@ -2,8 +2,6 @@
 
 
 # Standard library imports.
-from __future__ import print_function
-
 import math
 
 # Enthought library imports.

--- a/enable/qt4/constants.py
+++ b/enable/qt4/constants.py
@@ -9,8 +9,6 @@
 # Thanks for using Enthought open source!
 #------------------------------------------------------------------------------
 
-from __future__ import absolute_import
-
 import warnings
 
 import six.moves as sm

--- a/enable/savage/compliance/viewer.py
+++ b/enable/savage/compliance/viewer.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import time
 from six import StringIO

--- a/enable/savage/svg/backends/kiva/renderer.py
+++ b/enable/savage/svg/backends/kiva/renderer.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from math import sqrt, pi
 import sys
 import warnings

--- a/enable/savage/svg/document.py
+++ b/enable/savage/svg/document.py
@@ -1,8 +1,6 @@
 """
     SVGDocument
 """
-from __future__ import print_function
-
 from io import BytesIO
 import warnings
 import math

--- a/enable/scrollbar.py
+++ b/enable/scrollbar.py
@@ -5,8 +5,6 @@ The scrollbar uses images for the pieces of the scrollbar itself and stretches
 them appropriately in the draw phase.
 """
 
-from __future__ import with_statement
-
 import six.moves as sm
 # PZW: Define a scrollbar that uses the system/wx-native scrollbar instead
 # of drawing our own.

--- a/enable/scrolled.py
+++ b/enable/scrolled.py
@@ -1,6 +1,3 @@
-
-from __future__ import with_statement
-
 # Enthought library imports
 from traits.api import Any, Bool, DelegatesTo, Float, Instance, Int
 

--- a/enable/slider.py
+++ b/enable/slider.py
@@ -1,6 +1,3 @@
-
-from __future__ import with_statement
-
 from numpy import linspace, zeros
 
 # Enthought library imports

--- a/enable/tests/tools/apptools/commands_test_case.py
+++ b/enable/tests/tools/apptools/commands_test_case.py
@@ -6,9 +6,6 @@
 # LICENSE.txt
 #
 """ Tests for Commands that work with Components """
-
-from __future__ import (division, absolute_import, print_function,
-                        unicode_literals)
 import unittest
 
 # Third party library imports

--- a/enable/tests/tools/apptools/move_command_tool_test_case.py
+++ b/enable/tests/tools/apptools/move_command_tool_test_case.py
@@ -6,9 +6,6 @@
 # LICENSE.txt
 #
 """ Test case for MoveCommandTool """
-
-from __future__ import (division, absolute_import, print_function,
-                        unicode_literals)
 import unittest
 
 # Third party library imports

--- a/enable/tests/tools/apptools/resize_command_tool_test_case.py
+++ b/enable/tests/tools/apptools/resize_command_tool_test_case.py
@@ -6,9 +6,6 @@
 # LICENSE.txt
 #
 """ Test case for ResizeCommandTool """
-
-from __future__ import (division, absolute_import, print_function,
-                        unicode_literals)
 import unittest
 
 # Third party library imports

--- a/enable/tests/tools/apptools/undo_tool_test_case.py
+++ b/enable/tests/tools/apptools/undo_tool_test_case.py
@@ -6,9 +6,6 @@
 # LICENSE.txt
 #
 """ Tests for Commands that work with Components """
-
-from __future__ import (division, absolute_import, print_function,
-                        unicode_literals)
 import unittest
 
 # Third party library imports

--- a/enable/tests/tools/button_tool_test_case.py
+++ b/enable/tests/tools/button_tool_test_case.py
@@ -5,9 +5,6 @@
 # This file is open source software distributed according to the terms in
 # LICENSE.txt
 #
-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import unittest
 
 from traits.testing.unittest_tools import UnittestTools

--- a/enable/tests/tools/hover_tool_test_case.py
+++ b/enable/tests/tools/hover_tool_test_case.py
@@ -1,8 +1,5 @@
 # (C) Copyright 2008-2019 Enthought, Inc., Austin, TX
 # All rights reserved.
-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import unittest
 try:
     from unittest import mock

--- a/enable/tests/viewport_test_case.py
+++ b/enable/tests/viewport_test_case.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 from enable.api import Component, Container, Viewport

--- a/enable/text_field.py
+++ b/enable/text_field.py
@@ -1,6 +1,3 @@
-
-from __future__ import with_statement
-
 # Standard library imports
 from math import floor, sqrt
 from bisect import insort_left

--- a/enable/text_grid.py
+++ b/enable/text_grid.py
@@ -2,8 +2,6 @@
 TextGrid is a text grid widget that is meant to be used with Numpy.
 """
 
-from __future__ import with_statement
-
 # Major library imports
 from numpy import arange, array, dstack, repeat, newaxis
 

--- a/enable/tools/apptools/api.py
+++ b/enable/tools/apptools/api.py
@@ -20,8 +20,6 @@ of the Enable codebase as a whole.
 
 """
 
-from __future__ import absolute_import
-
 # Support for Undo/Redo with Enable
 from .commands import ComponentCommand, MoveCommand, ResizeCommand
 from .command_tool import BaseCommandTool, BaseUndoTool

--- a/enable/tools/apptools/command_tool.py
+++ b/enable/tools/apptools/command_tool.py
@@ -15,9 +15,6 @@ Command stack.
 
 """
 
-from __future__ import (division, absolute_import, print_function,
-                        unicode_literals)
-
 from apptools.undo.api import ICommandStack, IUndoManager
 from traits.api import Callable, Instance
 

--- a/enable/tools/apptools/commands.py
+++ b/enable/tools/apptools/commands.py
@@ -16,9 +16,6 @@ setting attribute values.
 
 """
 
-from __future__ import (division, absolute_import, print_function,
-                        unicode_literals)
-
 from apptools.undo.api import AbstractCommand
 from traits.api import Bool, Instance, Tuple, Unicode
 from traits.util.camel_case import camel_case_to_words

--- a/enable/tools/apptools/move_command_tool.py
+++ b/enable/tools/apptools/move_command_tool.py
@@ -14,9 +14,6 @@ commands.
 
 """
 
-from __future__ import (division, absolute_import, print_function,
-                        unicode_literals)
-
 from traits.api import Bool, Tuple
 
 from enable.tools.move_tool import MoveTool

--- a/enable/tools/apptools/resize_command_tool.py
+++ b/enable/tools/apptools/resize_command_tool.py
@@ -14,9 +14,6 @@ resize commands.
 
 """
 
-from __future__ import (division, absolute_import, print_function,
-                        unicode_literals)
-
 from traits.api import Bool, Tuple
 
 from enable.tools.resize_tool import ResizeTool

--- a/enable/tools/apptools/undo_tool.py
+++ b/enable/tools/apptools/undo_tool.py
@@ -13,9 +13,6 @@ Tool that triggers undo or redo when keys are pressed.
 
 """
 
-from __future__ import (division, absolute_import, print_function,
-                        unicode_literals)
-
 # Enthought library imports
 from traits.api import Instance, List
 

--- a/enable/tools/base_drop_tool.py
+++ b/enable/tools/base_drop_tool.py
@@ -10,8 +10,6 @@
 #------------------------------------------------------------------------------
 """ Abstract base class for tools that handle drag and drop """
 
-from __future__ import absolute_import, print_function, division
-
 from traits.api import Enum
 
 from enable.base_tool import BaseTool

--- a/enable/tools/hover_tool.py
+++ b/enable/tools/hover_tool.py
@@ -6,8 +6,6 @@ Tool to detect when the user hovers over a specific part of an underlying
 components.
 """
 
-from __future__ import absolute_import
-
 # Enthought library imports
 from enable.base_tool import BaseTool
 from traits.api import Any, Callable, Enum, Float, Int

--- a/enable/tools/toolbars/toolbar_buttons.py
+++ b/enable/tools/toolbars/toolbar_buttons.py
@@ -1,6 +1,3 @@
-
-from __future__ import with_statement, print_function
-
 # Enthought library imports
 from enable.api import ColorTrait, Component
 from enable.font_metrics_provider import font_metrics_provider

--- a/enable/tools/toolbars/viewport_toolbar.py
+++ b/enable/tools/toolbars/viewport_toolbar.py
@@ -1,6 +1,3 @@
-
-from __future__ import with_statement
-
 # Library imports
 
 # Enthought Library imports

--- a/enable/viewport.py
+++ b/enable/viewport.py
@@ -1,7 +1,5 @@
 """ Defines a Viewport which renders sub-areas of components """
 
-from __future__ import with_statement
-
 # Standard library imports
 from numpy import array, dot
 

--- a/enable/wx/base_window.py
+++ b/enable/wx/base_window.py
@@ -3,8 +3,6 @@ Defines the concrete top-level Enable 'Window' class for the wxPython GUI
 toolkit, based on the kiva agg driver.
 """
 
-from __future__ import absolute_import
-
 import sys
 import time
 

--- a/enable/wx/constants.py
+++ b/enable/wx/constants.py
@@ -9,8 +9,6 @@
 # Thanks for using Enthought open source!
 #------------------------------------------------------------------------------
 
-from __future__ import absolute_import
-
 import warnings
 
 import wx

--- a/examples/enable/basic_move.py
+++ b/examples/enable/basic_move.py
@@ -1,7 +1,6 @@
 """
 This allows a simple component to be moved around the screen.
 """
-from __future__ import print_function
 
 from traits.api import Float
 

--- a/examples/enable/compass_example.py
+++ b/examples/enable/compass_example.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from enable.api import OverlayContainer, Compass
 from enable.example_support import demo_main, DemoFrame
 

--- a/examples/enable/component_demo.py
+++ b/examples/enable/component_demo.py
@@ -1,7 +1,6 @@
 """
 Basic demo of drawing within an Enable component.
 """
-from __future__ import print_function
 
 from enable.api import Component, ComponentEditor
 from traits.api import HasTraits, Instance

--- a/examples/enable/latency_demo.py
+++ b/examples/enable/latency_demo.py
@@ -1,7 +1,6 @@
 """
 Test to see what level of click latency is noticeable.
 """
-from __future__ import print_function
 
 import time
 

--- a/examples/enable/slider_example.py
+++ b/examples/enable/slider_example.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from enable.api import OverlayContainer, Slider
 from enable.example_support import demo_main, DemoFrame
 

--- a/examples/enable/tools/apptools/undoable_move_tool.py
+++ b/examples/enable/tools/apptools/undoable_move_tool.py
@@ -14,8 +14,6 @@ This example shows how to integrate a simple component move tool with apptools
 undo/redo infrastructure.
 
 """
-from __future__ import (division, absolute_import, print_function,
-                        unicode_literals)
 
 from apptools.undo.api import (CommandStack, ICommandStack, IUndoManager,
                                UndoManager)

--- a/examples/enable/tools/button_tool.py
+++ b/examples/enable/tools/button_tool.py
@@ -14,8 +14,6 @@ This example shows how to integrate a simple component move tool with apptools
 undo/redo infrastructure.
 
 """
-from __future__ import (division, absolute_import, print_function,
-                        unicode_literals)
 
 from traits.api import Bool
 from kiva.constants import FILL, STROKE

--- a/examples/enable/tools/pyface/context_menu.py
+++ b/examples/enable/tools/pyface/context_menu.py
@@ -2,7 +2,6 @@
 This demonstrates the most basic drawing capabilities using Enable.  A new
 component is created and added to a container.
 """
-from __future__ import print_function
 
 from enable.example_support import DemoFrame, demo_main
 from enable.api import Component, Container, Window

--- a/examples/enable/view_bounds_test.py
+++ b/examples/enable/view_bounds_test.py
@@ -1,7 +1,6 @@
 """
 Demonstrates how clipping of objects occurs with the view_bounds parameter to draw().
 """
-from __future__ import print_function
 
 from enable.api import Container, Component, Scrolled
 from enable.base import empty_rectangle, intersect_bounds

--- a/examples/enable/zoomed_event_demo.py
+++ b/examples/enable/zoomed_event_demo.py
@@ -1,8 +1,6 @@
 """
 Use mouse wheel to zoom and right-click to pan the viewport.
 """
-from __future__ import print_function
-
 from traits.api import Float
 
 from enable.api import (AbstractOverlay, Canvas, Viewport, ColorTrait,

--- a/examples/kiva/agg/benchmark.py
+++ b/examples/kiva/agg/benchmark.py
@@ -1,8 +1,6 @@
 """
 Benchmarks Agg rendering times.
 """
-from __future__ import print_function
-
 try:
     from time import perf_counter
 except ImportError:

--- a/examples/kiva/agg/dash.py
+++ b/examples/kiva/agg/dash.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 try:
     from time import perf_counter
 except ImportError:

--- a/examples/kiva/agg/lion.py
+++ b/examples/kiva/agg/lion.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 try:
     from time import perf_counter
 except ImportError:

--- a/examples/kiva/agg/polygon_hit_test.py
+++ b/examples/kiva/agg/polygon_hit_test.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 try:
     from time import perf_counter
 except ImportError:

--- a/examples/kiva/agg/simple.py
+++ b/examples/kiva/agg/simple.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from kiva import agg
 from kiva import constants
 

--- a/examples/kiva/agg/simple_clip.py
+++ b/examples/kiva/agg/simple_clip.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 try:
     from time import perf_counter
 except ImportError:

--- a/examples/kiva/agg/star_path.py
+++ b/examples/kiva/agg/star_path.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from math import sin, cos, pi
 
 from numpy import array, arange

--- a/examples/kiva/agg/text_ex.py
+++ b/examples/kiva/agg/text_ex.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 try:
     from time import perf_counter
 except ImportError:

--- a/examples/kiva/dash.py
+++ b/examples/kiva/dash.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import tempfile
 try:
     from time import perf_counter

--- a/examples/kiva/simple_clip.py
+++ b/examples/kiva/simple_clip.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 try:
     from time import perf_counter
 except ImportError:

--- a/examples/kiva/star_path.py
+++ b/examples/kiva/star_path.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from numpy import cos, sin, arange, pi, array
 
 from kiva.constants import FILL, EOF_FILL, STROKE, FILL_STROKE, EOF_FILL_STROKE

--- a/examples/kiva/sub_path.py
+++ b/examples/kiva/sub_path.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from numpy import array
 
 from kiva.image import GraphicsContext

--- a/examples/savage/buttons_on_canvas.py
+++ b/examples/savage/buttons_on_canvas.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os.path
 import xml.etree.cElementTree as etree
 

--- a/kiva/abstract_graphics_context.py
+++ b/kiva/abstract_graphics_context.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from abc import ABCMeta, abstractmethod
 
 import six

--- a/kiva/agg/src/tst_convert.py
+++ b/kiva/agg/src/tst_convert.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import agg
 q=agg.Image((10,10),pix_format="rgb24")
 q.convert_pixel_format("rgba32")

--- a/kiva/agg/tests/font_loading_test.py
+++ b/kiva/agg/tests/font_loading_test.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from string import ascii_lowercase, ascii_uppercase
 import os
 import time

--- a/kiva/agg/tests/graphics_context_test_case.py
+++ b/kiva/agg/tests/graphics_context_test_case.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 import unittest
 
 from numpy import all, allclose, array, dtype, pi, ones

--- a/kiva/basecore2d.py
+++ b/kiva/basecore2d.py
@@ -29,9 +29,6 @@ transform
     to access its values. Currently, I do the latter.
 
 """
-
-from __future__ import absolute_import, print_function
-
 import six.moves as sm
 
 import numpy as np

--- a/kiva/cairo.py
+++ b/kiva/cairo.py
@@ -7,7 +7,6 @@
     This is currently under development and is not yet fully functional.
 
 """
-from __future__ import absolute_import
 import cairo
 import copy
 import six.moves as sm

--- a/kiva/celiagg.py
+++ b/kiva/celiagg.py
@@ -8,7 +8,6 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 # Thanks for using Enthought open source!
 # -----------------------------------------------------------------------------
-from __future__ import absolute_import, print_function, division
 
 from collections import namedtuple
 from math import fabs

--- a/kiva/fonttools/afm.py
+++ b/kiva/fonttools/afm.py
@@ -34,8 +34,6 @@ AUTHOR:
   John D. Hunter <jdhunter@ace.bsd.uchicago.edu>
 """
 
-from __future__ import absolute_import, print_function
-
 import os
 import logging
 

--- a/kiva/fonttools/font.py
+++ b/kiva/fonttools/font.py
@@ -3,8 +3,6 @@ Defines the Kiva Font class and a utility method to parse free-form font
 specification strings into Font instances.
 """
 
-from __future__ import absolute_import, print_function
-
 import six
 
 import copy

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -46,8 +46,6 @@ License   : matplotlib license (PSF compatible)
             see license/LICENSE_TTFQUERY.
 """
 
-from __future__ import absolute_import, print_function
-
 import logging
 import os
 import sys

--- a/kiva/fonttools/sstruct.py
+++ b/kiva/fonttools/sstruct.py
@@ -52,8 +52,6 @@ calcsize(format)
 
 # Updated to Python 2.7/3.0, CJW
 
-from __future__ import absolute_import, print_function
-
 __version__ = "1.2"
 __copyright__ = "Copyright 1998, Just van Rossum <just@letterror.com>"
 

--- a/kiva/gl.py
+++ b/kiva/gl.py
@@ -1,6 +1,3 @@
-
-from __future__ import absolute_import, print_function
-
 # Major library imports
 import ctypes
 from math import floor

--- a/kiva/graphics_state.py
+++ b/kiva/graphics_state.py
@@ -6,9 +6,6 @@ tracked by Python, rather than by an internal graphics state (eg. Wx, SVG and
 PDF backends, but not Agg or QPainter).
 
 """
-
-from __future__ import absolute_import, print_function
-
 import copy
 
 from numpy import array, float64

--- a/kiva/line_state.py
+++ b/kiva/line_state.py
@@ -7,8 +7,6 @@ state (eg. Wx, SVG and PDF backends, but not Agg or QPainter).
 
 """
 
-from __future__ import absolute_import, print_function
-
 from numpy import alltrue, array, asarray, shape, sometrue
 
 from .constants import NO_DASH

--- a/kiva/pdf.py
+++ b/kiva/pdf.py
@@ -17,8 +17,6 @@
     The PDF implementation relies heavily on the ReportLab project.
 """
 
-from __future__ import absolute_import, print_function
-
 # standard library imports
 import six.moves as sm
 import warnings

--- a/kiva/pdfmetrics.py
+++ b/kiva/pdfmetrics.py
@@ -14,7 +14,6 @@
 #copyright ReportLab Inc. 2001
 #see license.txt for license details
 #history http://cvs.sourceforge.net/cgi-bin/cvsweb.cgi/reportlab/pdfbase/pdfmetrics.py?cvsroot=reportlab
-from __future__ import print_function
 
 # MODIFIED from reportlab's version for the sake of easier integration in Kiva -- David Ascher
 

--- a/kiva/ps.py
+++ b/kiva/ps.py
@@ -15,7 +15,6 @@
     :Author:      David Ascher (davida@activestate.com)
     :Version:     $Revision: 1.2 $
 """
-from __future__ import print_function
 
 # Major library imports
 import os

--- a/kiva/qpainter.py
+++ b/kiva/qpainter.py
@@ -10,8 +10,6 @@
 # ------------------------------------------------------------------------------
 """ This is the QPainter backend for kiva. """
 
-from __future__ import absolute_import, print_function
-
 from functools import partial
 import six.moves as sm
 import numpy as np

--- a/kiva/quartz/setup.py
+++ b/kiva/quartz/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 
 import os
 import platform

--- a/kiva/tests/agg/image_test_case.py
+++ b/kiva/tests/agg/image_test_case.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from timeit import Timer
 import os, sys
 import unittest

--- a/kiva/tests/agg/test_image3.py
+++ b/kiva/tests/agg/test_image3.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import time
 from math import pi

--- a/kiva/tests/basecore2d_test_case.py
+++ b/kiva/tests/basecore2d_test_case.py
@@ -8,8 +8,6 @@
     nothing is obviously wrong.
 """
 
-from __future__ import with_statement
-
 import unittest
 
 from numpy import alltrue, array, ravel

--- a/kiva/tests/dummy.py
+++ b/kiva/tests/dummy.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 import six
 
 from enable.kiva_graphics_context import GraphicsContext

--- a/kiva/tests/test_quartz.py
+++ b/kiva/tests/test_quartz.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 
 from kiva.tests._testing import skip_if_not_wx


### PR DESCRIPTION
part of #415 

Currently CI is only running on python 3.6 and we plan to drop support for versions <3.6 with the next release.  This PR removes the no longer needed `from __futute__ import _____` statements in the codebase.