### PR TITLE
Drop python2 specific imports

### DIFF
--- a/enable/savage/svg/document.py
+++ b/enable/savage/svg/document.py
@@ -10,11 +10,8 @@ import os
 import urllib
 import urllib.parse as urlparse
 from xml.etree import cElementTree as ET
-try:
-    from xml.etree.cElementTree import ParseError
-except ImportError:
-    # ParseError doesn't exist in Python 2.6 and SyntaxError is raised instead
-    ParseError = SyntaxError
+from xml.etree.cElementTree import ParseError
+
 
 
 import numpy

--- a/examples/kiva/agg/benchmark.py
+++ b/examples/kiva/agg/benchmark.py
@@ -1,10 +1,7 @@
 """
 Benchmarks Agg rendering times.
 """
-try:
-    from time import perf_counter
-except ImportError:
-    from time import clock as perf_counter
+from time import perf_counter
 
 from numpy import array, shape, arange, transpose, sin, cos, zeros, pi
 from scipy import stats

--- a/examples/kiva/agg/dash.py
+++ b/examples/kiva/agg/dash.py
@@ -1,7 +1,4 @@
-try:
-    from time import perf_counter
-except ImportError:
-    from time import clock as perf_counter
+from time import perf_counter
 
 from numpy import array
 

--- a/examples/kiva/agg/lion.py
+++ b/examples/kiva/agg/lion.py
@@ -1,7 +1,4 @@
-try:
-    from time import perf_counter
-except ImportError:
-    from time import clock as perf_counter
+from time import perf_counter
 
 from numpy import amax, amin, array
 

--- a/examples/kiva/agg/polygon_hit_test.py
+++ b/examples/kiva/agg/polygon_hit_test.py
@@ -1,7 +1,4 @@
-try:
-    from time import perf_counter
-except ImportError:
-    from time import clock as perf_counter
+from time import perf_counter
 
 import numpy
 

--- a/examples/kiva/agg/simple_clip.py
+++ b/examples/kiva/agg/simple_clip.py
@@ -1,7 +1,4 @@
-try:
-    from time import perf_counter
-except ImportError:
-    from time import clock as perf_counter
+from time import perf_counter
 
 from kiva import agg
 

--- a/examples/kiva/agg/text_ex.py
+++ b/examples/kiva/agg/text_ex.py
@@ -1,7 +1,4 @@
-try:
-    from time import perf_counter
-except ImportError:
-    from time import clock as perf_counter
+from time import perf_counter
 
 from kiva.agg import AffineMatrix, GraphicsContextArray
 from kiva.constants import MODERN

--- a/examples/kiva/dash.py
+++ b/examples/kiva/dash.py
@@ -1,8 +1,5 @@
 import tempfile
-try:
-    from time import perf_counter
-except ImportError:
-    from time import clock as perf_counter
+from time import perf_counter
 
 import numpy
 

--- a/examples/kiva/simple_clip.py
+++ b/examples/kiva/simple_clip.py
@@ -1,7 +1,4 @@
-try:
-    from time import perf_counter
-except ImportError:
-    from time import clock as perf_counter
+from time import perf_counter
 
 from kiva.image import GraphicsContext
 


### PR DESCRIPTION
closes #415 

This PR removes a couple import try excepts that were python 2 specific (e.g. `time.perf_counter` is always available since python 3.3 so we no longer need the except clause)