### PR TITLE
Update CI requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,8 @@ env:
 
 matrix:
   include:
-  - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2" PILLOW='pillow'
-  - env: RUNTIME=3.6 TOOLKITS="wx" PILLOW='pillow'
-  - env: RUNTIME=3.6 TOOLKITS=null PILLOW='pillow<3.0.0'
+  - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
+  - env: RUNTIME=3.6 TOOLKITS="wx"
   fast_finish: true
 
 branches:
@@ -60,13 +59,13 @@ before_install:
 install:
   - for toolkit in ${TOOLKITS}; do
         if [[ ${TRAVIS_EVENT_TYPE} == "cron" ]] ; then
-          edm run -- python ci/edmtool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --pillow=${PILLOW} --source || exit;
+          edm run -- python ci/edmtool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit;
         else
-          edm run -- python ci/edmtool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --pillow=${PILLOW} || exit;
+          edm run -- python ci/edmtool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit;
         fi;
     done
 script:
-  - for toolkit in ${TOOLKITS}; do edm run -- python ci/edmtool.py test --runtime=${RUNTIME} --toolkit=${toolkit} --pillow=${PILLOW} || exit; done
+  - for toolkit in ${TOOLKITS}; do edm run -- python ci/edmtool.py test --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
 
 after_success:
   - edm run -- coverage combine

--- a/appveyor-run.cmd
+++ b/appveyor-run.cmd
@@ -13,7 +13,7 @@ FOR %%x IN (%*) DO (
 SET /A counter=!counter! + 1
 IF !counter! EQU 1 SET operation=%%x
 IF !counter! EQU 2 SET runtime=%%x
-IF !counter! GTR 2 CALL edm run -- python ci/edmtool.py !operation! --runtime=!runtime! --toolkit=%%x --pillow=pillow || GOTO error
+IF !counter! GTR 2 CALL edm run -- python ci/edmtool.py !operation! --runtime=!runtime! --toolkit=%%x || GOTO error
 )
 GOTO end
 

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -99,6 +99,7 @@ dependencies = {
     "numpy",
     "pygments",
     "pyparsing",
+    "pillow",
     "reportlab",
     "swig",
     "traits",
@@ -136,8 +137,6 @@ environment_vars = {
     'null': {'ETS_TOOLKIT': 'null.image'},
 }
 
-pillow_trans = ''.maketrans({'<': '_', '=': '_', '>': '_'})
-
 if sys.platform == 'darwin':
     dependencies.add('Cython')
 
@@ -166,18 +165,17 @@ def cli():
 @cli.command()
 @click.option('--runtime', default='3.6')
 @click.option('--toolkit', default='null')
-@click.option('--pillow', default='pillow')
 @click.option('--environment', default=None)
 @click.option(
     "--source/--no-source",
     default=False,
     help="Install ETS packages from source",
 )
-def install(runtime, toolkit, pillow, environment, source):
+def install(runtime, toolkit, environment, source):
     """ Install project and dependencies into a clean EDM environment.
 
     """
-    parameters = get_parameters(runtime, toolkit, pillow, environment)
+    parameters = get_parameters(runtime, toolkit, environment)
     parameters['packages'] = ' '.join(
         dependencies | extra_dependencies.get(toolkit, set()))
     # edm commands to setup the development environment
@@ -186,7 +184,6 @@ def install(runtime, toolkit, pillow, environment, source):
          "--force --version={runtime}"),
         ("edm --config {edm_config} install -y -e {environment} {packages} "
         "--add-repository enthought/lgpl"),
-        "edm run -e {environment} -- pip install {pillow}",
         ("edm run -e {environment} -- pip install -r ci/requirements.txt"
          " --no-dependencies"),
     ]
@@ -245,11 +242,10 @@ def install(runtime, toolkit, pillow, environment, source):
 @cli.command()
 @click.option('--runtime', default='3.6')
 @click.option('--toolkit', default='null')
-@click.option('--pillow', default='pillow')
 @click.option('--environment', default=None)
-def docs(runtime, toolkit, pillow, environment):
+def docs(runtime, toolkit, environment):
     """ Build documentation. """
