### PR TITLE
Import version from package instead of manually compiling the version file

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,9 +46,8 @@ copyright = '2008-2019, Enthought'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
-base_path = os.path.dirname(__file__)
-version_file = os.path.join(base_path, '..', '..', 'enable', '_version.py')
-version = release = runpy.run_path(version_file)['full_version']
+from enable import __version__
+version = release = __version__
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
Trying to build the docs on master on a windows machine is broken. Running the `docs` command raises the following error - 

```
Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "C:\Users\rporuri\.edm\envs\enable-test-3.6-pyqt5\lib\site-packages\sphinx\config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "C:\Users\rporuri\.edm\envs\enable-test-3.6-pyqt5\lib\site-packages\sphinx\util\pycompat.py", line 81, in execfile_
    exec(code, _globals)
  File "C:\Users\rporuri\work\github\ets\enable\docs\source\conf.py", line 51, in <module>
    version = release = runpy.run_path(version_file)['full_version']
  File "C:\Users\rporuri\.edm\envs\enable-test-3.6-pyqt5\lib\runpy.py", line 261, in run_path
    code, fname = _get_code_from_file(run_name, path_name)
  File "C:\Users\rporuri\.edm\envs\enable-test-3.6-pyqt5\lib\runpy.py", line 231, in _get_code_from_file
    with open(fname, "rb") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\rporuri\\work\\github\\ets\\enable\\docs\\source\\..\\..\\enable\\_version.py'
```

This seems to be happening because we try creating the `enable/_version.py` and `kiva/_version.py` in the setup.py file - https://github.com/enthought/enable/blob/5834fb812c4506324897a3bd14bfe6875f5f2998/setup.py#L236-L237 - which doesn't work as expected on windows.

Instead of making more modifications to the already messy setup file, I chose to simply import the version info from the package instead of manually searching and compiling the `_version.py` file for the version info.