### PR TITLE
Add self as the first argument to method

### DIFF
--- a/kiva/abstract_graphics_context.py
+++ b/kiva/abstract_graphics_context.py
@@ -329,7 +329,7 @@ class AbstractGraphicsContext(object, metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def draw_image(image, rect=None):
+    def draw_image(self, image, rect=None):
         """ Render an image into a rectangle
 
         The rectangle is specified as an (x, y, w, h) tuple.  If it is not


### PR DESCRIPTION
fixes #393 

This PR simply adds self as the first argument to the `draw_image` abstract method.  

I believe this was previously inconsequential because this method is always intended to be overridden.  Those overriding it  add the self argument. Apparently `@abstractmethod` doesn't strictly enforce the signature of the method, so subclasses / registered classes are free to change the signature.

In any case, this method should still take `self` as its first argument. 