### PR TITLE
Address resource warnings because of open file handles

### DIFF
--- a/kiva/ps.py
+++ b/kiva/ps.py
@@ -123,17 +123,17 @@ class PSGC(basecore2d.GraphicsContextBase):
         return self.size[1]
 
     def save(self, filename):
-        f = open(filename, 'w')
-        ext = os.path.splitext(filename)[1]
-        if ext in ('.eps', '.epsf'):
-            f.write("%!PS-Adobe-3.0 EPSF-3.0\n")
-            f.write('%%%%BoundingBox: 0 0 %d %d\n' % self.size)
-            f.write(self.contents.getvalue())
-        elif ext == '.ps':
-            f.write("%!PS-Adobe-2.0\n")
-            f.write(self.contents.getvalue())
-        else:
-            raise ValueError("don't know how to write a %s file" % ext)
+        with open(filename, 'w') as f:
+            ext = os.path.splitext(filename)[1]
+            if ext in ('.eps', '.epsf'):
+                f.write("%!PS-Adobe-3.0 EPSF-3.0\n")
+                f.write('%%%%BoundingBox: 0 0 %d %d\n' % self.size)
+                f.write(self.contents.getvalue())
+            elif ext == '.ps':
+                f.write("%!PS-Adobe-2.0\n")
+                f.write(self.contents.getvalue())
+            else:
+                raise ValueError("don't know how to write a %s file" % ext)
 
     # Text handling code
 

--- a/kiva/svg.py
+++ b/kiva/svg.py
@@ -164,19 +164,19 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
         return self.size[1]
 
     def save(self, filename):
-        f = open(filename, 'w')
-        ext = os.path.splitext(filename)[1]
-        if ext == '.svg':
-            template = xmltemplate
-            width, height = self.size
-            contents = self.contents.getvalue().replace("<svg:", "<").replace("</svg:", "</")
-        elif ext == '.html':
-            width, height = self.size[0]*3, self.size[1]*3
-            contents = self.contents.getvalue()
-            template = htmltemplate
-        else:
-            raise ValueError("don't know how to write a %s file" % ext)
-        f.write(template % locals())
+        with open(filename, 'w') as f:
+            ext = os.path.splitext(filename)[1]
+            if ext == '.svg':
+                template = xmltemplate
+                width, height = self.size
+                contents = self.contents.getvalue().replace("<svg:", "<").replace("</svg:", "</")
+            elif ext == '.html':
+                width, height = self.size[0]*3, self.size[1]*3
+                contents = self.contents.getvalue()
+                template = htmltemplate
+            else:
+                raise ValueError("don't know how to write a %s file" % ext)
+            f.write(template % locals())
 
 
     # Text handling code

--- a/kiva/tests/test_gl_drawing.py
+++ b/kiva/tests/test_gl_drawing.py
@@ -52,7 +52,10 @@ class TestGLDrawing(DrawingImageTester, unittest.TestCase):
         self.window.dispatch_events()
         filename = "{0}.png".format(self.filename)
         buffer = pyglet.image.get_buffer_manager()
-        buffer.get_color_buffer().save(filename, encoder=PNGImageEncoder())
+        with open(filename, mode="wb") as file_handle:
+            buffer.get_color_buffer().save(
+                filename, file=file_handle, encoder=PNGImageEncoder()
+            )
         self.assertImageSavedWithContent(filename)
 
 


### PR DESCRIPTION
Saving the graphics context to the PS and SVG backends raises resource warnings because the file handler is not closed by the save method. This PR fixes the issue by using open as a context manager.

For example, the resource warnings look like this on master - 

```
test_circle (test_ps_drawing.TestPSDrawing) ... ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\rporuri\\AppData\\Local\\Temp\\tmp5jjp1zn9\\rendered.eps' mode='w' encoding='cp1252'> [test_ps_drawing.py:17]
ok
test_circle_clip (test_ps_drawing.TestPSDrawing) ... ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\rporuri\\AppData\\Local\\Temp\\tmpd9y5my5y\\rendered.eps' mode='w' encoding='cp1252'> [test_ps_drawing.py:17]
ok
test_circle_fill (test_ps_drawing.TestPSDrawing) ... ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\rporuri\\AppData\\Local\\Temp\\tmpo6l4mdcw\\rendered.eps' mode='w' encoding='cp1252'> [test_ps_drawing.py:17]
ok
test_line (test_ps_drawing.TestPSDrawing) ... ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\rporuri\\AppData\\Local\\Temp\\tmpgixdhapv\\rendered.eps' mode='w' encoding='cp1252'> [test_ps_drawing.py:17]
ok
test_quarter_circle (test_ps_drawing.TestPSDrawing) ... ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\rporuri\\AppData\\Local\\Temp\\tmpid_gsfje\\rendered.eps' mode='w' encoding='cp1252'> [test_ps_drawing.py:17]
ok
test_rect (test_ps_drawing.TestPSDrawing) ... ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\rporuri\\AppData\\Local\\Temp\\tmp6rmirwob\\rendered.eps' mode='w' encoding='cp1252'> [test_ps_drawing.py:17]
ok
test_rectangle (test_ps_drawing.TestPSDrawing) ... ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\rporuri\\AppData\\Local\\Temp\\tmpusjbnlc7\\rendered.eps' mode='w' encoding='cp1252'> [test_ps_drawing.py:17]
ok
test_star_clip (test_ps_drawing.TestPSDrawing) ... ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\rporuri\\AppData\\Local\\Temp\\tmpc74amg35\\rendered.eps' mode='w' encoding='cp1252'> [test_ps_drawing.py:17]
ok
test_star_eof_fill (test_ps_drawing.TestPSDrawing) ... ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\rporuri\\AppData\\Local\\Temp\\tmp4wgsmrcn\\rendered.eps' mode='w' encoding='cp1252'> [test_ps_drawing.py:17]
ok
test_star_fill (test_ps_drawing.TestPSDrawing) ... ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\rporuri\\AppData\\Local\\Temp\\tmprtlf3hns\\rendered.eps' mode='w' encoding='cp1252'> [test_ps_drawing.py:17]
ok
test_text (test_ps_drawing.TestPSDrawing) ... ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\rporuri\\AppData\\Local\\Temp\\tmphyf5uun5\\rendered.eps' mode='w' encoding='cp1252'> [test_ps_drawing.py:17]
ok
test_text_clip (test_ps_drawing.TestPSDrawing) ... ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\rporuri\\AppData\\Local\\Temp\\tmpbend34qb\\rendered.eps' mode='w' encoding='cp1252'> [test_ps_drawing.py:17]
ok
```