-    parameters = get_parameters(runtime, toolkit, pillow, environment)
+    parameters = get_parameters(runtime, toolkit, environment)
     packages = " ".join([
         "sphinx",
         "enthought_sphinx_theme",
@@ -315,14 +311,13 @@ def docs(runtime, toolkit, pillow, environment):
 @cli.command()
 @click.option('--runtime', default='3.6')
 @click.option('--toolkit', default='null')
-@click.option('--pillow', default='pillow')
 @click.option('--environment', default=None)
-def shell(runtime, toolkit, pillow, environment):
+def shell(runtime, toolkit, environment):
     """ Create a shell into the EDM development environment
     (aka 'activate' it).
 
     """
-    parameters = get_parameters(runtime, toolkit, pillow, environment)
+    parameters = get_parameters(runtime, toolkit, environment)
     commands = [
         "edm shell -e {environment}",
     ]
@@ -332,13 +327,12 @@ def shell(runtime, toolkit, pillow, environment):
 @cli.command()
 @click.option('--runtime', default='3.6')
 @click.option('--toolkit', default='null')
-@click.option('--pillow', default='pillow')
 @click.option('--environment', default=None)
-def test(runtime, toolkit, pillow, environment):
+def test(runtime, toolkit, environment):
     """ Run the test suite in a given environment with the specified toolkit.
 
     """
-    parameters = get_parameters(runtime, toolkit, pillow, environment)
+    parameters = get_parameters(runtime, toolkit, environment)
     environ = environment_vars.get(toolkit, {}).copy()
     environ['PYTHONUNBUFFERED'] = "1"
     commands = [
@@ -362,13 +356,12 @@ def test(runtime, toolkit, pillow, environment):
 @cli.command()
 @click.option('--runtime', default='3.6')
 @click.option('--toolkit', default='null')
-@click.option('--pillow', default='pillow')
 @click.option('--environment', default=None)
-def cleanup(runtime, toolkit, pillow, environment):
+def cleanup(runtime, toolkit, environment):
     """ Remove a development environment.
 
     """
-    parameters = get_parameters(runtime, toolkit, pillow, environment)
+    parameters = get_parameters(runtime, toolkit, environment)
     commands = [
         "edm run -e {environment} -- python setup.py clean",
         "edm environments remove {environment} --purge -y",
@@ -381,14 +374,14 @@ def cleanup(runtime, toolkit, pillow, environment):
 @cli.command()
 @click.option('--runtime', default='3.6')
 @click.option('--toolkit', default='null')
-@click.option('--pillow', default='pillow')
-def test_clean(runtime, toolkit, pillow):
+def test_clean(runtime, toolkit):
     """ Run tests in a clean environment, cleaning up afterwards
 
     """
-    args = ['--toolkit={}'.format(toolkit),
-            '--runtime={}'.format(runtime),
-            '--pillow={}'.format(pillow)]
+    args = [
+        '--toolkit={}'.format(toolkit),
+        '--runtime={}'.format(runtime),
+    ]
     try:
         install(args=args, standalone_mode=False)
         test(args=args, standalone_mode=False)
@@ -399,13 +392,12 @@ def test_clean(runtime, toolkit, pillow):
 @cli.command()
 @click.option('--runtime', default='3.6')
 @click.option('--toolkit', default='null')
-@click.option('--pillow', default='pillow')
 @click.option('--environment', default=None)
-def update(runtime, toolkit, pillow, environment):
+def update(runtime, toolkit, environment):
     """ Update/Reinstall package into environment.
 
     """
-    parameters = get_parameters(runtime, toolkit, pillow, environment)
+    parameters = get_parameters(runtime, toolkit, environment)
     commands = [
         "edm run -e {environment} -- python setup.py install"]
     click.echo("Re-installing in  '{environment}'".format(**parameters))
@@ -429,19 +421,18 @@ def test_all():
 # Utility routines
 # ----------------------------------------------------------------------------
 
-def get_parameters(runtime, toolkit, pillow, environment):
+def get_parameters(runtime, toolkit, environment):
     """Set up parameters dictionary for format() substitution
     """
-    parameters = {'runtime': runtime, 'toolkit': toolkit, 'pillow': pillow,
+    parameters = {'runtime': runtime, 'toolkit': toolkit,
                   'environment': environment}
     if toolkit not in supported_combinations[runtime]:
-        msg = ("Python {runtime}, toolkit {toolkit}, and pillow {pillow} "
+        msg = ("Python {runtime} and toolkit {toolkit} "
                "not supported by test environments")
         raise RuntimeError(msg.format(**parameters))
     if environment is None:
         tmpl = 'enable-test-{runtime}-{toolkit}'
         environment = tmpl.format(**parameters)
-        environment += '-{}'.format(str(pillow).translate(pillow_trans))
         parameters['environment'] = environment
 
     parameters["edm_config"] = EDM_CONFIG

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -93,9 +93,13 @@ supported_combinations = {
 dependencies = {
     "apptools",
     "coverage",
+    "fonttools",
+    "hypothesis",
+    "kiwisolver",
     "numpy",
     "pygments",
     "pyparsing",
+    "reportlab",
     "swig",
     "traits",
     "traitsui",

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,6 +1,2 @@
 pygarrayimage
-hypothesis<3.0.0
-fonttools==3.28.0
-reportlab<=3.1
-kiwisolver ; python_version <= "2.7"
-https://bitbucket.org/pyglet/pyglet/get/pyglet-1.1.4.zip ; python_version <= "2.7"
+pyglet


### PR DESCRIPTION
This:
- installs requirements from EDM where possible,
- removes the option to use older versions of Pillow,
- installs the most recent Pyglet from PyPI
