### PR TITLE
Remove import side effect of creating font cache in font_manager

### DIFF
--- a/kiva/fonttools/font.py
+++ b/kiva/fonttools/font.py
@@ -5,6 +5,7 @@ specification strings into Font instances.
 import copy
 from kiva.constants import (DEFAULT, DECORATIVE, ROMAN, SCRIPT, SWISS, MODERN,
                             TELETYPE, NORMAL, ITALIC, BOLD, BOLD_ITALIC)
+from .font_manager import default_font_manager, FontProperties
 
 # Various maps used by str_to_font
 font_families = {
@@ -93,8 +94,6 @@ class Font(object):
         """ Returns the file name containing the font that most closely matches
         our font properties.
         """
-        from .font_manager import default_font_manager
-
         fp = self._make_font_props()
         return str(default_font_manager().findfont(fp))
 
@@ -109,8 +108,6 @@ class Font(object):
         """ Returns a font_manager.FontProperties object that encapsulates our
         font properties
         """
-        from .font_manager import FontProperties
-
         # XXX: change the weight to a numerical value
         if self.style == BOLD or self.style == BOLD_ITALIC:
             weight = "bold"

--- a/kiva/fonttools/font.py
+++ b/kiva/fonttools/font.py
@@ -93,10 +93,10 @@ class Font(object):
         """ Returns the file name containing the font that most closely matches
         our font properties.
         """
-        from .font_manager import fontManager
+        from .font_manager import default_font_manager
 
         fp = self._make_font_props()
-        return str(fontManager.findfont(fp))
+        return str(default_font_manager().findfont(fp))
 
     def findfontname(self):
         """ Returns the name of the font that most closely matches our font

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -1390,19 +1390,29 @@ def is_opentype_cff_font(filename):
         return result
     return False
 
-
+# Global singleton of FontManager, cached at the module level.
 fontManager = None
 
-def get_font_cache_path():
+
+def _get_font_cache_path():
+    """ Return the file path for the font cache to be saved / loaded.
+
+    Returns
+    -------
+    path : str
+        Path to the font cache file.
+    """
     return os.path.join(get_configdir(), 'fontList.cache')
 
 
 def _rebuild():
+    """ Rebuild the default font manager and cache its content.
+    """
     global fontManager
-    fontManager = new_font_manager(get_font_cache_path())
+    fontManager = _new_font_manager(_get_font_cache_path())
 
 
-def new_font_manager(cache_file):
+def _new_font_manager(cache_file):
     """ Create a new FontManager (which will reload font files) and immediately
     cache its content with the given file path.
 
@@ -1421,7 +1431,7 @@ def new_font_manager(cache_file):
     return fontManager
 
 
-def rebuild_or_load_from_cache(cache_file):
+def _load_from_cache_or_rebuild(cache_file):
     """ Load the font manager from the cache and verify it is compatible.
     If the cache is not compatible, rebuild the cache and return the new
     font manager.
@@ -1440,12 +1450,12 @@ def rebuild_or_load_from_cache(cache_file):
         fontManager = pickle_load(cache_file)
         if (not hasattr(fontManager, '_version') or
                 fontManager._version != FontManager.__version__):
-            fontManager = new_font_manager(cache_file)
+            fontManager = _new_font_manager(cache_file)
         else:
             fontManager.default_size = None
             logger.debug("Using fontManager instance from %s", cache_file)
     except Exception:
-        fontManager = new_font_manager(cache_file)
+        fontManager = _new_font_manager(cache_file)
 
     return fontManager
 
@@ -1503,5 +1513,5 @@ def default_font_manager():
     """
     global fontManager
     if fontManager is None:
-        fontManager = rebuild_or_load_from_cache(get_font_cache_path())
+        fontManager = _load_from_cache_or_rebuild(_get_font_cache_path())
     return fontManager

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -1399,17 +1399,21 @@ def get_font_cache_path():
 
 def _rebuild():
     global fontManager
-    fontManager = new_with_cache(get_font_cache_path())
+    fontManager = new_font_manager(get_font_cache_path())
 
 
-def new_with_cache(cache_file):
-    """ Create a new FontManager and immediately cache its content with the
-    given file path.
+def new_font_manager(cache_file):
+    """ Create a new FontManager (which will reload font files) and immediately
+    cache its content with the given file path.
 
     Parameters
     ----------
     cache_file : str
         Path to the cache to be created.
+
+    Returns
+    -------
+    font_manager : FontManager
     """
     fontManager = FontManager()
     pickle_dump(fontManager, cache_file)
@@ -1426,18 +1430,22 @@ def rebuild_or_load_from_cache(cache_file):
     ----------
     cache_file : str
         Path to the cache to be created.
+
+    Returns
+    -------
+    font_manager : FontManager
     """
 
     try:
         fontManager = pickle_load(cache_file)
         if (not hasattr(fontManager, '_version') or
                 fontManager._version != FontManager.__version__):
-            fontManager = new_with_cache(cache_file)
+            fontManager = new_font_manager(cache_file)
         else:
             fontManager.default_size = None
             logger.debug("Using fontManager instance from %s", cache_file)
     except Exception:
-        fontManager = new_with_cache(cache_file)
+        fontManager = new_font_manager(cache_file)
 
     return fontManager
 
@@ -1486,7 +1494,12 @@ else:
 
 
 def default_font_manager():
-    """ Return the default font manager.
+    """ Return the default font manager, which is a singleton FontManager
+    cached in the module.
+
+    Returns
+    -------
+    font_manager : FontManager
     """
     global fontManager
     if fontManager is None:

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -1455,3 +1455,10 @@ else:
         global fontManager
         font = fontManager.findfont(prop, **kw)
         return font
+
+
+def default_font_manager():
+    """ Return the default font manager.
+    """
+    global fontManager
+    return fontManager

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -1479,7 +1479,6 @@ if USE_FONTCONFIG and sys.platform != 'win32':
         return result
 
 else:
-    fontManager = rebuild_or_load_from_cache(get_font_cache_path())
 
     def findfont(prop, **kw):
         font = default_font_manager().findfont(prop, **kw)
@@ -1490,4 +1489,6 @@ def default_font_manager():
     """ Return the default font manager.
     """
     global fontManager
+    if fontManager is None:
+        fontManager = rebuild_or_load_from_cache(get_font_cache_path())
     return fontManager

--- a/kiva/fonttools/tests/test_font.py
+++ b/kiva/fonttools/tests/test_font.py
@@ -1,0 +1,27 @@
+""" Tests for kiva.fonttools.font
+"""
+import os
+import unittest
+
+from kiva.fonttools import Font
+
+
+class TestFont(unittest.TestCase):
+
+    def test_find_font_empty_name(self):
+        # This test relies on the fact there exists some fonts on the system
+        # that the font manager can load. Ideally we should be able to redirect
+        # the path from which the font manager loads font files, then this test
+        # can be less fragile.
+        font = Font(face_name="")
+        font_file_path = font.findfont()
+        self.assertTrue(os.path.exists(font_file_path))
+
+    def test_find_font_some_face_name(self):
+        font = Font(face_name="ProbablyNotFound")
+
+        # There will be warnings as there will be no match for the requested
+        # face name.
+        with self.assertWarns(UserWarning):
+            font_file_path = font.findfont()
+        self.assertTrue(os.path.exists(font_file_path))

--- a/kiva/fonttools/tests/test_font_manager.py
+++ b/kiva/fonttools/tests/test_font_manager.py
@@ -1,5 +1,4 @@
 import contextlib
-import glob
 import importlib
 import os
 import shutil
@@ -21,8 +20,6 @@ from ..font_manager import (
     FontEntry,
     FontProperties,
     FontManager,
-    pickle_dump,
-    pickle_load,
     ttfFontProperty,
 )
 
@@ -143,7 +140,7 @@ class TestFontCache(unittest.TestCase):
 
             with patch_global_font_manager(None), \
                     patch_system_fonts(self.ttf_files):  # patch for speed
-                default_manager = font_manager_module.default_font_manager()
+                font_manager_module.default_font_manager()
 
             # The cache file is created
             self.assertTrue(os.path.exists(cache_file))
@@ -156,7 +153,7 @@ class TestFontCache(unittest.TestCase):
         original_module = modules.pop(module_name)
         with change_ets_app_dir(self.temp_dir) as cache_path:
             try:
-                new_module = importlib.import_module(module_name)
+                importlib.import_module(module_name)
             except Exception:
                 raise
             else:

--- a/kiva/fonttools/tests/test_font_manager.py
+++ b/kiva/fonttools/tests/test_font_manager.py
@@ -156,7 +156,7 @@ class TestFontCache(unittest.TestCase):
             ETSConfig.application_data = original_data_dir
             modules[module_name] = original_module
 
-    def test_rebuild_if_cache_not_found(self):
+    def test_no_import_side_effect(self):
         module_name = "kiva.fonttools.font_manager"
         modules = sys.modules
         original_data_dir = ETSConfig.application_data
@@ -168,10 +168,9 @@ class TestFontCache(unittest.TestCase):
         except Exception:
             raise
         else:
-            # A cache is created
-            self.assertTrue(
-                os.path.join(self.temp_dir, "kiva", "fontList.cache")
-            )
+            # A cache is not created
+            cache_path = os.path.join(self.temp_dir, "kiva", "fontList.cache")
+            self.assertFalse(os.path.exists(cache_path))
         finally:
             ETSConfig.application_data = original_data_dir
             modules[module_name] = original_module

--- a/kiva/fonttools/tests/test_font_manager.py
+++ b/kiva/fonttools/tests/test_font_manager.py
@@ -15,7 +15,9 @@ from traits.etsconfig.api import ETSConfig
 from ..font_manager import (
     createFontList,
     default_font_manager,
+    findfont,
     FontEntry,
+    FontProperties,
     FontManager,
     pickle_dump,
     pickle_load,
@@ -147,7 +149,7 @@ class TestFontCache(unittest.TestCase):
                 os.path.join(cache_dir, "fontList.cache")
             )
             self.assertEqual(
-                new_module.fontManager.ttffiles,
+                new_module.default_font_manager().ttffiles,
                 expected_manager.ttffiles,
             )
         finally:
@@ -181,6 +183,20 @@ class TestFontManager(unittest.TestCase):
     def test_default_font_manager(self):
         font_manager = default_font_manager()
         self.assertIsInstance(font_manager, FontManager)
+
+    def test_findFont(self):
+        # Warning because there are no families defined.
+        with self.assertWarns(UserWarning):
+            font = findfont(
+                FontProperties(
+                    family=[],
+                    weight=500,
+                )
+            )
+        # The returned value is a file path
+        # This assumes there exists fonts on the system that can be loaded
+        # by the font manager while the test is run.
+        self.assertTrue(os.path.exists(font))
 
 
 def patch_system_fonts(ttf_files):

--- a/kiva/fonttools/tests/test_font_manager.py
+++ b/kiva/fonttools/tests/test_font_manager.py
@@ -189,6 +189,12 @@ class TestFontManager(unittest.TestCase):
 def change_ets_app_dir(dirpath):
     """ Temporarily change the application data directory in ETSConfig.
 
+    Parameters
+    ----------
+    dirpath : str
+        Path to be temporarily set to the ETSConfig.application_data
+        so that it gets used for computing the font cache file path.
+
     Returns
     -------
     font_cache_file_path : str
@@ -221,6 +227,9 @@ def patch_font_cache(dirpath, ttf_files):
 
     Parameters
     ----------
+    dirpath : str
+        Path to be temporarily set to the ETSConfig.application_data
+        so that it gets used for computing the font cache file path.
     ttf_files : list of str
         List of file paths to TTF files.
 

--- a/kiva/fonttools/tests/test_font_manager.py
+++ b/kiva/fonttools/tests/test_font_manager.py
@@ -136,7 +136,7 @@ class TestFontCache(unittest.TestCase):
 
         font_manager_module.fontManager = None
         with mock.patch.object(
-                font_manager_module, "get_font_cache_path",
+                font_manager_module, "_get_font_cache_path",
                 return_value=self.cache_file
         ):
             default_manager = font_manager_module.default_font_manager()

--- a/kiva/fonttools/tests/test_font_manager.py
+++ b/kiva/fonttools/tests/test_font_manager.py
@@ -119,8 +119,9 @@ class TestFontCache(unittest.TestCase):
             os.path.abspath(os.path.join(data_dir, "TestTTF.ttf"))
         ]
 
