### PR TITLE
Add disclaimer in compliance with FreeType License

### DIFF
--- a/docs/source/credits.rst
+++ b/docs/source/credits.rst
@@ -1,0 +1,5 @@
+Credits
+=======
+
+Portions of the Kiva Agg backend are copyright (C) 1996-2000 The FreeType
+Project (www.freetype.org).  All rights reserved except as specified.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,6 @@ Enable Documentation
   enable_apptools_integration.rst
 
   kiva.rst
-
+  credits.rst
 
 * :ref:`search`

--- a/docs/source/kiva.rst
+++ b/docs/source/kiva.rst
@@ -31,6 +31,9 @@ commands into a raster image which can then be saved as a standard image format
 available on any platform, and should work even if there is no GUI or windowing
 system available.
 
+Portions of the Kiva Agg backend are copyright (C) 1996-2000 The FreeType
+Project (www.freetype.org).  All rights reserved except as specified.
+
 Kiva Concepts
 -------------
 

--- a/docs/source/kiva.rst
+++ b/docs/source/kiva.rst
@@ -31,9 +31,6 @@ commands into a raster image which can then be saved as a standard image format
 available on any platform, and should work even if there is no GUI or windowing
 system available.
 
-Portions of the Kiva Agg backend are copyright (C) 1996-2000 The FreeType
-Project (www.freetype.org).  All rights reserved except as specified.
-
 Kiva Concepts
 -------------
 


### PR DESCRIPTION
Per requirement of FreeType License, kiva's documentation must explicitly cite the  FreeType project. This PR adds the require clause. See https://github.com/enthought/enable/blob/76683223b1d76d94b8557d41ea266c823153fa37/kiva/agg/freetype2/docs/LICENSE.TXT and https://github.com/enthought/enable/blob/76683223b1d76d94b8557d41ea266c823153fa37/kiva/agg/freetype2/docs/FTL.TXT