### PR TITLE
Dont document null submodule in api docs

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -251,6 +251,7 @@ def docs(runtime, toolkit, environment):
         "enthought_sphinx_theme",
     ])
     ignore = " ".join([
+        "enable/null",
         "enable/qt4",
         "enable/wx",
         "*/tests",

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -252,7 +252,9 @@ def docs(runtime, toolkit, environment):
     ])
     ignore = " ".join([
         "enable/null",
+        "enable/pyglet_backend",
         "enable/qt4",
+        "enable/vtk_backend",
         "enable/wx",
         "*/tests",
     ])


### PR DESCRIPTION
This PR adds `enable.null` submodule to the list of submodules that are ignored when generating the api documentation. FTR, the other modules ignored are `enable/qt4`, `enable/wx` and `*/tests`.