### PR TITLE
Fix documentation build failing on Python 3

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,6 +9,7 @@
 # All configuration values have a default value; values that are commented out
 # serve to show the default value.
 
+import runpy
 import sys, os
 
 # If your extensions are in another directory, add it here. If the directory
@@ -38,9 +39,9 @@ copyright = '2008-2019, Enthought'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
-d = {}
-execfile(os.path.join('..', '..', 'enable', '_version.py'), d)
-version = release = d['full_version']
+base_path = os.path.dirname(__file__)
+version_file = os.path.join(base_path, '..', '..', 'enable', '_version.py')
+version = release = runpy.run_path(version_file)['full_version']
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
When I tried to build the documentation with the following commands:
```
# In an environment with enable source installed
pip install sphinx
cd docs
make html
```

I get the following error:
```
Traceback (most recent call last):
  File "/Users/kchoi/.edm/envs/enable-test-3.6-null-pillow/lib/python3.6/site-packages/sphinx/config.py", line 319, in eval_config_file
    execfile_(filename, namespace)
  File "/Users/kchoi/.edm/envs/enable-test-3.6-null-pillow/lib/python3.6/site-packages/sphinx/util/pycompat.py", line 89, in execfile_
    exec(code, _globals)
  File "/Users/kchoi/Work/ETS/enable/docs/source/conf.py", line 42, in <module>
    execfile(os.path.join('..', '..', 'enable', '_version.py'), d)
NameError: name 'execfile' is not defined
```

`execfile` is a Python 2 built-in. This PR fixes the config file so that the config file works on Python 3. We probably want to add a `docs` command in `ci/edmtool.py` like in the other ETS projects to streamline this step, and possibly run this command as part of CI, but that can come in separate PRs/issues.
 