### PR TITLE
Remove module level findfont in font_manager

### DIFF
--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -1450,11 +1450,6 @@ def _load_from_cache_or_rebuild(cache_file):
     return fontManager
 
 
-def findfont(prop, **kw):
-    font = default_font_manager().findfont(prop, **kw)
-    return font
-
-
 def default_font_manager():
     """ Return the default font manager, which is a singleton FontManager
     cached in the module.

--- a/kiva/fonttools/tests/test_font_manager.py
+++ b/kiva/fonttools/tests/test_font_manager.py
@@ -16,7 +16,6 @@ from .. import font_manager as font_manager_module
 from ..font_manager import (
     createFontList,
     default_font_manager,
-    findfont,
     FontEntry,
     FontProperties,
     FontManager,
@@ -172,20 +171,6 @@ class TestFontManager(unittest.TestCase):
     def test_default_font_manager(self):
         font_manager = default_font_manager()
         self.assertIsInstance(font_manager, FontManager)
-
-    def test_findFont(self):
-        # Warning because there are no families defined.
-        with self.assertWarns(UserWarning):
-            font = findfont(
-                FontProperties(
-                    family=[],
-                    weight=500,
-                )
-            )
-        # The returned value is a file path
-        # This assumes there exists fonts on the system that can be loaded
-        # by the font manager while the test is run.
-        self.assertTrue(os.path.exists(font))
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Closes #497

The module level `kiva.fonttools.font_manager.findfont` function is believed to be unused.

Note that the functionality of `FontManager.findfont` is used via the `Font.findfont` method, where `Font` is a public facing API. That functionality has been tested in `kiva.fonttools.tests.test_font`.