### PR TITLE
Add module docstrings to kiva and enable api modules

### DIFF
--- a/enable/api.py
+++ b/enable/api.py
@@ -138,13 +138,6 @@ Enable Widgets
 ==============
 
 - :class:`~.AbstractWindow`
-- :class:`~.NativeScrollBar`
-- :class:`~.Compass`
-- :class:`~.Scrolled`
-- :class:`~.Slider`
-- :class:`~.TextFieldStyle`
-- :class:`~.TextField`
-- :class:`~.TextFieldGrid`
 - :class:`~.Viewport`
 - :class:`~.Window`
 

--- a/enable/api.py
+++ b/enable/api.py
@@ -1,6 +1,161 @@
 """ Enable is an interactive graphical component framework built on top of Kiva.
 
 See https://www.enthought.com/enthought/wiki/EnableProject
+
+Enable Base
+===========
+
+- :class:`~.IDroppedOnHandler`
+- :func:`~.str_to_font`
+- :func:`~.intersect_bounds`
+
+Constants
+---------
+- :attr:`~.TOP`
+- :attr:`~.VCENTER`
+- :attr:`~.BOTTOM`
+- :attr:`~.LEFT`
+- :attr:`~.HCENTER`
+- :attr:`~.RIGHT`
+- :attr:`~.TOP_LEFT`
+- :attr:`~.TOP_RIGHT`
+- :attr:`~.BOTTOM_LEFT`
+- :attr:`~.BOTTOM_RIGHT`
+- :attr:`~.empty_rectangle`
+
+Enable Trait Types
+==================
+
+- :attr:`~.border_size_editor`
+- :attr:`~.font_trait`
+- :attr:`~.bounds_trait`
+- :attr:`~.ComponentMinSize`
+- :attr:`~.ComponentMaxSize`
+- :attr:`~.Pointer`
+- :attr:`~.cursor_style_trait`
+- :attr:`~.spacing_trait`
+- :attr:`~.padding_trait`
+- :attr:`~.margin_trait`
+- :attr:`~.border_size_trait`
+- :attr:`~.TimeInterval`
+- :attr:`~.Stretch`
+- :attr:`~.NoStretch`
+- :attr:`~.LineStyle`
+- :attr:`~.LineStyleEditor`
+
+Constants
+---------
+- :attr:`~.basic_sequence_types`
+- :attr:`~.sequence_types`
+- :attr:`~.pointer_shapes`
+- :attr:`~.CURSOR_X`
+- :attr:`~.CURSOR_Y`
+- :attr:`~.cursor_styles`
+
+Colors
+======
+
+- :attr:`~.color_table`
+- :attr:`~.transparent_color`
+- :class:`~.ColorEditorFactory`
+
+Color Trait Types
+-----------------
+
+- :class:`~.ColorTrait`
+- :attr:`~.black_color_trait`
+- :attr:`~.white_color_trait`
+- :attr:`~.transparent_color_trait`
+
+Markers
+=======
+
+- :class:`~.SquareMarker`
+- :class:`~.CircleMarker`
+- :class:`~.TriangleMarker`
+- :class:`~.Inverted_TriangleMarker`
+- :class:`~.LeftTriangleMarker`
+- :class:`~.RightTriangleMarker`
+- :class:`~.PentagonMarker`
+- :class:`~.Hexagon1Marker`
+- :class:`~.Hexagon2Marker`
+- :class:`~.StarMarker`
+- :class:`~.CrossPlusMarker`
+- :class:`~.PlusMarker`
+- :class:`~.CrossMarker`
+- :class:`~.DiamondMarker`
+- :class:`~.DotMarker`
+- :class:`~.PixelMarker`
+- :class:`~.CustomMarker`
+- :class:`~.AbstractMarker`
+
+Marker Trait Types
+------------------
+- :class:`~.MarkerTrait`
+- :attr:`~.marker_trait`
+
+Marker Constants
+----------------
+- :attr:`~.MarkerNameDict`
+- :attr:`~.marker_names`
+
+Events
+======
+
+- :class:`~.BasicEvent`
+- :class:`~.BlobEvent`
+- :class:`~.BlobFrameEvent`
+- :class:`~.DragEvent`
+- :class:`~.KeyEvent`
+- :class:`~.MouseEvent`
+
+Event Trait Types
+-----------------
+
+- :attr:`~.drag_event_trait`
+- :attr:`~.key_event_trait`
+- :attr:`~.mouse_event_trait`
+
+Enable Components
+=================
+
+- :class:`~.Interactor`
+- :class:`~.BaseTool`
+- :class:`~.KeySpec`
+- :class:`~.AbstractOverlay`
+- :class:`~.Canvas`
+- :class:`~.Component`
+- :class:`~.Container`
+- :class:`~.CoordinateBox`
+- :class:`~.ComponentEditor`
+- :class:`~.OverlayContainer`
+- :class:`~.ConstraintsContainer`
+- :class:`~.Label`
+- :class:`~.GraphicsContextEnable`
+- :class:`~.ImageGraphicsContextEnable`
+
+Enable Widgets
+==============
+
+- :class:`~.AbstractWindow`
+- :class:`~.NativeScrollBar`
+- :class:`~.Compass`
+- :class:`~.Scrolled`
+- :class:`~.Slider`
+- :class:`~.TextFieldStyle`
+- :class:`~.TextField`
+- :class:`~.TextFieldGrid`
+- :class:`~.Viewport`
+- :class:`~.Window`
+
+Drawing Primitives
+==================
+
+- :class:`~.Annotater`
+- :class:`~.Box`
+- :class:`~.Line`
+- :class:`~.Polygon`
+
 """
 
 # Major package imports

