### PR TITLE
remove all "coding: UTF-8" headers

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Enable documentation build configuration file, created by
 # sphinx-quickstart on Mon Jul 21 22:01:37 2008.
 #

--- a/enable/savage/compliance/sike.py
+++ b/enable/savage/compliance/sike.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: UTF-8 -*-
 
 from collections import defaultdict
 import os

--- a/enable/savage/compliance/xml_view.py
+++ b/enable/savage/compliance/xml_view.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: UTF-8 -*-
 """ Traits UI tools for viewing the XML tree of SVG files.
 """
 


### PR DESCRIPTION
part of #415 

Python 3 reads source code in UTF-8 by default, so these can all be removed