### PR TITLE
Replace dangerous [] defaults with None, and explicitly check for None

### DIFF
--- a/enable/savage/svg/backends/kiva/renderer.py
+++ b/enable/savage/svg/backends/kiva/renderer.py
@@ -166,13 +166,15 @@ class LinearGradientBrush(AbstractGradientBrush):
     """ A Brush representing a linear gradient.
     """
     def __init__(self, x1,y1, x2,y2, stops, spreadMethod='pad',
-        transforms=[], units='userSpaceOnUse'):
+        transforms=None, units='userSpaceOnUse'):
         self.x1 = x1
         self.y1 = y1
         self.x2 = x2
         self.y2 = y2
         self.stops = stops
         self.spreadMethod = spreadMethod
+        if transforms is None:
+            transforms = []
         self.transforms = transforms
         self.units = units
 
@@ -220,7 +222,7 @@ class RadialGradientBrush(AbstractGradientBrush):
     """ A Brush representing a radial gradient.
     """
     def __init__(self, cx,cy, r, stops, fx=None,fy=None, spreadMethod='pad',
-        transforms=[], units='userSpaceOnUse'):
+        transforms=None, units='userSpaceOnUse'):
         self.cx = cx
         self.cy = cy
         self.r = r
@@ -232,6 +234,8 @@ class RadialGradientBrush(AbstractGradientBrush):
             fy = self.cy
         self.fy = fy
         self.spreadMethod = spreadMethod
+        if transforms is None:
+            transforms = []
         self.transforms = transforms
         self.units = units
 
@@ -350,13 +354,13 @@ class Renderer(NullRenderer):
 
     @classmethod
     def createLinearGradientBrush(cls, x1,y1,x2,y2, stops, spreadMethod='pad',
-                                  transforms=[], units='userSpaceOnUse'):
+                                  transforms=None, units='userSpaceOnUse'):
         return LinearGradientBrush(x1,y1,x2,y2,stops, spreadMethod, transforms,
             units)
 
     @classmethod
     def createRadialGradientBrush(cls, cx,cy, r, stops, fx=None,fy=None,
-                                  spreadMethod='pad', transforms=[],
+                                  spreadMethod='pad', transforms=None,
                                   units='userSpaceOnUse'):
         return RadialGradientBrush(cx,cy, r, stops, fx,fy, spreadMethod,
             transforms, units)

--- a/enable/savage/svg/backends/kiva/renderer.py
+++ b/enable/savage/svg/backends/kiva/renderer.py
@@ -336,7 +336,6 @@ class Renderer(NullRenderer):
     def createAffineMatrix(cls, a,b,c,d,x,y):
         # FIXME: should we create a 6x1 or 3x3 matrix???
         return (a,b,c,d,x,y)
-#        return affine.affine_from_values(a,b,c,d,x,y)
 
     @classmethod
     def createBrush(cls, color_tuple):
@@ -345,7 +344,6 @@ class Renderer(NullRenderer):
     @classmethod
     def createNativePen(cls, pen):
         # fixme: Not really sure what to do here...
-        #return wx.GraphicsRenderer_GetDefaultRenderer().CreatePen(pen)
         return pen
 
     @classmethod
@@ -544,12 +542,6 @@ class Renderer(NullRenderer):
             # text which will render up side down.  To fix this, we set the
             # text transform matrix to have y going up so the text is rendered
             # upright.  But since, +y is now *up*, we need to draw at -y.
-
-            # fixme: There is something wrong with the text matrix.  The following
-            #        commands don't work and I would expect them to.
-            #text_matrix = affine.affine_from_values(1,0,0,-1,x,-y)
-            #gc.set_text_matrix(text_matrix)
-            #gc.show_text_at_point(text, 0, 0)
 
             if anchor != 'start':
                 tx, ty, tw, th = gc.get_text_extent(text)

--- a/enable/savage/svg/backends/kiva/tests/test_renderer.py
+++ b/enable/savage/svg/backends/kiva/tests/test_renderer.py
@@ -1,0 +1,30 @@
+import unittest
+from enable.savage.svg.backends.kiva.renderer import (
+    LinearGradientBrush,
+    RadialGradientBrush,
+    Renderer,
+)
+
+class TestRenderer(unittest.TestCase):
+
+    def test_linear_gradient_brush(self):
+        lgb = LinearGradientBrush(1,1,2,2,3)
+        lgb.transforms.append('a')
+        self.assertEqual(LinearGradientBrush(1,1,2,2,3).transforms, [])
+
+    def test_radial_gradient_brush(self):
+        rgb = RadialGradientBrush(1,1,2,2,3)
+        rgb.transforms.append('a')
+        self.assertEqual(RadialGradientBrush(1,1,2,2,3).transforms, [])
+
+    def test_create_linear_gradient_brush(self):
+        renderer = Renderer()
+        lgb = renderer.createLinearGradientBrush(1,1,2,2,3)
+        lgb.transforms.append('a')
+        self.assertEqual(renderer.createLinearGradientBrush(1,1,2,2,3).transforms, [])
+
+    def test_create_radial_gradient_brush(self):
+        renderer = Renderer()
+        rgb = renderer.createRadialGradientBrush(1,1,2,2,3)
+        rgb.transforms.append('a')
+        self.assertEqual(renderer.createRadialGradientBrush(1,1,2,2,3).transforms, [])

--- a/enable/savage/svg/backends/kiva/tests/test_renderer.py
+++ b/enable/savage/svg/backends/kiva/tests/test_renderer.py
@@ -1,9 +1,11 @@
 import unittest
+
 from enable.savage.svg.backends.kiva.renderer import (
     LinearGradientBrush,
     RadialGradientBrush,
     Renderer,
 )
+
 
 class TestRenderer(unittest.TestCase):
 
@@ -21,10 +23,16 @@ class TestRenderer(unittest.TestCase):
         renderer = Renderer()
         lgb = renderer.createLinearGradientBrush(1,1,2,2,3)
         lgb.transforms.append('a')
-        self.assertEqual(renderer.createLinearGradientBrush(1,1,2,2,3).transforms, [])
+        self.assertEqual(
+            renderer.createLinearGradientBrush(1,1,2,2,3).transforms,
+            []
+        )
 
     def test_create_radial_gradient_brush(self):
         renderer = Renderer()
         rgb = renderer.createRadialGradientBrush(1,1,2,2,3)
         rgb.transforms.append('a')
-        self.assertEqual(renderer.createRadialGradientBrush(1,1,2,2,3).transforms, [])
+        self.assertEqual(
+            renderer.createRadialGradientBrush(1,1,2,2,3).transforms,
+            []
+        )


### PR DESCRIPTION
fixes #395 

This PR adds some tests to illustrate the dangers associated with having `[]` as a default.  It also replaces the default values of `[]` with `None`, and then explicitly checks if the value is `None` and updates the value to `[]` in the method body to avoid the danger.  

Also, I noticed some more commented out code in the file so I removed it here even though it is orthogonal to the purpose of this PR.  