### PR TITLE
Use config for bootstrapping a EDM environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
   - mkdir -p "${HOME}/.cache/download"
   - ci/install-edm.sh
   - export PATH="${HOME}/edm/bin:/usr/lib/ccache:${PATH}"
-  - edm install -y wheel click coverage
+  - edm --config ci/.edm.yaml install -y wheel click coverage
 install:
   - for toolkit in ${TOOLKITS}; do
         if [[ ${TRAVIS_EVENT_TYPE} == "cron" ]] ; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ init:
 
 install:
   - install-edm-windows.cmd
-  - edm install -y wheel click coverage
+  - edm --config ci\.edm.yaml install -y wheel click coverage
   - appveyor-run.cmd install %runtime% %toolkits%
 test_script:
   - appveyor-run.cmd test %runtime% %toolkits%

--- a/ci/.edm.yaml
+++ b/ci/.edm.yaml
@@ -1,0 +1,3 @@
+store_url: https://packages.enthought.com
+repositories:
+  - enthought/free

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -148,6 +148,9 @@ CONTEXT_SETTINGS = {
     "help_option_names": ["-h", "--help"],
 }
 
+# Config file for EDM
+EDM_CONFIG = os.path.join(ROOT, "ci", ".edm.yaml")
+
 
 @click.group(context_settings=CONTEXT_SETTINGS)
 def cli():
@@ -174,7 +177,7 @@ def install(runtime, toolkit, pillow, environment, source):
     # edm commands to setup the development environment
     commands = [
         "edm environments create {environment} --force --version={runtime}",
-        "edm install -y -e {environment} {packages}",
+        "edm --config {edm_config} install -y -e {environment} {packages}",
         "edm run -e {environment} -- pip install {pillow}",
         ("edm run -e {environment} -- pip install -r ci/requirements.txt"
          " --no-dependencies"),
@@ -362,6 +365,8 @@ def get_parameters(runtime, toolkit, pillow, environment):
         environment = tmpl.format(**parameters)
         environment += '-{}'.format(str(pillow).translate(pillow_trans))
         parameters['environment'] = environment
+
+    parameters["edm_config"] = EDM_CONFIG
     return parameters
 
 

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -176,7 +176,7 @@ def install(runtime, toolkit, pillow, environment, source):
         dependencies | extra_dependencies.get(toolkit, set()))
     # edm commands to setup the development environment
     commands = [
-        ("edm --config {edm_config} environments create {environment}"
+        ("edm --config {edm_config} environments create {environment} "
          "--force --version={runtime}"),
         "edm --config {edm_config} install -y -e {environment} {packages}",
         "edm run -e {environment} -- pip install {pillow}",

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -176,7 +176,8 @@ def install(runtime, toolkit, pillow, environment, source):
         dependencies | extra_dependencies.get(toolkit, set()))
     # edm commands to setup the development environment
     commands = [
-        "edm environments create {environment} --force --version={runtime}",
+        ("edm --config {edm_config} environments create {environment}"
+         "--force --version={runtime}"),
         "edm --config {edm_config} install -y -e {environment} {packages}",
         "edm run -e {environment} -- pip install {pillow}",
         ("edm run -e {environment} -- pip install -r ci/requirements.txt"


### PR DESCRIPTION
Currently CI builds are failing because the default config created by EDM includes a repository to `enthought/commercial` that has been ~deprecated~ (edited: removed). The default config should be fixed in EDM. In the meantime, this PR attempts to workaround the issue by specifying a config file to use.

(Orthogonal: Presumably enable should always provide a config file in all the steps involving EDM... but at the same time, if we had always provided a config, it would be harder for such issue to reveal themselves.)