-        self.temp_dir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, self.temp_dir)
+        temp_dir_obj = tempfile.TemporaryDirectory()
+        self.temp_dir = temp_dir_obj.name
+        self.addCleanup(temp_dir_obj.cleanup)
 
     def test_load_font_from_cache(self):
         # Test loading fonts from cache file.

--- a/kiva/fonttools/tests/test_font_manager.py
+++ b/kiva/fonttools/tests/test_font_manager.py
@@ -5,7 +5,13 @@ from unittest import mock
 from pkg_resources import resource_filename
 from fontTools.ttLib import TTFont
 
-from ..font_manager import FontEntry, createFontList, ttfFontProperty, getPropDict
+from ..font_manager import (
+    createFontList,
+    default_font_manager,
+    FontEntry,
+    FontManager,
+    ttfFontProperty,
+)
 
 data_dir = resource_filename('kiva.fonttools.tests', 'data')
 
@@ -91,3 +97,11 @@ class TestTTFFontProperty(unittest.TestCase):
         self.assertEqual(entry.weight, exp_weight)
         self.assertEqual(entry.stretch, exp_stretch)
         self.assertEqual(entry.size, exp_size)
+
+
+class TestFontManager(unittest.TestCase):
+    """ Test API of the font manager module."""
+
+    def test_default_font_manager(self):
+        font_manager = default_font_manager()
+        self.assertIsInstance(font_manager, FontManager)

