### PR TITLE
Fix AttributeError on Python 3.9 due to usage of removed API in xml

### DIFF
--- a/enable/savage/compliance/viewer.py
+++ b/enable/savage/compliance/viewer.py
@@ -68,7 +68,7 @@ class XMLTree(wx.TreeCtrl):
             node = self.AppendItem(node, txt)
             self.SetPyData(node, element)
         #children
-        for child in element.getchildren():
+        for child in element:
             self.addElementToTree(child, node)
         #attributes
         for key, value in element.items():

--- a/enable/savage/svg/document.py
+++ b/enable/savage/svg/document.py
@@ -653,7 +653,7 @@ class SVGDocument(object):
             clip_path = self.renderer.makePath()
             ops.extend(self.createTransformOpsFromNode(element))
             ops.extend(self.generatePathOps(clip_path))
-            for child in element.getchildren():
+            for child in element:
                 cpath, cops = self.processElement(child)
                 if cpath:
                     clip_path.AddPath(cpath)

--- a/enable/savage/svg/document.py
+++ b/enable/savage/svg/document.py
@@ -302,7 +302,7 @@ class SVGDocument(object):
         attribute it may be given.
         """
         idmap = {}
-        for e in element.getiterator():
+        for e in element.iter():
             id = e.get('id', None)
             if id is not None:
                 idmap[(uri, id)] = e
@@ -468,7 +468,7 @@ class SVGDocument(object):
         path = self.renderer.makePath()
         ops.extend(self.createTransformOpsFromNode(node))
         ops.extend(self.createTransformOpsFromXY(node))
-        for child in node.getchildren():
+        for child in node:
             cpath, cops = self.processElement(child)
             if cpath:
                 path.AddPath(cpath)

--- a/kiva/tests/test_svg_drawing.py
+++ b/kiva/tests/test_svg_drawing.py
@@ -17,7 +17,7 @@ class TestSVGDrawing(DrawingTester, unittest.TestCase):
         filename = "{0}.svg".format(self.filename)
         self.gc.save(filename)
         tree = ElementTree.parse(filename)
-        elements = [element for element in tree.getiterator()]
+        elements = [element for element in tree.iter()]
         if not len(elements) in [4, 7]:
             self.fail('The expected number of elements was not found')
 


### PR DESCRIPTION
Closes #490

The first commit fixes errors that can be seen by running the test suite on Python 3.9.

The second commit makes similar changes, but those changes are not covered by tests.

On the changes that are not covered by test:
For `enable.svg.document.addRectToDocument`. I was trying to write a test that does something like this:
```
    def test_add_rect_to_document_with_clip_path(self):
       # create_svg_text is a function that adds the necessary XML declaration and <svg> root element
        svg_text = create_svg_text(
            '<rect x="11" y="11" clip-path="circle() view-box" />'
        )
        document = document.SVGDocument(etree.parse(StringIO(svg_text)).getroot(), renderer=KivaRenderer())
```
However it still does not reach the code path where I fixed the usage of ElementTree.
It seems that [`if 'clip-path' in node:`](https://github.com/enthought/enable/blob/6b41a429f5cfddc70fa67c3a1025cdd426a98988/enable/savage/svg/document.py#L646) is always false. Previously it was doing `if 'clip-path' in node.keys()` where [`keys()` returns the XML attributes](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.keys), but `node` was thought to be a `dict` during a migration from Python 2 to 3 (see #284).  Upon fixing `in node` to `in node.keys()`, I run into another difficulty trying to open an SVG referenced by the clip-path assuming it was a local file. So I eventually gave up. I am happy to revert the second commit owing to the fact it is untested.
