### PR TITLE
Unset 2to3 flag from setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -307,5 +307,4 @@ if __name__ == "__main__":
           },
           platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
           zip_safe=False,
-          use_2to3=False,
           **config)


### PR DESCRIPTION
Now that we don't have any Python 2 code, we can simply remove the `use_2to3` boolean flag in setup. Note that we werent using 2to3 in the recent release anyway.