### PR TITLE
Remove try excepts for importing unittest.mock

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -96,7 +96,6 @@ dependencies = {
     "apptools",
     "six",
     "nose",
-    "mock",
     "coverage",
     "numpy",
     "pygments",

--- a/enable/testing.py
+++ b/enable/testing.py
@@ -1,9 +1,7 @@
 # Copyright (c) 2008-2013 by Enthought, Inc.
 # All rights reserved.
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock
+from unittest.mock import Mock
+
 
 from enable.abstract_window import AbstractWindow
 from enable.events import MouseEvent, KeyEvent, DragEvent

--- a/enable/testing.py
+++ b/enable/testing.py
@@ -2,7 +2,6 @@
 # All rights reserved.
 from unittest.mock import Mock
 
-
 from enable.abstract_window import AbstractWindow
 from enable.events import MouseEvent, KeyEvent, DragEvent
 from kiva.testing import KivaTestAssistant

--- a/enable/tests/test_assistant_test_case.py
+++ b/enable/tests/test_assistant_test_case.py
@@ -1,7 +1,4 @@
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 import nose
 
 from enable.component import Component

--- a/enable/tests/test_assistant_test_case.py
+++ b/enable/tests/test_assistant_test_case.py
@@ -1,4 +1,5 @@
 from unittest import mock
+
 import nose
 
 from enable.component import Component

--- a/enable/tests/tools/apptools/commands_test_case.py
+++ b/enable/tests/tools/apptools/commands_test_case.py
@@ -10,12 +10,8 @@
 from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 import unittest
+from unittest.mock import MagicMock
 
-# Third party library imports
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
 
 # Enthought library imports
 from traits.testing.unittest_tools import UnittestTools

--- a/enable/tests/tools/apptools/commands_test_case.py
+++ b/enable/tests/tools/apptools/commands_test_case.py
@@ -12,7 +12,6 @@ from __future__ import (division, absolute_import, print_function,
 import unittest
 from unittest.mock import MagicMock
 
-
 # Enthought library imports
 from traits.testing.unittest_tools import UnittestTools
 

--- a/enable/tests/tools/apptools/move_command_tool_test_case.py
+++ b/enable/tests/tools/apptools/move_command_tool_test_case.py
@@ -10,12 +10,7 @@
 from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 import unittest
-
-# Third party library imports
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 # Enthought library imports
 from apptools.undo.api import CommandStack

--- a/enable/tests/tools/apptools/resize_command_tool_test_case.py
+++ b/enable/tests/tools/apptools/resize_command_tool_test_case.py
@@ -10,12 +10,7 @@
 from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 import unittest
-
-# Third party library imports
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 # Enthought library imports
 from apptools.undo.api import CommandStack

--- a/enable/tests/tools/apptools/undo_tool_test_case.py
+++ b/enable/tests/tools/apptools/undo_tool_test_case.py
@@ -10,12 +10,7 @@
 from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 import unittest
-
-# Third party library imports
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 # Enthought library imports
 from apptools.undo.api import UndoManager

--- a/enable/tests/tools/hover_tool_test_case.py
+++ b/enable/tests/tools/hover_tool_test_case.py
@@ -4,10 +4,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
+
 
 from pyface.toolkit import toolkit_object
 

--- a/enable/tests/tools/hover_tool_test_case.py
+++ b/enable/tests/tools/hover_tool_test_case.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, print_function,
 import unittest
 from unittest import mock
 
-
 from pyface.toolkit import toolkit_object
 
 from enable.component import Component

--- a/enable/tests/wx/mouse_wheel_test_case.py
+++ b/enable/tests/wx/mouse_wheel_test_case.py
@@ -1,10 +1,5 @@
-
 from unittest import TestCase
-
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 from traits.api import Any
 from enable.tests._testing import skip_if_not_wx

--- a/kiva/fonttools/tests/test_font_manager.py
+++ b/kiva/fonttools/tests/test_font_manager.py
@@ -2,7 +2,6 @@ import os
 import unittest
 from unittest import mock
 
-
 from pkg_resources import resource_filename
 from fontTools.ttLib import TTFont
 

--- a/kiva/fonttools/tests/test_font_manager.py
+++ b/kiva/fonttools/tests/test_font_manager.py
@@ -1,9 +1,7 @@
 import os
 import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
+
 
 from pkg_resources import resource_filename
 from fontTools.ttLib import TTFont

--- a/kiva/testing.py
+++ b/kiva/testing.py
@@ -1,9 +1,6 @@
 # Copyright (c) 2008-2013 by Enthought, Inc.
 # All rights reserved.
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock
+from unittest.mock import Mock
 
 from kiva.image import GraphicsContext
 


### PR DESCRIPTION
part of #415 
`unittest.mock` became part of the standard library in python 3.3.  Since we are dropping all python versions <3.6 we no longer need to have `try ... except`s for these imports 

Also, as a result of this, `mock` can be removed from the list of dependencies in edmtool.py.