### PR TITLE
Maint: Make tests for font manager quieter

### DIFF
--- a/kiva/fonttools/tests/test_font_manager.py
+++ b/kiva/fonttools/tests/test_font_manager.py
@@ -28,7 +28,8 @@ class TestCreateFontList(unittest.TestCase):
         "kiva.fonttools.font_manager.ttfFontProperty", side_effect=ValueError)
     def test_ttc_exception_on_ttfFontProperty(self, m_ttfFontProperty):
         # When
-        fontlist = createFontList([self.ttc_fontpath])
+        with self.assertLogs("kiva"):
+            fontlist = createFontList([self.ttc_fontpath])
 
         # Then
         self.assertEqual(len(fontlist), 0)
@@ -38,7 +39,8 @@ class TestCreateFontList(unittest.TestCase):
         "kiva.fonttools.font_manager.TTCollection", side_effect=RuntimeError)
     def test_ttc_exception_on_TTCollection(self, m_TTCollection):
         # When
-        fontlist = createFontList([self.ttc_fontpath])
+        with self.assertLogs("kiva"):
+            fontlist = createFontList([self.ttc_fontpath])
 
         # Then
         self.assertEqual(len(fontlist), 0)


### PR DESCRIPTION
Currently running the tests for font managers causes two log messages to be emitted to console (using last resort log handler):
```
$ python -m unittest kiva.fonttools.tests.test_font_manager
/Users/kchoi/Work/ETS/py39-venv/enable-env/lib/python3.9/site-packages/fontTools/misc/py23.py:11: DeprecationWarning: The py23 module has been deprecated and will be removed in the next release. Please update your code.
  warnings.warn(
.Could not open font file /Users/kchoi/Work/ETS/enable/kiva/fonttools/tests/data/TestTTC.ttc
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/enable/kiva/fonttools/font_manager.py", line 721, in createFontList
    collection = TTCollection(f)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/mock.py", line 1093, in __call__
    return self._mock_call(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/mock.py", line 1097, in _mock_call
    return self._execute_mock_call(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/mock.py", line 1152, in _execute_mock_call
    raise effect
RuntimeError
.Could not convert font to FontEntry for file /Users/kchoi/Work/ETS/enable/kiva/fonttools/tests/data/TestTTC.ttc
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/enable/kiva/fonttools/font_manager.py", line 725, in createFontList
    props.append(ttfFontProperty(fpath, font))
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/mock.py", line 1093, in __call__
    return self._mock_call(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/mock.py", line 1097, in _mock_call
    return self._execute_mock_call(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/mock.py", line 1152, in _execute_mock_call
    raise effect
ValueError
..
----------------------------------------------------------------------
Ran 4 tests in 0.008s

OK
```

This PR makes the tests quieter. The logs are expected because the test deliberately makes the font conversion fail as a test setup.

Having a quieter test suite makes it easier to detect any unexpected logs while refactoring the font_manager module.