### PR TITLE
Remove all use of six from codebase

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -94,7 +94,6 @@ supported_combinations = {
 
 dependencies = {
     "apptools",
-    "six",
     "nose",
     "mock",
     "coverage",

--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -10,7 +10,6 @@ __requires__ = [
     'traits',
     'traitsui',
     'pyface',
-    'six',
     'fonttools'
 ]
 

--- a/enable/abstract_window.py
+++ b/enable/abstract_window.py
@@ -1,6 +1,6 @@
+from functools import reduce
 
 # Major library imports
-import six.moves as sm
 from numpy import dot
 
 # Enthought library imports
@@ -137,7 +137,7 @@ class AbstractWindow(HasTraits):
             gc.clear(self.bgcolor_)
         else:
             # Fixme: should use clip_to_rects
-            update_union = sm.reduce(union_bounds, self._update_region)
+            update_union = reduce(union_bounds, self._update_region)
             gc.clip_to_rect(*update_union)
         return
 
@@ -268,7 +268,7 @@ class AbstractWindow(HasTraits):
             if history is not None and len(history) > 0:
                 # Assemble all the transforms
                 transforms = [c.get_event_transform() for c in history]
-                total_transform = sm.reduce(dot, transforms[::-1])
+                total_transform = reduce(dot, transforms[::-1])
                 key_event.push_transform(total_transform)
             elif self.mouse_owner_transform is not None:
                 key_event.push_transform(self.mouse_owner_transform)
@@ -317,7 +317,7 @@ class AbstractWindow(HasTraits):
             if history is not None and len(history) > 0:
                 # Assemble all the transforms
                 transforms = [c.get_event_transform() for c in history]
-                total_transform = sm.reduce(dot, transforms[::-1])
+                total_transform = reduce(dot, transforms[::-1])
                 mouse_event.push_transform(total_transform)
             elif self.mouse_owner_transform is not None:
                 mouse_event.push_transform(self.mouse_owner_transform)

--- a/enable/base.py
+++ b/enable/base.py
@@ -23,8 +23,6 @@ Enable package.
 
 from __future__ import generators
 
-# Major library imports
-import six.moves as sm
 
 # Enthought library imports
 from traits.api import TraitError
@@ -240,7 +238,7 @@ def send_event_to ( components, event_name, event ):
         setattr( component, pre_event_name, event )
         if event.handled:
             return len( components )
-    for i in sm.range( len( components ) - 1, -1, -1 ):
+    for i in range( len( components ) - 1, -1, -1 ):
         setattr( components[i], event_name, event )
         if event.handled:
             return i

--- a/enable/constraints_container.py
+++ b/enable/constraints_container.py
@@ -4,8 +4,6 @@
 #------------------------------------------------------------------------------
 from collections import deque
 
-import six
-
 # traits imports
 from traits.api import Any, Bool, Callable, Dict, Either, Instance, List, \
     Property
@@ -245,7 +243,7 @@ class ConstraintsContainer(Container):
         """ Make sure components that are added can be used with constraints.
         """
         # Clear the component maps
-        for key, item in six.iteritems(self._component_map):
+        for key, item in self._component_map.items():
             item.on_trait_change(self._component_size_hint_changed,
                                  'layout_size_hint', remove=True)
         self._component_map = {}
@@ -295,7 +293,7 @@ class ConstraintsContainer(Container):
         zero_offset = (0, 0)
         offset_table = [zero_offset]
         layout_table = []
-        queue = deque((0, child) for child in six.itervalues(self._component_map))
+        queue = deque((0, child) for child in self._component_map.values())
 
         # Micro-optimization: pre-fetch bound methods and store globals
         # as locals. This method is not on the code path of a resize
@@ -323,7 +321,7 @@ class ConstraintsContainer(Container):
                 running_index += 1
                 if isinst(item, Container_):
                     if item.transfer_layout_ownership(self):
-                        for child in six.itervalues(item._component_map):
+                        for child in item._component_map.values():
                             push((running_index, child))
 
         return offset_table, layout_table

--- a/enable/coordinate_box.py
+++ b/enable/coordinate_box.py
@@ -1,6 +1,3 @@
-
-import six
-
 # Enthought library imports
 from traits.api import HasTraits, Enum, Instance, Property, Tuple
 
@@ -164,7 +161,7 @@ class CoordinateBox(HasTraits):
 
     def _set_width(self, val):
 
-        if isinstance(val, six.string_types):
+        if isinstance(val, str):
             try:
                 val = float(val)
             except:
@@ -179,7 +176,7 @@ class CoordinateBox(HasTraits):
         return self.bounds[1]
 
     def _set_height(self, val):
-        if isinstance(val, six.string_types):
+        if isinstance(val, str):
             try:
                 val = float(val)
             except:

--- a/enable/events.py
+++ b/enable/events.py
@@ -3,7 +3,7 @@ Define the event objects and traits used by Enable components.
 
 For a list of all the possible event suffixes, see interactor.py.
 """
-import six.moves as sm
+from functools import reduce
 
 # Major library imports
 from numpy import array, dot
@@ -104,7 +104,7 @@ class BasicEvent(HasTraits):
         if len(self._transform_stack) == 0:
             return affine.affine_identity()
         else:
-            return sm.reduce(dot, self._transform_stack[::-1])
+            return reduce(dot, self._transform_stack[::-1])
 
     def current_pointer_position(self):
         """

--- a/enable/gadgets/vu_meter.py
+++ b/enable/gadgets/vu_meter.py
@@ -1,8 +1,6 @@
 
 import math
 
-import six.moves as sm
-
 from traits.api import Float, Property, List, Str, Range
 from enable.api import Component
 from kiva.trait_defs.kiva_font_trait import KivaFont
@@ -39,7 +37,7 @@ class VUMeter(Component):
 
     # Values of the percentage-based ticks; these are drawn and labeled along
     # the bottom of the curve axis.
-    percent_ticks = List(list(sm.range(0, 101, 20)))
+    percent_ticks = List(list(range(0, 101, 20)))
 
     # Text to write in the middle of the VU Meter.
     text = Str("VU")

--- a/enable/layout/ab_constrainable.py
+++ b/enable/layout/ab_constrainable.py
@@ -4,11 +4,8 @@
 #------------------------------------------------------------------------------
 from abc import ABCMeta
 
-import six
 
-
-@six.add_metaclass(ABCMeta)
-class ABConstrainable(object):
+class ABConstrainable(object, metaclass=ABCMeta):
     """ An abstract base class for objects that can be laid out using
     layout helpers.
 

--- a/enable/layout/layout_helpers.py
+++ b/enable/layout/layout_helpers.py
@@ -6,9 +6,6 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from uuid import uuid4
 
-import six
-import six.moves as sm
-
 from kiwisolver import Variable, Constraint
 
 from traits.api import HasTraits, Instance, Range
@@ -87,8 +84,7 @@ def is_spacer(item):
 #------------------------------------------------------------------------------
 # Deferred Constraints
 #------------------------------------------------------------------------------
-@six.add_metaclass(ABCMeta)
-class DeferredConstraints(object):
+class DeferredConstraints(object, metaclass=ABCMeta):
     """ Abstract base class for objects that will yield lists of
     constraints upon request.
 
@@ -107,9 +103,9 @@ class DeferredConstraints(object):
         strength.
 
         """
-        if isinstance(other, (float, six.integer_types)):
+        if isinstance(other, (float, int)):
             self.default_string = float(other)
-        elif isinstance(other, six.string_types):
+        elif isinstance(other, str):
             if other not in STRENGTHS:
                 raise ValueError('Invalid strength %r' % other)
             self.default_strength = other
@@ -656,12 +652,12 @@ class GridHelper(BoxHelper):
         row_vars = []
         col_vars = []
         cn_id = self.constraints_id
-        for idx in sm.range(num_rows + 1):
+        for idx in range(num_rows + 1):
             name = 'row' + str(idx)
             var = Variable('{0}|{1}'.format(cn_id, name))
             row_vars.append(var)
             constraints.append(var >= 0)
-        for idx in sm.range(num_cols + 1):
+        for idx in range(num_cols + 1):
             name = 'col' + str(idx)
             var = Variable('{0}|{1}'.format(cn_id, name))
             col_vars.append(var)
@@ -722,7 +718,7 @@ class GridHelper(BoxHelper):
             for cell in cells:
                 if cell.start_row == cell.end_row:
                     row_map[cell.start_row].append(cell.item)
-            for items in six.itervalues(row_map):
+            for items in row_map.values():
                 if len(items) > 1:
                     helpers.append(AlignmentHelper(self.row_align, *items))
 
@@ -734,7 +730,7 @@ class GridHelper(BoxHelper):
             for cell in cells:
                 if cell.start_col == cell.end_col:
                     col_map[cell.start_col].append(cell.item)
-            for items in six.itervalues(row_map):
+            for items in row_map.values():
                 if len(items) > 1:
                     helpers.append(AlignmentHelper(self.col_align, *items))
 
@@ -748,8 +744,7 @@ class GridHelper(BoxHelper):
 #------------------------------------------------------------------------------
 # Abstract Constraint Factory
 #------------------------------------------------------------------------------
-@six.add_metaclass(ABCMeta)
-class AbstractConstraintFactory(object):
+class AbstractConstraintFactory(object, metaclass=ABCMeta):
     """ An abstract constraint factory class. Subclasses must implement
     the 'constraints' method implement which returns a LinearConstraint
     instance.
@@ -1074,8 +1069,7 @@ class AlignmentConstraintFactory(SequenceConstraintFactory):
 #------------------------------------------------------------------------------
 # Spacers
 #------------------------------------------------------------------------------
-@six.add_metaclass(ABCMeta)
-class Spacer(object):
+class Spacer(object, metaclass=ABCMeta):
     """ An abstract base class for spacers. Subclasses must implement
     the 'constrain' method.
 

--- a/enable/layout/linear_symbolic.py
+++ b/enable/layout/linear_symbolic.py
@@ -4,13 +4,10 @@
 # ------------------------------------------------------------------------------
 from abc import ABCMeta
 
-import six
-
 import kiwisolver as kiwi
 
 
-@six.add_metaclass(ABCMeta)
-class LinearSymbolic(object):
+class LinearSymbolic(object, metaclass=ABCMeta):
     """ An abstract base class for testing linear symbolic interfaces.
 
     """

--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -14,8 +14,6 @@
 # been on my list of things to do.
 #------------------------------------------------------------------------------
 
-import six
-
 # Qt imports.
 from pyface.qt import QtCore, QtGui, QtOpenGL
 
@@ -371,14 +369,14 @@ class _Window(AbstractWindow):
                 return None
 
         if event_type == 'character':
-            key = six.text_type(event.text())
+            key = str(event.text())
         else:
             # Convert the keypress to a standard enable key if possible, otherwise
             # to text.
             key_code = event.key()
             key = KEY_MAP.get(key_code)
             if key is None:
-                key = six.unichr(key_code).lower()
+                key = chr(key_code).lower()
 
         if not key:
             return None

--- a/enable/qt4/constants.py
+++ b/enable/qt4/constants.py
@@ -13,8 +13,6 @@ from __future__ import absolute_import
 
 import warnings
 
-import six.moves as sm
-
 from pyface.qt import QtCore
 
 from ..toolkit_constants import key_names, mouse_wheel_axes_names, pointer_names
@@ -84,7 +82,7 @@ pointer_shapes = [
 if len(pointer_names) != len(pointer_shapes):
     warnings.warn("The Qt4 toolkit backend pointer map is out of sync!")
 
-POINTER_MAP = dict(sm.zip(pointer_names, pointer_shapes))
+POINTER_MAP = dict(zip(pointer_names, pointer_shapes))
 
 KEY_MAP = {
     QtCore.Qt.Key_Backspace: 'Backspace',

--- a/enable/qt4/scrollbar.py
+++ b/enable/qt4/scrollbar.py
@@ -3,8 +3,6 @@ Define a standard horizontal and vertical Enable scrollbar component that wraps
 the standard Qt one.
 """
 
-import six.moves as sm
-
 from pyface.qt import QtCore, QtGui
 from traits.api import Any, Bool, Enum, Float, Int, Property, Trait, TraitError
 
@@ -130,7 +128,7 @@ class NativeScrollBar(Component):
 
     def _draw_mainlayer(self, gc, view_bounds=None, mode="default"):
         x_pos, y_pos = self.position
-        x_size, y_size = sm.map(int, self.bounds)
+        x_size, y_size = map(int, self.bounds)
 
         qt_xpos, qt_ypos = self._get_abs_coords(x_pos, y_pos+y_size-1)
 

--- a/enable/savage/compliance/comparator.py
+++ b/enable/savage/compliance/comparator.py
@@ -3,7 +3,7 @@
 renderers.
 """
 
-from six import StringIO
+from io import StringIO
 import glob
 import logging
 import os

--- a/enable/savage/compliance/drawer.py
+++ b/enable/savage/compliance/drawer.py
@@ -1,6 +1,4 @@
 import svg
-import six
-import six.moves as sm
 
 import wx
 import wx.py.shell
@@ -46,7 +44,7 @@ class PathPanel(wx.Panel):
 class DrawFrame(wx.Frame):
     def __init__(self, parent, *args, **kwargs):
         wx.Frame.__init__(self, parent, *args, **kwargs)
-        self.pathOps = {k: v for (k,v) in six.iteritems(wx.GraphicsPath.__dict__) if k.startswith("Add")}
+        self.pathOps = {k: v for (k,v) in wx.GraphicsPath.__dict__.items() if k.startswith("Add")}
         self.pathOps["CloseSubpath"] = wx.GraphicsPath.CloseSubpath
         self.pathOps["MoveToPoint"] = wx.GraphicsPath.MoveToPoint
         self.pathOps[""] = None
@@ -98,14 +96,14 @@ class DrawFrame(wx.Frame):
         self.panel.SetPath(path)
 
     def FillPath(self, path):
-        for row in sm.range(100):
+        for row in range(100):
             #~ print row,
             operation = self.grid.GetCellValue(row, 0)
             if not operation:
                 return
             #~ print operation,
             args = []
-            for col in sm.range(1,20):
+            for col in range(1,20):
                 v = self.grid.GetCellValue(row, col)
                 if not v:
                     break

--- a/enable/savage/compliance/sike.py
+++ b/enable/savage/compliance/sike.py
@@ -5,8 +5,6 @@ from collections import defaultdict
 import os
 import pstats
 
-import six
-
 from traits.api import (Any, Bool, Constant, Dict, Event, Float,
     HasTraits, Instance, Int, List, Property, Str, on_trait_change)
 from traitsui import api as tui
@@ -206,7 +204,7 @@ class SillyStatsWrapper(object):
             self.stats = {}
         elif isinstance(obj, dict):
             self.stats = obj
-        elif isinstance(obj, six.string_types):
+        elif isinstance(obj, str):
             # Load from a file.
             self.stats = pstats.Stats(obj)
         elif hasattr(obj, 'stats'):

--- a/enable/savage/compliance/viewer.py
+++ b/enable/savage/compliance/viewer.py
@@ -2,10 +2,8 @@ from __future__ import print_function
 
 import os
 import time
-from six import StringIO
+from io import StringIO
 import xml.etree.cElementTree as etree
-
-import six.moves as sm
 
 import wx
 import wx.aui
@@ -175,7 +173,7 @@ class ViewFrame(wx.Frame):
     def getFileList(self):
         #look for the test files in the w3c dir
         files = os.listdir(self.getSVGDir())
-        splitted = sm.map(os.path.splitext, files)
+        splitted = map(os.path.splitext, files)
 
         return sorted(fname for fname, ext in splitted)
 

--- a/enable/savage/svg/attributes.py
+++ b/enable/savage/svg/attributes.py
@@ -1,7 +1,7 @@
 """
     Parsers for specific attributes
 """
-import six.moves.urllib.parse as urlparse
+import urllib.parse as urlparse
 from pyparsing import (Literal,
     Optional, oneOf, Group, StringEnd, Combine, Word, alphas, hexnums,
     CaselessLiteral, SkipTo

--- a/enable/savage/svg/backends/kiva/renderer.py
+++ b/enable/savage/svg/backends/kiva/renderer.py
@@ -4,8 +4,6 @@ from math import sqrt, pi
 import sys
 import warnings
 
-import six
-
 import numpy as np
 
 from enable.compiled_path import CompiledPath as KivaCompiledPath
@@ -406,7 +404,7 @@ class Renderer(NullRenderer):
 
     @classmethod
     def setFontStyle(cls, font, style):
-        if isinstance(style, six.string_types):
+        if isinstance(style, str):
             if style not in fonttools.font.font_styles:
                 warnings.warn('font style "%s" not supported' % style)
             else:
@@ -416,7 +414,7 @@ class Renderer(NullRenderer):
 
     @classmethod
     def setFontWeight(cls, font, weight):
-        if isinstance(weight, six.string_types):
+        if isinstance(weight, str):
             if weight not in fonttools.font.font_weights:
                 warnings.warn('font weight "%s" not supported' % weight)
             else:

--- a/enable/savage/svg/css/colour.py
+++ b/enable/savage/svg/css/colour.py
@@ -9,7 +9,7 @@
     * named color: black
 """
 import string
-import six.moves.urllib.parse as urlparse
+import urllib.parse as urlparse
 from pyparsing import nums, Literal, Optional, oneOf, Group, StringEnd, Combine, Word, alphas, hexnums
 from enable.savage.svg.pathdata import number, sign
 

--- a/enable/savage/svg/css/identifier.py
+++ b/enable/savage/svg/css/identifier.py
@@ -1,6 +1,4 @@
 """ Parse CSS identifiers. More complicated than it sounds"""
-import six
-
 from pyparsing import Word, Literal, Regex, Combine, Optional, White, oneOf, ZeroOrMore
 import string
 import re
@@ -17,7 +15,7 @@ escaped = (
 )
 
 def convertToUnicode(t):
-    return six.unichr(int(t[0], 16))
+    return chr(int(t[0], 16))
 hex_unicode = (
     Literal("\\").suppress() +
     Regex("[0-9a-f]{1,6}", re.IGNORECASE) +

--- a/enable/savage/svg/document.py
+++ b/enable/savage/svg/document.py
@@ -9,10 +9,8 @@ import math
 from functools import wraps
 import os
 
-import six
-import six.moves as sm
-
-import six.moves.urllib.parse as urlparse
+import urllib
+import urllib.parse as urlparse
 from xml.etree import cElementTree as ET
 try:
     from xml.etree.cElementTree import ParseError
@@ -188,7 +186,7 @@ class ResourceGetter(object):
             # Plain URI. Pass it back.
             # Read the data and stuff it in a StringIO in order to satisfy
             # functions that need a functioning seek() and stuff.
-            return path, lambda uri: BytesIO(sm.urllib.request.urlopen(uri).read())
+            return path, lambda uri: BytesIO(urllib.request.urlopen(uri).read())
         path = os.path.abspath(os.path.join(self.dirname, path_part))
         return path, lambda fn: open(fn, 'rb')
 
@@ -761,10 +759,10 @@ class SVGDocument(object):
                 else:
                     arguments = iter(arguments)
                     if command ==  'm':
-                        yield (command, six.next(arguments))
+                        yield (command, next(arguments))
                         command = "l"
                     elif command == "M":
-                        yield (command, six.next(arguments))
+                        yield (command, next(arguments))
                         command = "L"
                     for arg in arguments:
                         yield (command, arg)
@@ -826,7 +824,7 @@ class SVGDocument(object):
             pen.SetWidth(width)
         stroke_dasharray = self.state.get('stroke-dasharray', 'none')
         if stroke_dasharray != 'none':
-            stroke_dasharray = list(sm.map(valueToPixels,
+            stroke_dasharray = list(map(valueToPixels,
                 stroke_dasharray.replace(',', ' ').split()))
             if len(stroke_dasharray) % 2:
                 # Repeat to get an even array.
@@ -1008,7 +1006,7 @@ class SVGDocument(object):
             path.AddLineToPoint(*pt)
         elif type == 'C':
             #control1, control2, endpoint = arg
-            control1, control2, endpoint = sm.map(
+            control1, control2, endpoint = map(
                 normalizePoint, arg
             )
             self.lastControl = control2
@@ -1026,7 +1024,7 @@ class SVGDocument(object):
 
         elif type == 'S':
             #control2, endpoint = arg
-            control2, endpoint = sm.map(
+            control2, endpoint = map(
                 normalizePoint, arg
             )
             if self.lastControl:
@@ -1041,7 +1039,7 @@ class SVGDocument(object):
                 endpoint
             )
         elif type == "Q":
-            (cx, cy), (x,y) = sm.map(normalizePoint, arg)
+            (cx, cy), (x,y) = map(normalizePoint, arg)
             self.lastControlQ = (cx, cy)
             path.AddQuadCurveToPoint(cx, cy, x, y)
         elif type == "T":

--- a/enable/savage/svg/svg_regex.py
+++ b/enable/savage/svg/svg_regex.py
@@ -16,8 +16,6 @@ Out[5]: [('M', [(100.0, -200.0)])]
 import re
 from functools import partial
 
-import six
-
 
 # Sentinel.
 class _EOF(object):
@@ -118,8 +116,8 @@ class SVGPathParser(object):
         """ Parse a string of SVG <path> data.
         """
         svg_iterator = self.lexer.lex(text)
-        token = six.next(svg_iterator)
-        return self.rule_svg_path(partial(six.next, svg_iterator), token)
+        token = next(svg_iterator)
+        return self.rule_svg_path(partial(next, svg_iterator), token)
 
     def rule_svg_path(self, next, token):
         commands = []

--- a/enable/savage/svg/tests/css/test_identifier.py
+++ b/enable/savage/svg/tests/css/test_identifier.py
@@ -2,11 +2,9 @@ import unittest
 import string
 import sys
 
-import six
-import six.moves as sm
-
 from pyparsing import ParseException, Regex, StringEnd
 import enable.savage.svg.css.identifier as identifier
+
 
 class TestEscaped(unittest.TestCase):
     def testEscapedSpecialChar(self):
@@ -62,20 +60,20 @@ class TestHexUnicode(unittest.TestCase):
 class TestEscape(unittest.TestCase):
     def testEscapeValues(self):
         self.assertEqual(u"&", identifier.escape.parseString(r"\26")[0])
-        self.assertEqual(u'\x81', identifier.escape.parseString("\\" + six.unichr(129))[0])
+        self.assertEqual(u'\x81', identifier.escape.parseString("\\" + chr(129))[0])
         self.assertEqual(u"~", identifier.escape.parseString(r'\~')[0])
 
 
 class TestNonAscii(unittest.TestCase):
     def testNoMatchInAsciiRange(self):
-        for c in sm.map(six.unichr, sm.range(128)):
+        for c in map(chr, range(128)):
             self.assertRaises(
                 ParseException,
                 identifier.nonascii.parseString, c
             )
 
     def testMatchesOutsideAsciiRange(self):
-        for c in sm.map(six.unichr, sm.range(128, sys.maxunicode+1)):
+        for c in map(chr, range(128, sys.maxunicode+1)):
             self.assertEqual(
                 c,
                 identifier.nonascii.parseString(c)[0]

--- a/enable/savage/svg/tests/test_document.py
+++ b/enable/savage/svg/tests/test_document.py
@@ -1,7 +1,7 @@
 import unittest
 import enable.savage.svg.document as document
 import xml.etree.cElementTree as etree
-from six import StringIO
+from io import StringIO
 
 from enable.savage.svg.backends.kiva.renderer import Renderer as KivaRenderer
 

--- a/enable/savage/trait_defs/ui/qt4/svg_editor.py
+++ b/enable/savage/trait_defs/ui/qt4/svg_editor.py
@@ -22,7 +22,7 @@
 #  Imports:
 #-------------------------------------------------------------------------------
 
-from six import BytesIO
+from io import BytesIO
 from xml.etree.cElementTree import ElementTree
 
 from enable.savage.svg.document import SVGDocument

--- a/enable/savage/trait_defs/ui/svg_button_editor.py
+++ b/enable/savage/trait_defs/ui/svg_button_editor.py
@@ -19,8 +19,6 @@
 #  Imports:
 #-------------------------------------------------------------------------------
 
-import six
-
 from enable.savage.trait_defs.ui.toolkit import toolkit_object
 
 from traits.api import Bool, Enum, Int, Property, Range, Str, Any
@@ -101,7 +99,7 @@ class SVGButtonEditor(BasicEditorFactory):
 
     def _set_value ( self, value ):
         self._value = value
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             try:
                 self._value = int( value )
             except:

--- a/enable/scrollbar.py
+++ b/enable/scrollbar.py
@@ -7,7 +7,7 @@ them appropriately in the draw phase.
 
 from __future__ import with_statement
 
-import six.moves as sm
+from functools import reduce
 # PZW: Define a scrollbar that uses the system/wx-native scrollbar instead
 # of drawing our own.
 
@@ -167,13 +167,13 @@ class ScrollBar ( Component ):
         sb_image[ 'vtrack' ] = self.image_for('=sb_vtrack')
         sb_image[ 'htrack' ] = self.image_for('=sb_htrack')
         v_width   = sb_image[ 'vtrack' ].width()
-        vs_height = sm.reduce(lambda a, b: a + sb_image[b].height(),
+        vs_height = reduce(lambda a, b: a + sb_image[b].height(),
                             [ 'vtop', 'vbottom', 'vmid' ], 0)
-        v_height  = sm.reduce(lambda a, b: a + sb_image[b].height(),
+        v_height  = reduce(lambda a, b: a + sb_image[b].height(),
                             [ 'aup', 'adown' ], vs_height)
-        hs_width  = sm.reduce(lambda a, b: a + sb_image[b].width(),
+        hs_width  = reduce(lambda a, b: a + sb_image[b].width(),
                             [ 'hleft', 'hright', 'hmid' ], 0)
-        h_width   = sm.reduce(lambda a, b: a + sb_image[b].width(),
+        h_width   = reduce(lambda a, b: a + sb_image[b].width(),
                             [ 'aleft', 'aright' ], hs_width)
         h_height  = sb_image[ 'htrack' ].height()
         return

--- a/enable/tests/primitives/test_image.py
+++ b/enable/tests/primitives/test_image.py
@@ -3,8 +3,6 @@
 import os
 import sys
 
-import six
-
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
 else:

--- a/enable/text_field.py
+++ b/enable/text_field.py
@@ -5,8 +5,6 @@ from __future__ import with_statement
 from math import floor, sqrt
 from bisect import insort_left
 
-import six.moves as sm
-
 # Enthought library imports
 from traits.api import (Bool, Int, Event, Instance, Any, Property,
                                   List, DelegatesTo)
@@ -392,7 +390,7 @@ class TextField(Component):
         """ Realign all the text being drawn such that the first character being
             drawn in each line is the one at index '_draw_text_xstart.'
         """
-        for i in sm.range(len(self.__draw_text)):
+        for i in range(len(self.__draw_text)):
             line = self._text[self._draw_text_ystart + i]
             self.__draw_text[i] = self._clip_line(line, self._draw_text_xstart)
 
@@ -477,7 +475,7 @@ class TextField(Component):
                 self.__draw_text = []
                 self._draw_text_xstart, self._draw_text_ystart = 0, 0
                 end = min(len(self._text), self._text_height)
-                for i in sm.range(self._draw_text_ystart, end):
+                for i in range(self._draw_text_ystart, end):
                     line = self._clip_line(self._text[i], 0)
                     self.__draw_text.append(line)
             else:

--- a/enable/tools/drag_tool.py
+++ b/enable/tools/drag_tool.py
@@ -1,6 +1,5 @@
 """ Defines the base DragTool class.
 """
-import six.moves as sm
 # Enthought library imports
 from traits.api import Bool, Enum, Tuple, Property, cached_property, List, Str
 from enable.base_tool import BaseTool, KeySpec
@@ -138,7 +137,7 @@ class DragTool(BaseTool):
 
     def _drag_cancel_keypressed(self, event):
         if self._drag_state != "nondrag" and \
-                         any(sm.map(lambda x: x.match(event), self._cancel_keys)):
+                         any(map(lambda x: x.match(event), self._cancel_keys)):
             return self._cancel_drag(event)
         else:
             return False

--- a/enable/tools/value_drag_tool.py
+++ b/enable/tools/value_drag_tool.py
@@ -15,9 +15,6 @@ drag operation has a direct effect on some underlying value.  This can
 potentially be used as the basis for many different interactions,
 
 """
-import six
-
-
 from traits.api import Str, Float, Set, Enum, Bool, Tuple, Dict, Event, Any, Either
 from .drag_tool import DragTool
 
@@ -209,13 +206,13 @@ class AttributeDragTool(ValueDragTool):
         if self.x_attr:
             x_value =  value[0] + delta_x
             if self.x_bounds[0] is not None:
-                if isinstance(self.x_bounds[0], six.string_types):
+                if isinstance(self.x_bounds[0], str):
                     m = getattr(self.model, self.x_bounds[0])
                 else:
                     m = self.x_bounds[0]
                 x_value = max(x_value, m)
             if self.x_bounds[1] is not None:
-                if isinstance(self.x_bounds[1], six.string_types):
+                if isinstance(self.x_bounds[1], str):
                     M = getattr(self.model, self.x_bounds[1])
                 else:
                     M = self.x_bounds[1]
@@ -225,13 +222,13 @@ class AttributeDragTool(ValueDragTool):
         if self.y_attr:
             y_value = value[1] + delta_y
             if self.y_bounds[0] is not None:
-                if isinstance(self.y_bounds[0], six.string_types):
+                if isinstance(self.y_bounds[0], str):
                     m = getattr(self.model, self.y_bounds[0])
                 else:
                     m = self.y_bounds[0]
                 y_value = max(y_value, m)
             if self.y_bounds[1] is not None:
-                if isinstance(self.y_bounds[1], six.string_types):
+                if isinstance(self.y_bounds[1], str):
                     M = getattr(self.model, self.y_bounds[1])
                 else:
                     M = self.y_bounds[1]

--- a/enable/vtk_backend/vtk_window.py
+++ b/enable/vtk_backend/vtk_window.py
@@ -1,7 +1,5 @@
 import warnings
 
-import six
-
 from tvtk.api import tvtk
 from tvtk import messenger
 from traits.api import HasTraits, Any, Callable, Property, Instance, \
@@ -293,7 +291,7 @@ class EnableVTKWindow(AbstractWindow, CoordinateBox):
         key = KEY_MAP.get(self.control.key_sym, None)
 
         if key is None:
-            key = six.text_type(self.control.key_sym)
+            key = str(self.control.key_sym)
 
             if not key:
                 return

--- a/enable/wx/base_window.py
+++ b/enable/wx/base_window.py
@@ -8,8 +8,6 @@ from __future__ import absolute_import
 import sys
 import time
 
-import six
-
 import wx
 
 from traits.api import Any, Instance, Trait
@@ -318,7 +316,7 @@ class BaseWindow(AbstractWindow):
 
         if focus_owner is not None:
             if event_type == 'character':
-                key = six.unichr(event.GetUniChar())
+                key = chr(event.GetUniChar())
                 if not key:
                     return None
             else:
@@ -326,7 +324,7 @@ class BaseWindow(AbstractWindow):
                 if key_code in KEY_MAP:
                     key = KEY_MAP.get(key_code)
                 else:
-                    key = six.unichr(event.GetUniChar()).lower()
+                    key = chr(event.GetUniChar()).lower()
 
             # Use the last-seen mouse coordinates instead of GetX/GetY due
             # to wx bug.

--- a/enable/wx/cairo.py
+++ b/enable/wx/cairo.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 #------------------------------------------------------------------------------
 
-import six.moves as sm
+from functools import reduce
 
 import wx
 
@@ -39,7 +39,7 @@ class Window(BaseWindow):
         wdc = control._dc = wx.PaintDC(control)
         self._update_region = None
         if self._update_region is not None:
-            update_bounds = sm.reduce(union_bounds, self._update_region)
+            update_bounds = reduce(union_bounds, self._update_region)
             pixel_map.draw_to_wxwindow(control, int(update_bounds[0]), int(update_bounds[1]),
                                        width=int(update_bounds[2]), height=int(update_bounds[3]))
         else:

--- a/kiva/_fontdata.py
+++ b/kiva/_fontdata.py
@@ -34,7 +34,7 @@ __doc__="""
 import os
 import sys
 
-from six.moves import UserDict
+from collections import UserDict
 
 # mapping of name to width vector, starts empty until fonts are added
 # e.g. widths['Courier'] = [...600,600,600,...]

--- a/kiva/abstract_graphics_context.py
+++ b/kiva/abstract_graphics_context.py
@@ -2,12 +2,10 @@ from __future__ import absolute_import
 
 from abc import ABCMeta, abstractmethod
 
-import six
-
 from .constants import FILL_STROKE, SQUARE_MARKER
 
-@six.add_metaclass(ABCMeta)
-class AbstractGraphicsContext(object):
+
+class AbstractGraphicsContext(object, metaclass=ABCMeta):
     """ Abstract Base Class for Kiva Graphics Contexts """
 
     # ----------------------------------------------------------------

--- a/kiva/agg/freetype2/src/tools/cordic.py
+++ b/kiva/agg/freetype2/src/tools/cordic.py
@@ -1,8 +1,6 @@
 # compute arctangent table for CORDIC computations in fttrigon.c
 import sys, math
 
-import six.moves as sm
-
 #units  = 64*65536.0   # don't change !!
 units  = 256
 scale  = units/math.pi
@@ -38,7 +36,7 @@ print()
 print("table of arctan( 1/2^n ) for PI = " + repr(units/65536.0) + " units")
 
 # compute range of "i"
-r = list(sm.range(-1, 32))
+r = list(range(-1, 32))
 
 for n in r:
 

--- a/kiva/agg/freetype2/src/tools/docmaker/utils.py
+++ b/kiva/agg/freetype2/src/tools/docmaker/utils.py
@@ -3,8 +3,6 @@
 
 import string, sys, os, glob
 
-import six.moves as sm
-
 # current output directory
 #
 output_dir = None
@@ -127,7 +125,7 @@ def  make_file_list( args = None ):
         file_list = None
     else:
         # now filter the file list to remove non-existing ones
-        file_list = list(sm.filter( file_exists, file_list ))
+        file_list = list(filter( file_exists, file_list ))
 
     return file_list
 

--- a/kiva/agg/tests/unicode_font_test_case.py
+++ b/kiva/agg/tests/unicode_font_test_case.py
@@ -1,7 +1,5 @@
 import unittest
 
-import six
-
 from kiva.agg import AggFontType, GraphicsContextArray
 from kiva.fonttools import Font
 
@@ -12,7 +10,7 @@ class UnicodeTest(unittest.TestCase):
     def test_show_text_at_point(self):
         gc = GraphicsContextArray((100,100))
         gc.set_font(Font())
-        gc.show_text_at_point(six.text_type('asdf'), 5,5)
+        gc.show_text_at_point(str('asdf'), 5,5)
 
     def test_agg_font_type(self):
         f1 = AggFontType(u"Arial")

--- a/kiva/basecore2d.py
+++ b/kiva/basecore2d.py
@@ -32,8 +32,6 @@ transform
 
 from __future__ import absolute_import, print_function
 
-import six.moves as sm
-
 import numpy as np
 from numpy import alltrue, array, asarray, float64, shape, pi, concatenate
 
@@ -449,7 +447,7 @@ class GraphicsContextBase(AbstractGraphicsContext):
         if self.path_transform_indices:
             tf = array(self.active_subpath,
                        object)[self.path_transform_indices, :]
-            self.path_transform_indices = list(sm.range(len(tf)))
+            self.path_transform_indices = list(range(len(tf)))
             self.active_subpath = list(tf)
         else:
             self.active_subpath = []
@@ -514,7 +512,7 @@ class GraphicsContextBase(AbstractGraphicsContext):
             The current point is moved to the last point in 'ends'.
         """
         self._new_subpath()
-        for i in sm.range(min(len(starts), len(ends))):
+        for i in range(min(len(starts), len(ends))):
             self.active_subpath.append((POINT, starts[i]))
             self.active_subpath.append((LINE, ends[i]))
         self.state.current_point = ends[i]

--- a/kiva/cairo.py
+++ b/kiva/cairo.py
@@ -10,7 +10,6 @@
 from __future__ import absolute_import
 import cairo
 import copy
-import six.moves as sm
 
 import numpy
 import warnings
@@ -589,7 +588,7 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
             N.B. Cairo cannot make disjointed lines as a single subpath,
             thus each line forms it's own subpath
         """
-        for start, end in sm.zip(starts, ends):
+        for start, end in zip(starts, ends):
             self._ctx.move_to(*start)
             self._ctx.line_to(*end)
 
@@ -1306,7 +1305,7 @@ if __name__=="__main__":
         x = linspace(low, high, numpoints)
         pd = ArrayPlotData(index=x)
         p = Plot(pd, bgcolor="lightgray", padding=50, border_visible=True)
-        for t,i in sm.zip(cycle(['line','scatter']),sm.range(10)):
+        for t,i in zip(cycle(['line','scatter']),range(10)):
             pd.set_data("y" + str(i), jn(i,x))
             p.plot(("index", "y" + str(i)), color=tuple(COLOR_PALETTE[i]),
                    width = 2.0 * dpi_scale, type=t)

--- a/kiva/fonttools/font.py
+++ b/kiva/fonttools/font.py
@@ -5,8 +5,6 @@ specification strings into Font instances.
 
 from __future__ import absolute_import, print_function
 
-import six
-
 import copy
 from kiva.constants import (DEFAULT, DECORATIVE, ROMAN, SCRIPT, SWISS, MODERN,
                             TELETYPE, NORMAL, ITALIC, BOLD, BOLD_ITALIC)
@@ -83,14 +81,9 @@ class Font(object):
                  style=NORMAL, underline=0, encoding=DEFAULT):
         if (type(size) != int) or (type(family) != type(SWISS)) or \
             (type(weight) != type(NORMAL)) or (type(style) != type(NORMAL)) or \
-            (type(underline) != int) or (not isinstance(face_name, six.string_types)) or \
+            (type(underline) != int) or (not isinstance(face_name, str)) or \
             (type(encoding) != type(DEFAULT)):
                 raise RuntimeError("Bad value in Font() constructor.")
-        ### HACK:  C++ stuff expects a string (not unicode) for the face_name, so fix
-        ###        if needed.
-        ### Only for python < 3
-        if six.PY2 and isinstance(face_name, six.text_type):
-            face_name = face_name.encode("latin1")
         self.size = size
         self.family = family
         self.weight = weight

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -50,15 +50,13 @@ from __future__ import absolute_import, print_function
 
 import logging
 import os
+import pickle
 import sys
 import glob
 import subprocess
 import warnings
 import tempfile
 import errno
-
-import six
-import six.moves as sm
 
 from fontTools.ttLib import TTCollection, TTFont, TTLibError
 from traits.etsconfig.api import ETSConfig
@@ -176,7 +174,7 @@ def _is_writable_dir(p):
     p is a string pointing to a putative writable dir -- return True p
     is such a string, else False
     """
-    if not isinstance(p, six.string_types):
+    if not isinstance(p, str):
         return False
 
     try:
@@ -210,7 +208,7 @@ def is_string_like(obj):
     'Return True if *obj* looks like a string'
     from numpy import ma
 
-    if isinstance(obj, six.string_types):
+    if isinstance(obj, str):
         return True
     # numpy strings are subclass of str, ma strings are not
     if ma.isMaskedArray(obj):
@@ -287,7 +285,7 @@ def win32FontDirectory():
     If the key is not found, $WINDIR/Fonts will be returned.
     """
     try:
-        from six.moves import winreg
+        import winreg
     except ImportError:
         pass  # Fall through to default
     else:
@@ -313,7 +311,7 @@ def win32InstalledFonts(directory=None, fontext='ttf'):
     'afm'.
     """
 
-    from six.moves import winreg
+    import winreg
     if directory is None:
         directory = win32FontDirectory()
 
@@ -332,7 +330,7 @@ def win32InstalledFonts(directory=None, fontext='ttf'):
                 files.extend(glob.glob(os.path.join(directory, '*.'+ext)))
             return files
         try:
-            for j in sm.range(winreg.QueryInfoKey(local)[1]):
+            for j in range(winreg.QueryInfoKey(local)[1]):
                 try:
                     key, direc, any = winreg.EnumValue(local, j)
                     if not os.path.dirname(direc):
@@ -477,7 +475,7 @@ def findSystemFonts(fontpaths=None, fontext='ttf'):
             for f in get_fontconfig_fonts(fontext):
                 fontfiles[f] = 1
 
-    elif isinstance(fontpaths, six.string_types):
+    elif isinstance(fontpaths, str):
         fontpaths = [fontpaths]
 
     for path in fontpaths:
@@ -734,7 +732,7 @@ def createFontList(fontfiles, fontext='ttf'):
                                 font_entry_err_msg, fpath, exc_info=True)
                             continue
                 else:
-                    font = TTFont(six.text_type(fpath))
+                    font = TTFont(str(fpath))
             except (RuntimeError, TTLibError):
                 logger.error(
                     "Could not open font file %s", fpath, exc_info=True)
@@ -866,12 +864,12 @@ class FontProperties(object):
         Return the name of the font that best matches the font
         properties.
         """
-        filename = six.text_type(fontManager.findfont(self))
+        filename = str(fontManager.findfont(self))
         if filename.endswith('.afm'):
             return afm.AFM(open(filename)).get_familyname()
 
         font = fontManager.findfont(self)
-        prop_dict = getPropDict(TTFont(six.text_type(font)))
+        prop_dict = getPropDict(TTFont(str(font)))
         return prop_dict['name']
 
     def get_style(self):
@@ -1045,7 +1043,7 @@ def pickle_dump(data, filename):
     """
     fh = open(filename, 'wb')
     try:
-        sm.cPickle.dump(data, fh)
+        pickle.dump(data, fh)
     finally:
         fh.close()
 
@@ -1057,7 +1055,7 @@ def pickle_load(filename):
     """
     fh = open(filename, 'rb')
     try:
-        data = sm.cPickle.load(fh)
+        data = pickle.load(fh)
     finally:
         fh.close()
     return data
@@ -1096,7 +1094,7 @@ class FontManager:
                 else:
                     paths.append(ttfpath)
 
-        logger.debug("font search path %s", six.text_type(paths))
+        logger.debug("font search path %s", str(paths))
         #  Load TrueType fonts and create font dictionary.
 
         self.ttffiles = findSystemFonts(paths) + findSystemFonts()

--- a/kiva/pdf.py
+++ b/kiva/pdf.py
@@ -20,7 +20,6 @@
 from __future__ import absolute_import, print_function
 
 # standard library imports
-import six.moves as sm
 import warnings
 import copy
 from numpy import array, pi
@@ -343,7 +342,7 @@ class GraphicsContext(GraphicsContextBase):
         if self.current_pdf_path is None:
             self.begin_path()
 
-        for start, end in sm.zip(starts, ends):
+        for start, end in zip(starts, ends):
             self.current_pdf_path.moveTo(start[0], start[1])
             self.current_pdf_path.lineTo(end[0], end[1])
             self.current_point = (end[0], end[1])

--- a/kiva/pdfmetrics.py
+++ b/kiva/pdfmetrics.py
@@ -39,9 +39,6 @@ trap attempts to access them and do it on first access.
 import string, os
 import warnings
 
-import six
-import six.moves as sm
-
 # XXX Kiva specific changes
 defaultEncoding = 'WinAnsiEncoding'       # 'WinAnsi' or 'MacRoman'
 
@@ -226,7 +223,7 @@ class Encoding:
             # assume based on the usual one
             self.baseEncodingName = defaultEncoding
             self.vector = _fontdata.encodings[defaultEncoding]
-        elif isinstance(base, six.string_types):
+        elif isinstance(base, str):
             baseEnc = getEncoding(base)
             self.baseEncodingName = baseEnc.name
             self.vector = baseEnc.vector[:]
@@ -279,7 +276,7 @@ class Encoding:
 
         ranges = []
         curRange = None
-        for i in sm.range(len(self.vector)):
+        for i in range(len(self.vector)):
             glyph = self.vector[i]
             if glyph==otherEnc.vector[i]:
                 if curRange:

--- a/kiva/ps.py
+++ b/kiva/ps.py
@@ -18,11 +18,10 @@
 from __future__ import print_function
 
 # Major library imports
+from io import StringIO
 import os
 import sys
 import warnings
-
-import six
 
 from numpy import arange, ravel, array
 
@@ -50,7 +49,7 @@ CompiledPath = None
 
 
 def _strpoints(points):
-    c = six.StringIO()
+    c = StringIO()
     for x,y in points:
         c.write('%3.2f,%3.2f ' % (x,y))
     return c.getvalue()
@@ -111,12 +110,12 @@ class PSGC(basecore2d.GraphicsContextBase):
         super(PSGC, self).__init__(size, *args, **kwargs)
         self.size = size
         self._height = size[1]
-        self.contents = six.StringIO()
+        self.contents = StringIO()
         self._clipmap = {}
         self.clip_id = None
 
     def clear(self):
-        self.contents = six.StringIO()
+        self.contents = StringIO()
 
     def width(self):
         return self.size[0]

--- a/kiva/qpainter.py
+++ b/kiva/qpainter.py
@@ -13,7 +13,6 @@
 from __future__ import absolute_import, print_function
 
 from functools import partial
-import six.moves as sm
 import numpy as np
 import warnings
 
@@ -342,7 +341,7 @@ class GraphicsContext(object):
     def line_set(self, starts, ends):
         """ Draw multiple disjoint line segments.
         """
-        for start, end in sm.zip(starts, ends):
+        for start, end in zip(starts, ends):
             self.path.path.moveTo(start[0], start[1])
             self.path.path.lineTo(end[0], end[1])
 

--- a/kiva/svg.py
+++ b/kiva/svg.py
@@ -35,12 +35,11 @@ Miscellaneous notes:
 """
 
 # Major library imports
+from io import StringIO
 import os
 import sys
 from numpy import arange, ravel, array
 import warnings
-
-import six
 
 # Local, relative Kiva imports
 from . import affine
@@ -57,7 +56,7 @@ from . import agg
 from base64 import b64encode
 
 def _strpoints(points):
-    c = six.StringIO()
+    c = StringIO()
     for x,y in points:
         c.write('%3.2f,%3.2f ' % (x,y))
     return c.getvalue()
@@ -146,7 +145,7 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
         super(GraphicsContext, self).__init__(self, size, *args, **kwargs)
         self.size = size
         self._height = size[1]
-        self.contents = six.StringIO()
+        self.contents = StringIO()
         self._clipmap = {}
 
     def render(self, format):
@@ -156,7 +155,7 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
         return xmltemplate % locals()
 
     def clear(self):
-        self.contents = six.StringIO()
+        self.contents = StringIO()
 
     def width(self):
         return self.size[0]
@@ -265,7 +264,7 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
             # This is not strictly required.
             pil_img = pil_img.resize((int(width), int(height)), PilImage.NEAREST)
 
-        png_buffer = six.StringIO()
+        png_buffer = StringIO()
         pil_img.save(png_buffer, 'png')
         b64_img_data = b64encode(png_buffer.getvalue())
         png_buffer.close()

--- a/kiva/tests/agg/image_test_case.py
+++ b/kiva/tests/agg/image_test_case.py
@@ -4,8 +4,6 @@ from timeit import Timer
 import os, sys
 import unittest
 
-import six
-
 from PIL import Image
 from numpy import alltrue, array, concatenate, dtype, frombuffer, newaxis, \
                   pi, ravel, ones, zeros

--- a/kiva/tests/dummy.py
+++ b/kiva/tests/dummy.py
@@ -1,7 +1,5 @@
 from __future__ import with_statement
 
-import six
-
 from enable.kiva_graphics_context import GraphicsContext
 from kiva import affine
 from kiva.fonttools import Font
@@ -243,7 +241,7 @@ if __name__ == "__main__":
     )
     gcs = { 'eps': ps.PSGC, 'svg': svg.GraphicsContext }
 
-    for fmt, gc in six.iteritems(gcs):
+    for fmt, gc in gcs.items():
         for test_func in tests:
             context = gc((800, 600))
             test_func(context)

--- a/kiva/tests/test_graphics_context.py
+++ b/kiva/tests/test_graphics_context.py
@@ -7,8 +7,6 @@ from PIL import Image as PILImage
 from hypothesis import given
 from hypothesis.strategies import sampled_from
 
-import six
-
 from kiva.image import GraphicsContext
 from kiva.compat import piltostring
 

--- a/kiva/tests/test_pdf_drawing.py
+++ b/kiva/tests/test_pdf_drawing.py
@@ -1,8 +1,6 @@
 import contextlib
 import unittest
 
-import six
-
 from kiva.tests.drawing_tester import DrawingTester
 
 try:
@@ -48,10 +46,10 @@ class TestPDFDrawing(DrawingTester, unittest.TestCase):
         # been drawn.
         line = content.getData().splitlines()[-2]
         if not any((
-                line.endswith(six.b('f')),
-                line.endswith(six.b('S')),
-                line.endswith(six.b('f*')),
-                line.endswith(six.b('ET')) and six.b('hello kiva') in line)):
+                line.endswith('f'),
+                line.endswith('S'),
+                line.endswith('f*'),
+                line.endswith('ET') and 'hello kiva' in line)):
             self.fail('Path was not closed')
 
 

--- a/kiva/tests/test_pdf_drawing.py
+++ b/kiva/tests/test_pdf_drawing.py
@@ -46,10 +46,10 @@ class TestPDFDrawing(DrawingTester, unittest.TestCase):
         # been drawn.
         line = content.getData().splitlines()[-2]
         if not any((
-                line.endswith('f'),
-                line.endswith('S'),
-                line.endswith('f*'),
-                line.endswith('ET') and 'hello kiva' in line)):
+                line.endswith(b'f'),
+                line.endswith(b'S'),
+                line.endswith(b'f*'),
+                line.endswith(b'ET') and b'hello kiva' in line)):
             self.fail('Path was not closed')
 
 


### PR DESCRIPTION
part of #415 

I apologize to the reviewer in advance as this is quite a lengthy PR.  This PR removes all use of the `six` package in the codebase as we are dropping python 2 support.  