### PR TITLE
Remove TODO.txt from the manifest file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ include CONTRIBUTING.rst
 include LICENSE.txt
 include image_LICENSE.txt
 include image_LICENSE_*.txt
-include TODO.txt
 include kiva/agg/agg.i
 include docs/Makefile
 include docs/kiva/agg/notes


### PR DESCRIPTION
The `TODO.txt` file doesnt exist anymore. It was removed in #474 so we can remove it from the manifest file.