### PR TITLE
TST: Switch on default warning flag for CI test command

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -262,10 +262,10 @@ def test(runtime, toolkit, pillow, environment):
     environ = environment_vars.get(toolkit, {}).copy()
     environ['PYTHONUNBUFFERED'] = "1"
     commands = [
-        "edm run -e {environment} -- python -W default -m"
-        "coverage run -m nose.core enable -v --nologcapture",
-        "edm run -e {environment} -- python -W default -m"
-        "coverage run -a -m nose.core kiva -v --nologcapture",
+        ("edm run -e {environment} -- python -W default -m"
+        "coverage run -m nose.core enable -v --nologcapture"),
+        ("edm run -e {environment} -- python -W default -m"
+        "coverage run -a -m nose.core kiva -v --nologcapture"),
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong traitsui

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -262,8 +262,10 @@ def test(runtime, toolkit, pillow, environment):
     environ = environment_vars.get(toolkit, {}).copy()
     environ['PYTHONUNBUFFERED'] = "1"
     commands = [
-        "edm run -e {environment} -- coverage run -m nose.core enable -v --nologcapture",
-        "edm run -e {environment} -- coverage run -a -m nose.core kiva -v --nologcapture",
+        "edm run -e {environment} -- python -W default -m"
+        "coverage run -m nose.core enable -v --nologcapture",
+        "edm run -e {environment} -- python -W default -m"
+        "coverage run -a -m nose.core kiva -v --nologcapture",
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong traitsui


### PR DESCRIPTION
fixes #434 

This PR makes the exact same fix that was done in https://github.com/enthought/envisage/pull/326 and https://github.com/enthought/traitsui/pull/1059. It adds the adds the -W default flag.