### PR TITLE
Overwrite _create_component instead of _create_window to avoid Error in examples

### DIFF
--- a/enable/examples/demo/enable/shapes/run.py
+++ b/enable/examples/demo/enable/shapes/run.py
@@ -3,7 +3,7 @@ An example showing moveable shapes.
 """
 
 # Enthought library imports.
-from enable.api import Container, Window
+from enable.api import Container
 from enable.example_support import DemoFrame, demo_main
 
 # Local imports

--- a/enable/examples/demo/enable/shapes/run.py
+++ b/enable/examples/demo/enable/shapes/run.py
@@ -1,14 +1,6 @@
 """
-**WARNING**
-
-  This demo might not work as expected and some documented features might be
-  missing.
-
--------------------------------------------------------------------------------
-
 An example showing moveable shapes.
 """
-# Issue related to the demo warning: enthought/enable#500
 
 # Enthought library imports.
 from enable.api import Container, Window
@@ -25,14 +17,13 @@ class MyFrame(DemoFrame):
     # 'DemoFrame' interface.
     #--------------------------------------------------------------------------
 
-    def _create_window(self):
-        """ Create an enable window. """
+    def _create_component(self):
 
         container = Container(
             auto_size=False, bgcolor='black', *self._create_shapes()
         )
 
-        return Window(self, component=container)
+        return container
 
     # Private interface.
     #--------------------------------------------------------------------------

--- a/enable/examples/demo/enable/tools/button_tool.py
+++ b/enable/examples/demo/enable/tools/button_tool.py
@@ -6,17 +6,9 @@
 # LICENSE.txt
 #
 """
-**WARNING**
-
-  This demo might not work as expected and some documented features might be
-  missing.
-
--------------------------------------------------------------------------------
-
 Button Tool
 ===========
 """
-# Issue related to the demo warning: enthought/enable#500
 
 from traits.api import Bool
 from kiva.constants import FILL, STROKE
@@ -81,7 +73,7 @@ class MyFrame(DemoFrame):
     # DemoApplication interface
     #-------------------------------------------------------------------------
 
-    def _create_window(self):
+    def _create_component(self):
         # create a box that changes color when clicked
         push_button_box = SelectableBox(bounds=[100,50], position=[50, 50], color='red')
 
@@ -108,8 +100,7 @@ class MyFrame(DemoFrame):
         container.add(push_button_box)
         container.add(toggle_box)
 
-        window = Window(self, -1, component=container)
-        return window
+        return container
 
 
 if __name__ == "__main__":

--- a/enable/examples/demo/enable/tools/button_tool.py
+++ b/enable/examples/demo/enable/tools/button_tool.py
@@ -13,7 +13,7 @@ Button Tool
 from traits.api import Bool
 from kiva.constants import FILL, STROKE
 
-from enable.api import Container, Window, transparent_color
+from enable.api import Container, transparent_color
 from enable.colors import ColorTrait
 from enable.example_support import DemoFrame, demo_main
 from enable.primitives.api import Box

--- a/enable/examples/demo/enable/tools/drop_tool.py
+++ b/enable/examples/demo/enable/tools/drop_tool.py
@@ -1,14 +1,6 @@
 """
-**WARNING**
-
-  This demo might not work as expected and some documented features might be
-  missing.
-
--------------------------------------------------------------------------------
-
 This demonstrates the use of the drop tool.
 """
-# Issue related to the demo warning: enthought/enable#500
 
 from enable.example_support import DemoFrame, demo_main
 from enable.api import Component, Container, Label, Window
@@ -45,13 +37,15 @@ class TextDropTool(BaseDropTool):
 
 class MyFrame(DemoFrame):
 
-    def _create_window(self):
+    def _create_component(self):
         box = Box(bounds=[100.0, 100.0], position=[50.0, 50.0])
         container = Container(bounds=[500,500])
         container.add(box)
         drop_tool = TextDropTool(component=container)
         container.tools.append(drop_tool)
-        return Window(self, -1, component=container)
+
+        return container
+
 
 if __name__ == "__main__":
     demo_main(MyFrame)

--- a/enable/examples/demo/enable/tools/drop_tool.py
+++ b/enable/examples/demo/enable/tools/drop_tool.py
@@ -3,7 +3,7 @@ This demonstrates the use of the drop tool.
 """
 
 from enable.example_support import DemoFrame, demo_main
-from enable.api import Component, Container, Label, Window
+from enable.api import Component, Container, Label
 from enable.tools.base_drop_tool import BaseDropTool
 
 class Box(Component):


### PR DESCRIPTION
closes #500

In this PR a few examples are update to overwrite the `_create_component` method of `DemoFrame` rather than overwriting `_create_window` (which is only used for the `pyglet` toolkit).  The logic previously contained in the `_create_window` methods could easily be pulled into the `create_component` method.  If `pyglet` is used, the actual window creation is handled by the default behavior of `_create_window` so long as `_create_component` is defined.  In non `pyglet` cases configure_traits is called and the `DemoFrame` class sets things up appropriately.