--- a/kiva/trait_defs/ui/wx/kiva_font_editor.py
+++ b/kiva/trait_defs/ui/wx/kiva_font_editor.py
@@ -27,7 +27,7 @@ from traits.trait_base \
 from traitsui.wx.font_editor \
     import ToolkitEditorFactory as EditorFactory
 
-from kiva.fonttools.font_manager import fontManager
+from kiva.fonttools.font_manager import default_font_manager
 
 
 #-------------------------------------------------------------------------------
@@ -119,7 +119,13 @@ class ToolkitEditorFactory ( EditorFactory ):
     def all_facenames(self):
         """ Returns a list of all available font typeface names.
         """
-        return sorted({f.name for f in fontManager.ttflist})
+        return _all_facenames()
+
+
+def _all_facenames():
+    """ Return a list of all available (TTF) font typeface names."""
+    font_manager = default_font_manager()
+    return sorted({f.name for f in font_manager.ttflist})
 
 
 def KivaFontEditor(*args, **traits):

--- a/kiva/trait_defs/ui/wx/kiva_font_editor.py
+++ b/kiva/trait_defs/ui/wx/kiva_font_editor.py
@@ -119,13 +119,8 @@ class ToolkitEditorFactory ( EditorFactory ):
     def all_facenames(self):
         """ Returns a list of all available font typeface names.
         """
