### PR TITLE
Use templates when generating apidocs for enable and kiva

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,16 @@
 *~
 .DS_Store
 
+# Docs files to ignore
+/docs/source/api/*.rst
+!docs/source/api/enable.api.rst
+!docs/source/api/kiva.api.rst
+docs/build/
+
 # Ignore the build directories
 *.egg-info/
 build/
 dist/
-docs/build/
 
 # SWIG & Cython intermediate files
 kiva/agg/agg.py

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -273,9 +273,7 @@ def docs(runtime, toolkit, environment):
         "Regenerating API docs in  '{environment}'".format(**parameters)
     )
     api_path = os.path.join("docs", "source", "api")
-    if os.path.exists(api_path):
-        rmtree(api_path)
-    os.makedirs(api_path)
+    templates_path = os.path.join(api_path, "templates")
     commands = [
         "edm run -e {environment} -- sphinx-apidoc -e -M -o "
         + api_path
@@ -286,8 +284,9 @@ def docs(runtime, toolkit, environment):
     click.echo("Done regenerating enable API docs")
 
     commands = [
-        "edm run -e {environment} -- sphinx-apidoc -e -M -o "
+        "edm run -e {environment} -- sphinx-apidoc --separate --no-toc -o "
         + api_path
+        + " -t " + templates_path
         + " kiva "
         + " */tests"
     ]

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -275,8 +275,9 @@ def docs(runtime, toolkit, environment):
     api_path = os.path.join("docs", "source", "api")
     templates_path = os.path.join(api_path, "templates")
     commands = [
-        "edm run -e {environment} -- sphinx-apidoc -e -M -o "
+        "edm run -e {environment} -- sphinx-apidoc --separate --no-toc -o "
         + api_path
+        + " -t " + templates_path
         + " enable "
         + ignore
     ]

--- a/docs/source/api/enable.api.rst
+++ b/docs/source/api/enable.api.rst
@@ -1,7 +1,4 @@
 enable.api module
 =================
 
-.. toctree::
-  :maxdepth: 2
-
 .. automodule:: enable.api

--- a/docs/source/api/enable.api.rst
+++ b/docs/source/api/enable.api.rst
@@ -1,0 +1,7 @@
+enable.api module
+=================
+
+.. toctree::
+  :maxdepth: 2
+
+.. automodule:: enable.api

--- a/docs/source/api/kiva.api.rst
+++ b/docs/source/api/kiva.api.rst
@@ -1,0 +1,7 @@
+kiva.api module
+===============
+
+.. toctree::
+  :maxdepth: 2
+
+.. automodule:: kiva.api

--- a/docs/source/api/kiva.api.rst
+++ b/docs/source/api/kiva.api.rst
@@ -1,7 +1,4 @@
 kiva.api module
 ===============
 
-.. toctree::
-  :maxdepth: 2
-
 .. automodule:: kiva.api

--- a/docs/source/api/templates/module.rst_t
+++ b/docs/source/api/templates/module.rst_t
@@ -1,0 +1,21 @@
+..
+   (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+   All rights reserved.
+
+   This software is provided without warranty under the terms of the BSD
+   license included in LICENSE.txt and may be redistributed only under
+   the conditions described in the aforementioned license. The license
+   is also available online at http://www.enthought.com/licenses/BSD.txt
+
+   Thanks for using Enthought open source!
+
+{% macro automodule(modname, options) -%}
+.. automodule:: {{ modname }}
+{%- for option in options %}
+   :{{ option }}:
+{%- endfor %}
+{% endmacro -%}
+
+{{ [basename, "module"] | join(' ') | e | heading }}
+
+{{ automodule(qualname, automodule_options) }}

--- a/docs/source/api/templates/module.rst_t
+++ b/docs/source/api/templates/module.rst_t
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2006-2020 Enthought, Inc., Austin, TX
+   (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/api/templates/module.rst_t
+++ b/docs/source/api/templates/module.rst_t
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+   (C) Copyright 2006-2020 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/api/templates/package.rst_t
+++ b/docs/source/api/templates/package.rst_t
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2006-2020 Enthought, Inc., Austin, TX
+   (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/api/templates/package.rst_t
+++ b/docs/source/api/templates/package.rst_t
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+   (C) Copyright 2006-2020 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/api/templates/package.rst_t
+++ b/docs/source/api/templates/package.rst_t
@@ -1,0 +1,38 @@
+..
+   (C) Copyright 2018-2020 Enthought, Inc., Austin, TX
+   All rights reserved.
+
+   This software is provided without warranty under the terms of the BSD
+   license included in LICENSE.txt and may be redistributed only under
+   the conditions described in the aforementioned license. The license
+   is also available online at http://www.enthought.com/licenses/BSD.txt
+
+   Thanks for using Enthought open source!
+
+{% macro automodule(modname, options) -%}
+.. automodule:: {{ modname }}
+{%- for option in options %}
+   :{{ option }}:
+{%- endfor %}
+{% endmacro -%}
+
+{%- macro toctree(docnames) -%}
+.. toctree::
+{% for docname in docnames %}
+   {{ docname }}
+{%- endfor %}
+{%- endmacro -%}
+
+{{ [pkgname, "package"] | join(" ") | e | heading }}
+
+{{ automodule(pkgname, automodule_options) }}
+
+{%- if submodules %}
+
+{{ toctree(submodules) }}
+{% endif %}
+
+{%- if subpackages %}
+
+{{ toctree(subpackages) }}
+{% endif %}


### PR DESCRIPTION
The work in this PR has been adapted from a similar PR in traits-futures - https://github.com/enthought/traits-futures/pull/181/
In my personal opinion, this makes the api docs cleaner and less cluttered.

| before | after |
|---------|------|
|![kiva-before](https://user-images.githubusercontent.com/1926457/103408082-f7b56e80-4b58-11eb-8931-705bebba47af.png)|![kiva-after](https://user-images.githubusercontent.com/1926457/103408087-fb48f580-4b58-11eb-877b-ffb752a86970.png)|
|![enable-before](https://user-images.githubusercontent.com/1926457/103408090-013ed680-4b59-11eb-9913-aa90e31a96d4.png)|![enable-after](https://user-images.githubusercontent.com/1926457/103408094-04d25d80-4b59-11eb-949b-9f37e255746c.png)|