### PR TITLE
Make kiva_explorer a popup

### DIFF
--- a/kiva/examples/kiva/kiva_explorer.py
+++ b/kiva/examples/kiva/kiva_explorer.py
@@ -126,6 +126,9 @@ class ScriptedComponentView(ModelView):
         title='Kiva Explorer',
     )
 
+# "popup" is a magically named variable for the etsdemo application which will
+# cause this demo to be run as a popup rather than trying to compress it into
+# a tab on the application
 popup = ScriptedComponentView()
 
 if __name__ == '__main__':

--- a/kiva/examples/kiva/kiva_explorer.py
+++ b/kiva/examples/kiva/kiva_explorer.py
@@ -126,7 +126,7 @@ class ScriptedComponentView(ModelView):
         title='Kiva Explorer',
     )
 
-demo = ScriptedComponentView()
+popup = ScriptedComponentView()
 
 if __name__ == '__main__':
-    demo.configure_traits()
+    popup.configure_traits()


### PR DESCRIPTION
fixes #509 

This is very short PR which simply changes `kiva_explorer` to come up as a popup rather than trying to compress it into the demo tab of the etsdemo application.  All this requires is a change to use the magic named `popup`