-        return _all_facenames()
-
-
-def _all_facenames():
-    """ Return a list of all available (TTF) font typeface names."""
-    font_manager = default_font_manager()
-    return sorted({f.name for f in font_manager.ttflist})
+        font_manager = default_font_manager()
+        return sorted({f.name for f in font_manager.ttflist})
 
 
 def KivaFontEditor(*args, **traits):

--- a/kiva/trait_defs/ui/wx/tests/test_kiva_font_editor.py
+++ b/kiva/trait_defs/ui/wx/tests/test_kiva_font_editor.py
@@ -15,4 +15,5 @@ class TestFacename(unittest.TestCase):
     def test_all_facenames(self):
         # Test loading of available face names does not fail.
         # The available face names depend on the system
-        self.assertGreaterEqual(len(kiva_font_editor._all_facenames()), 0)
+        editor_factory = kiva_font_editor.KivaFontEditor()
+        self.assertGreaterEqual(len(editor_factory.all_facenames()), 0)

--- a/kiva/trait_defs/ui/wx/tests/test_kiva_font_editor.py
+++ b/kiva/trait_defs/ui/wx/tests/test_kiva_font_editor.py
@@ -1,0 +1,18 @@
+""" Tests for ui.wx.kiva_font_editor
+"""
+
+import unittest
+
+from kiva.tests._testing import is_wx, skip_if_not_wx
+
+if is_wx():
+    from kiva.trait_defs.ui.wx import kiva_font_editor
+
+
+@skip_if_not_wx
+class TestFacename(unittest.TestCase):
+
+    def test_all_facenames(self):
+        # Test loading of available face names does not fail.
+        # The available face names depend on the system
+        self.assertGreaterEqual(len(kiva_font_editor._all_facenames()), 0)


### PR DESCRIPTION
Closes #362

This PR removes the import side effect of building font cache in the `font_manager` module. The action of loading fonts and building the cache is deferred until the global font manager singleton is requested.  All code external to `font_manager` should use the `default_font_manager` callable to access this font manager singleton.

Benefits of this change:
- Make it harder to resurrect the import side-effect in other modules that depend on font_manager (it is too easy to introduce an import and not noticing that brings about additional side effects.)
- Make it easier to test `font_manager` without the import side effect. (The global singleton still makes testing harder.)

It might be easier to review this PR by commits. As an overview:
- Add the `default_font_manager` function and add tests for modules (outside of `font_manager` that uses the `fontManager` singleton
- Refactor code to make removing the import side effects easier
- Remove the import side effect
- Rewrite tests after the import side effect is gone: Its absence makes testing easier

Note:
If downstream code has only ever access the FontManager via `kiva.font.Font.findfont`, then this PR does not change the  behaviour perceived externally because #368 already defers the import side effect to where `kiva.font.Font.findfont` is called.