--- a/kiva/api.py
+++ b/kiva/api.py
@@ -25,7 +25,7 @@ Constants
 
 - :attr:`~.IDENTITY` - represents the :func:`~.affine_identity` matrix.
 
-Drawing Utilities
+Drawing Constants
 =================
 
 Line Dash Constants
@@ -68,28 +68,6 @@ Text Drawing Mode Constants
 - :attr:`~.TEXT_FILL_STROKE_CLIP`
 - :attr:`~.TEXT_CLIP`
 - :attr:`~.TEXT_OUTLINE`
-
-Subpath Drawing Primitive Constants
------------------------------------
-
-- :attr:`~.POINT`
-- :attr:`~.LINE`
-- :attr:`~.LINES`
-- :attr:`~.RECT`
-- :attr:`~.CLOSE`
-- :attr:`~.CURVE_TO`
-- :attr:`~.QUAD_CURVE_TO`
-- :attr:`~.ARC`
-- :attr:`~.ARC_TO`
-
-Subpath Context Manager Constants
----------------------------------
-
-- :attr:`~.SCALE_CTM`
-- :attr:`~.TRANSLATE_CTM`
-- :attr:`~.ROTATE_CTM`
-- :attr:`~.CONCAT_CTM`
-- :attr:`~.LOAD_CTM`
 
 Marker Types
 ------------

