### PR TITLE
Remove python version checks 

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -135,11 +135,7 @@ environment_vars = {
     'null': {'ETS_TOOLKIT': 'null.image'},
 }
 
-if sys.version_info < (3, 0):
-    import string
-    pillow_trans = string.maketrans('<=>', '___')
-else:
-    pillow_trans = ''.maketrans({'<': '_', '=': '_', '>': '_'})
+pillow_trans = ''.maketrans({'<': '_', '=': '_', '>': '_'})
 
 if sys.platform == 'darwin':
     dependencies.add('Cython')

--- a/enable/tests/primitives/test_image.py
+++ b/enable/tests/primitives/test_image.py
@@ -5,10 +5,7 @@ import sys
 
 import six
 
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 import numpy as np
 from numpy.testing import assert_array_equal

--- a/enable/tests/primitives/test_image.py
+++ b/enable/tests/primitives/test_image.py
@@ -2,10 +2,9 @@
 
 import os
 import sys
+import unittest
 
 import six
-
-import unittest
 
 import numpy as np
 from numpy.testing import assert_array_equal

--- a/kiva/fonttools/font.py
+++ b/kiva/fonttools/font.py
@@ -86,11 +86,6 @@ class Font(object):
             (type(underline) != int) or (not isinstance(face_name, six.string_types)) or \
             (type(encoding) != type(DEFAULT)):
                 raise RuntimeError("Bad value in Font() constructor.")
-        ### HACK:  C++ stuff expects a string (not unicode) for the face_name, so fix
-        ###        if needed.
-        ### Only for python < 3
-        if six.PY2 and isinstance(face_name, six.text_type):
-            face_name = face_name.encode("latin1")
         self.size = size
         self.family = family
         self.weight = weight


### PR DESCRIPTION
part of #415 

This PR removes any explicit python version checks and only keeps the code paths that are specific to python versions we plan to continue to support (python >=3.6).