### PR TITLE
Clean-up a couple demos

### DIFF
--- a/enable/examples/demo/enable/shapes/api.py
+++ b/enable/examples/demo/enable/shapes/api.py
@@ -1,2 +1,2 @@
-from box import Box
-from circle import Circle
+from enable.examples.demo.enable.shapes.box import Box
+from enable.examples.demo.enable.shapes.circle import Circle

--- a/enable/examples/demo/enable/shapes/run.py
+++ b/enable/examples/demo/enable/shapes/run.py
@@ -7,11 +7,10 @@ from enable.api import Container
 from enable.example_support import DemoFrame, demo_main
 
 # Local imports
-from box import Box
-from circle import Circle
+from enable.examples.demo.enable.shapes.api import Box, Circle
 
 
-class MyFrame(DemoFrame):
+class Demo(DemoFrame):
     """ The top-level frame. """
 
     # 'DemoFrame' interface.
@@ -65,5 +64,5 @@ class MyFrame(DemoFrame):
 if __name__ == "__main__":
     # Save demo so that it doesn't get garbage collected when run within
     # existing event loop (i.e. from ipython).
-    demo = demo_main(MyFrame, size=(500, 500),
+    demo = demo_main(Demo, size=(500, 500),
                      title="Click and drag the shapes")

--- a/enable/examples/demo/enable/tools/pyface/context_menu.py
+++ b/enable/examples/demo/enable/tools/pyface/context_menu.py
@@ -4,7 +4,7 @@ component is created and added to a container.
 """
 
 from enable.example_support import DemoFrame, demo_main
-from enable.api import Component, Container, Window
+from enable.api import Component, Container
 from enable.tools.pyface.context_menu_tool import ContextMenuTool
 
 from pyface.action.api import MenuManager, Action

--- a/enable/examples/demo/enable/tools/pyface/context_menu.py
+++ b/enable/examples/demo/enable/tools/pyface/context_menu.py
@@ -21,11 +21,11 @@ class Box(Component):
             gc.rect(x, y, dx, dy)
             gc.fill_path()
 
-class MyFrame(DemoFrame):
+class Demo(DemoFrame):
     def hello(self):
         print("Hello World")
 
-    def _create_window(self):
+    def _create_component(self):
         box = Box(bounds=[100.0, 100.0], position=[50.0, 50.0])
         menu=MenuManager()
         menu.append(Action(name="Hello World", on_perform=self.hello))
@@ -34,7 +34,9 @@ class MyFrame(DemoFrame):
         box.tools.append(context_menu)
         container = Container(bounds=[500,500])
         container.add(box)
-        return Window(self, -1, component=container)
+
+        return container
+
 
 if __name__ == "__main__":
-    demo_main(MyFrame)
+    demo_main(Demo)


### PR DESCRIPTION
This PR cleans up a couple demos by using absolute imports, using magically named `Demo`, and over writing `_create_component` instead of `_create_window` so that these demos can be run / run smoothly through the etsdemo application