--- a/kiva/api.py
+++ b/kiva/api.py
@@ -1,3 +1,142 @@
+"""
+
+Affine Transformations
+======================
+
+- :func:`~.affine_identity`
+- :func:`~.affine_from_values`
+- :func:`~.affine_from_scale`
+- :func:`~.affine_from_rotation`
+- :func:`~.affine_from_translation`
+- :func:`~.scale`
+- :func:`~.rotate`
+- :func:`~.translate`
+- :func:`~.concat`
+- :func:`~.invert`
+- :func:`~.is_identity`
+- :func:`~.affine_params`
+- :func:`~.tsr_factor`
+- :func:`~.trs_factor`
+- :func:`~.transform_point`
+- :func:`~.transform_points`
+
+Constants
+---------
+
+- :attr:`~.IDENTITY` - represents the :func:`~.affine_identity` matrix.
+
+Drawing Utilities
+=================
+
+Line Dash Constants
+-------------------
+
+- :attr:`~.NO_DASH`
+
+Line Cap Constants
+------------------
+
+- :attr:`~.CAP_ROUND`
+- :attr:`~.CAP_BUTT`
+- :attr:`~.CAP_SQUARE`
+
+Line Join Constants
+-------------------
+
+- :attr:`~.JOIN_ROUND`
+- :attr:`~.JOIN_BEVEL`
+- :attr:`~.JOIN_MITER`
+
+Path Drawing Mode Constants
+---------------------------
+
+- :attr:`~.FILL`
+- :attr:`~.EOF_FILL`
+- :attr:`~.STROKE`
+- :attr:`~.FILL_STROKE`
+- :attr:`~.EOF_FILL_STROKE`
+
+Text Drawing Mode Constants
+---------------------------
+
+- :attr:`~.TEXT_FILL`
+- :attr:`~.TEXT_STROKE`
+- :attr:`~.TEXT_FILL_STROKE`
+- :attr:`~.TEXT_INVISIBLE`
+- :attr:`~.TEXT_FILL_CLIP`
+- :attr:`~.TEXT_STROKE_CLIP`
+- :attr:`~.TEXT_FILL_STROKE_CLIP`
+- :attr:`~.TEXT_CLIP`
+- :attr:`~.TEXT_OUTLINE`
+
+Subpath Drawing Primitive Constants
+-----------------------------------
+
+- :attr:`~.POINT`
+- :attr:`~.LINE`
+- :attr:`~.LINES`
+- :attr:`~.RECT`
+- :attr:`~.CLOSE`
+- :attr:`~.CURVE_TO`
+- :attr:`~.QUAD_CURVE_TO`
+- :attr:`~.ARC`
+- :attr:`~.ARC_TO`
+
+Subpath Context Manager Constants
+---------------------------------
+
+- :attr:`~.SCALE_CTM`
+- :attr:`~.TRANSLATE_CTM`
+- :attr:`~.ROTATE_CTM`
+- :attr:`~.CONCAT_CTM`
+- :attr:`~.LOAD_CTM`
+
+Marker Types
+------------
+
+- :attr:`~.NO_MARKER`
+- :attr:`~.SQUARE_MARKER`
+- :attr:`~.DIAMOND_MARKER`
+- :attr:`~.CIRCLE_MARKER`
+- :attr:`~.CROSSED_CIRCLE_MARKER`
+- :attr:`~.CROSS_MARKER`
+- :attr:`~.TRIANGLE_MARKER`
+- :attr:`~.INVERTED_TRIANGLE_MARKER`
+- :attr:`~.PLUS_MARKER`
+- :attr:`~.DOT_MARKER`
+- :attr:`~.PIXEL_MARKER`
+
+Fonts
+=====
+
+- :class:`~.Font`
+
+Font Constants
+--------------
+
+Font Sizes
+
+- :attr:`~.NORMAL`
+- :attr:`~.BOLD`
+- :attr:`~.ITALIC`
+- :attr:`~.BOLD_ITALIC`
+
+Font Families
+
+- :attr:`~.DEFAULT`
+- :attr:`~.SWISS`
+- :attr:`~.ROMAN`
+- :attr:`~.MODERN`
+- :attr:`~.DECORATIVE`
+- :attr:`~.SCRIPT`
+- :attr:`~.TELETYPE`
+
+Utilities
+=========
+
+- :func:`~.points_in_polygon`
+
+"""
 # flake8: noqa
 from .affine import (
     affine_identity, affine_from_values, affine_from_scale,


### PR DESCRIPTION
This PR adds module docstrings to `enable.api` and `kiva.api`, in an effort to improve the api documentation of kiva and enable.