### PR TITLE
Fix flake8 F401 and F403 errors (import-related)

### DIFF
--- a/enable/base.py
+++ b/enable/base.py
@@ -28,8 +28,6 @@ from kiva.constants import DEFAULT, DECORATIVE, ROMAN, SCRIPT, SWISS,\
                                      MODERN, NORMAL, BOLD, ITALIC
 from kiva.fonttools import Font
 
-from .colors import color_table, transparent_color
-
 # Special 'empty rectangle' indicator:
 empty_rectangle = -1
 

--- a/enable/colors.py
+++ b/enable/colors.py
@@ -1,7 +1,5 @@
 # This is a redirection file that determines what constitutes a color trait
 # in Chaco, and what constitutes the standard colors.
-import sys
-
 from traits.etsconfig.api import ETSConfig
 from traits.api import List, Str, Trait, Tuple, TraitError
 

--- a/enable/container.py
+++ b/enable/container.py
@@ -5,8 +5,7 @@ import warnings
 
 # Enthought library imports
 from kiva import affine
-from traits.api import Any, Bool, Enum, HasTraits, Instance, List, \
-        Property, Tuple
+from traits.api import Bool, Enum, Instance, List, Property, Tuple
 
 # Local, relative imports
 from .base import empty_rectangle, intersect_bounds

--- a/enable/example_support.py
+++ b/enable/example_support.py
@@ -52,7 +52,6 @@ if ETSConfig.toolkit == 'wx' or ETSConfig.toolkit == 'qt4':
 elif ETSConfig.toolkit == 'pyglet':
 
     from pyglet import app
-    from pyglet import clock
 
     class DemoFrame(object):
         def __init__(self):

--- a/enable/graphics_context.py
+++ b/enable/graphics_context.py
@@ -1,7 +1,6 @@
 from kiva.constants import FILL
 
 # Relative imports
-from .abstract_window import AbstractWindow
 from .base import bounding_coordinates, coordinates_to_bounds
 from .kiva_graphics_context import GraphicsContext
 

--- a/enable/primitives/image.py
+++ b/enable/primitives/image.py
@@ -2,7 +2,7 @@
 """
 
 # Enthought library imports
-from traits.api import Array, Bool, Enum, Instance, Property, cached_property
+from traits.api import Array, Enum, Instance, Property, cached_property
 
 # Local imports
 from enable.component import Component

--- a/enable/pyglet_backend/window.py
+++ b/enable/pyglet_backend/window.py
@@ -19,8 +19,7 @@ from enable.graphics_context import GraphicsContextEnable
 from enable.abstract_window import AbstractWindow
 
 # local, relative imports
-from .constants import ASCII_CONTROL_KEYS, KEY_MAP, \
-        POINTER_MAP, TEXT_KEYS
+from .constants import KEY_MAP, POINTER_MAP
 
 
 class PygletMouseEvent(object):

--- a/enable/qt4/constants.py
+++ b/enable/qt4/constants.py
@@ -13,7 +13,7 @@ import warnings
 
 from pyface.qt import QtCore
 
-from ..toolkit_constants import key_names, mouse_wheel_axes_names, pointer_names
+from ..toolkit_constants import mouse_wheel_axes_names, pointer_names
 
 DRAG_RESULTS_MAP = { "error":   QtCore.Qt.IgnoreAction,
                      "none":    QtCore.Qt.IgnoreAction,

--- a/enable/qt4/gl.py
+++ b/enable/qt4/gl.py
@@ -12,7 +12,6 @@
 import pyglet
 pyglet.options['shadow_window'] = False
 
-from traits.api import Bool, Instance
 from kiva.gl import CompiledPath, GraphicsContext
 
 from .base_window import BaseGLWindow

--- a/enable/savage/compliance/drawer.py
+++ b/enable/savage/compliance/drawer.py
@@ -1,5 +1,3 @@
-import svg
-
 import wx
 import wx.py.shell
 import wx.aui

--- a/enable/savage/svg/attributes.py
+++ b/enable/savage/svg/attributes.py
@@ -2,12 +2,8 @@
     Parsers for specific attributes
 """
 import urllib.parse as urlparse
-from pyparsing import (Literal,
-    Optional, oneOf, Group, StringEnd, Combine, Word, alphas, hexnums,
-    CaselessLiteral, SkipTo
-)
+from pyparsing import Literal, Optional, Group, StringEnd, CaselessLiteral, SkipTo
 from .css.colour import colourValue
-import string
 
 ##Paint values
 none = CaselessLiteral("none").setParseAction(lambda t: ["NONE", ()])

--- a/enable/savage/svg/backends/kiva/renderer.py
+++ b/enable/savage/svg/backends/kiva/renderer.py
@@ -1,11 +1,11 @@
-from math import sqrt, pi
+from math import pi
 import sys
 import warnings
 
 import numpy as np
 
 from enable.compiled_path import CompiledPath as KivaCompiledPath
-from kiva import affine, constants, fonttools
+from kiva import constants, fonttools
 from kiva.fonttools import Font
 
 from enable.savage.svg import svg_extras

--- a/enable/savage/svg/backends/wx/renderer.py
+++ b/enable/savage/svg/backends/wx/renderer.py
@@ -1,4 +1,3 @@
-import copy
 import numpy
 import warnings
 import wx

--- a/enable/savage/svg/css/colour.py
+++ b/enable/savage/svg/css/colour.py
@@ -8,9 +8,7 @@
     * rgb percent: rgb(100%,100%,0%)
     * named color: black
 """
-import string
-import urllib.parse as urlparse
-from pyparsing import nums, Literal, Optional, oneOf, Group, StringEnd, Combine, Word, alphas, hexnums
+from pyparsing import nums, Literal, Optional, Group, StringEnd, Word, alphas, hexnums
 from enable.savage.svg.pathdata import number, sign
 
 number = number.copy()

--- a/enable/savage/svg/css/identifier.py
+++ b/enable/savage/svg/css/identifier.py
@@ -1,6 +1,5 @@
 """ Parse CSS identifiers. More complicated than it sounds"""
-from pyparsing import Word, Literal, Regex, Combine, Optional, White, oneOf, ZeroOrMore
-import string
+from pyparsing import Literal, Regex, Combine, Optional, White, ZeroOrMore
 import re
 
 class White(White):

--- a/enable/savage/svg/css/transform.py
+++ b/enable/savage/svg/css/transform.py
@@ -2,8 +2,7 @@
     Parsing for CSS and CSS-style values, such as transform and filter attributes.
 """
 
-from pyparsing import (Literal, Word, CaselessLiteral,
-    Optional, Combine, Forward, ZeroOrMore, nums, oneOf, Group, delimitedList)
+from pyparsing import Literal, Optional, Group, delimitedList
 
 #some shared definitions from pathdata
 

--- a/enable/savage/svg/css/transform.py
+++ b/enable/savage/svg/css/transform.py
@@ -44,7 +44,3 @@ matrix = Literal("matrix") + Parenthised(
 transform = (skewY | skewX | rotate | scale | translate | matrix)
 
 transformList = delimitedList(Group(transform), delim=maybeComma)
-
-if __name__ == '__main__':
-    from tests.test_css import *
-    unittest.main()

--- a/enable/savage/svg/css/values.py
+++ b/enable/savage/svg/css/values.py
@@ -1,7 +1,7 @@
 """
 Parser for various kinds of CSS values as per CSS2 spec section 4.3
 """
-from pyparsing import Word, Combine, Optional, Literal, oneOf, CaselessLiteral, StringEnd, OneOrMore
+from pyparsing import Word, Combine, Optional, Literal, oneOf, StringEnd
 
 def asInt(s,l,t):
     return int(t[0])

--- a/enable/savage/svg/document.py
+++ b/enable/savage/svg/document.py
@@ -1069,7 +1069,3 @@ class SVGDocument(object):
             return
         for op, args in self.ops:
             op(context, *args)
-
-if __name__ == '__main__':
-    from tests.test_document import TestBrushFromColourValue, TestValueToPixels, unittest
-    unittest.main()

--- a/enable/savage/svg/pathdata.py
+++ b/enable/savage/svg/pathdata.py
@@ -10,8 +10,8 @@
 
 """
 
-from pyparsing import (ParserElement, Literal, Word, CaselessLiteral,
-    Optional, Combine, Forward, ZeroOrMore, nums, oneOf, Group, ParseException, OneOrMore)
+from pyparsing import (Literal, Word, CaselessLiteral,
+    Optional, Combine, ZeroOrMore, nums, oneOf, Group, ParseException, OneOrMore)
 
 #ParserElement.enablePackrat()
 

--- a/enable/savage/svg/tests/css/test_atrule.py
+++ b/enable/savage/svg/tests/css/test_atrule.py
@@ -1,7 +1,4 @@
 import unittest
-import string
-import sys
-from pyparsing import ParseException
 import enable.savage.svg.css.atrule as atrule
 
 class TestAtKeyword(unittest.TestCase):

--- a/enable/savage/svg/tests/css/test_transform.py
+++ b/enable/savage/svg/tests/css/test_transform.py
@@ -1,7 +1,9 @@
 import unittest
 from pyparsing import ParseException
 
-from enable.savage.svg.css.transform import *
+from enable.savage.svg.css.transform import (
+    rotate, scale, skewX, skewY, transform, transformList,
+)
 
 #list of tuples: parser, string, result
 transformTestsGood = [

--- a/enable/savage/svg/tests/test_pathdata.py
+++ b/enable/savage/svg/tests/test_pathdata.py
@@ -1,7 +1,11 @@
 import unittest
 from pyparsing import ParseException
 
-from enable.savage.svg.pathdata import *
+from enable.savage.svg.pathdata import (
+    coordinatePair, closePath, curve, ellipticalArc, horizontalLine, lineTo,
+    moveTo, number, quadraticBezierCurveto, Sequence,
+    smoothQuadraticBezierCurveto, svg, verticalLine,
+)
 
 
 class TestNumber(unittest.TestCase):

--- a/enable/tests/primitives/test_image.py
+++ b/enable/tests/primitives/test_image.py
@@ -1,7 +1,6 @@
 """ Tests for the Image component """
 
 import os
-import sys
 import unittest
 
 import numpy as np

--- a/enable/tests/test_resize_tool.py
+++ b/enable/tests/test_resize_tool.py
@@ -1,8 +1,5 @@
 import unittest
 
-from traits.api import Int
-
-from enable.testing import EnableTestAssistant
 from enable.component import Component
 from enable.tools.resize_tool import ResizeTool
 

--- a/enable/text_field.py
+++ b/enable/text_field.py
@@ -1,6 +1,5 @@
 # Standard library imports
 from math import floor, sqrt
-from bisect import insort_left
 
 # Enthought library imports
 from traits.api import (Bool, Int, Event, Instance, Any, Property,

--- a/enable/tools/toolbars/toolbar_buttons.py
+++ b/enable/tools/toolbars/toolbar_buttons.py
@@ -2,7 +2,7 @@
 from enable.api import ColorTrait, Component
 from enable.font_metrics_provider import font_metrics_provider
 from kiva.trait_defs.kiva_font_trait import KivaFont
-from traits.api import Bool, Enum, Instance, Int, Property, Str, Tuple
+from traits.api import Bool, Enum, Int, Str, Tuple
 
 class Button(Component):
 

--- a/enable/vtk_backend/vtk_window.py
+++ b/enable/vtk_backend/vtk_window.py
@@ -2,10 +2,10 @@ import warnings
 
 from tvtk.api import tvtk
 from tvtk import messenger
-from traits.api import HasTraits, Any, Callable, Property, Instance, \
+from traits.api import Any, Callable, Property, Instance, \
         Bool, Enum, Int, on_trait_change
 
-from numpy import arange, zeros, ascontiguousarray, reshape, uint8, any
+from numpy import ascontiguousarray, reshape, any
 from enable.api import AbstractWindow, MouseEvent, KeyEvent, \
         CoordinateBox
 from enable.graphics_context import ImageGraphicsContextEnable

--- a/enable/wx/base_window.py
+++ b/enable/wx/base_window.py
@@ -9,7 +9,7 @@ import warnings
 
 import wx
 
-from traits.api import Any, Instance, Trait
+from traits.api import Any, Instance
 from traitsui.wx.menu import MakeMenu
 
 # Relative imports

--- a/kiva/agg/tests/test_clip_to_rect.py
+++ b/kiva/agg/tests/test_clip_to_rect.py
@@ -21,7 +21,6 @@ import unittest
 from numpy import array, transpose
 
 from kiva.agg import GraphicsContextArray
-import kiva
 
 from .test_utils import Utils
 

--- a/kiva/agg/tests/test_compiled_path.py
+++ b/kiva/agg/tests/test_compiled_path.py
@@ -1,6 +1,6 @@
 import unittest
 
-from numpy import array, alltrue, ravel, pi
+from numpy import array, pi
 
 from kiva import agg
 

--- a/kiva/agg/tests/test_font_loading.py
+++ b/kiva/agg/tests/test_font_loading.py
@@ -1,5 +1,3 @@
-from string import ascii_lowercase, ascii_uppercase
-import os
 import time
 
 from kiva.image import font_metrics_provider as FMP

--- a/kiva/agg/tests/test_gcmem.py
+++ b/kiva/agg/tests/test_gcmem.py
@@ -2,7 +2,7 @@
 Test for memory leak in the wx image backend.
 """
 
-import unittest, sys
+import unittest
 import gc as garbagecollector
 
 from kiva.image import GraphicsContext, GraphicsContextSystem

--- a/kiva/agg/tests/test_join_stroke_path.py
+++ b/kiva/agg/tests/test_join_stroke_path.py
@@ -22,7 +22,7 @@
 """
 import unittest
 
-from numpy import array, alltrue, ravel
+from numpy import array
 
 from kiva.agg import GraphicsContextArray
 import kiva

--- a/kiva/agg/tests/test_save.py
+++ b/kiva/agg/tests/test_save.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from numpy import allclose, ravel
+from numpy import ravel
 
 from kiva import agg
 

--- a/kiva/agg/tests/test_stroke_path.py
+++ b/kiva/agg/tests/test_stroke_path.py
@@ -49,7 +49,7 @@
 
 import unittest
 
-from numpy import array, alltrue, ravel
+from numpy import array
 
 from kiva.agg import GraphicsContextArray
 import kiva

--- a/kiva/basecore2d.py
+++ b/kiva/basecore2d.py
@@ -43,7 +43,7 @@ from .constants import (POINT, LINE, LINES, RECT, NO_DASH, CLOSE,
                         SCALE_CTM, TRANSLATE_CTM, ROTATE_CTM, CONCAT_CTM,
                         LOAD_CTM)
 from .abstract_graphics_context import AbstractGraphicsContext
-from .line_state import LineState, line_state_equal
+from .line_state import LineState
 from .graphics_state import GraphicsState
 from .fonttools import Font
 import kiva.affine as affine

--- a/kiva/cairo.py
+++ b/kiva/cairo.py
@@ -1282,10 +1282,9 @@ def font_metrics_provider():
     return GraphicsContext((1,1))
 
 if __name__=="__main__":
-    from numpy import fabs, linspace, pi, sin
+    from numpy import linspace
     from scipy.special import jn
 
-    from traits.api import false
     from chaco.api import ArrayPlotData, Plot, PlotGraphicsContext
     from chaco.example_support import COLOR_PALETTE
 

--- a/kiva/fonttools/tests/test_font_manager.py
+++ b/kiva/fonttools/tests/test_font_manager.py
@@ -1,7 +1,6 @@
 import contextlib
 import importlib
 import os
-import shutil
 import sys
 import tempfile
 import unittest
@@ -17,7 +16,6 @@ from ..font_manager import (
     createFontList,
     default_font_manager,
     FontEntry,
-    FontProperties,
     FontManager,
     ttfFontProperty,
 )

--- a/kiva/gl.py
+++ b/kiva/gl.py
@@ -21,7 +21,6 @@ from pygarrayimage.arrayimage import ArrayInterfaceImage
 from .affine import affine_from_values, transform_points
 from .agg import GraphicsContextGL as _GCL
 from .agg import AggFontType
-from .agg import CompiledPath
 from .constants import BOLD, BOLD_ITALIC, ITALIC
 from .fonttools import Font
 

--- a/kiva/image.py
+++ b/kiva/image.py
@@ -20,18 +20,6 @@
 # proxy the imports.
 from .agg import GraphicsContextArray as GraphicsContext
 
-# FontType will be unified with the Kiva FontType soon.
-from .agg import AggFontType as FontType
-
-# GraphicsContextSystem wraps up platform- and toolkit- specific low
-# level calls with a GraphicsContextArray.  Eventually this low-level code
-# will be moved out of the Agg subpackage, and we won't have be importing
-# this here.
-from .agg import GraphicsContextSystem, Image
-
-# CompiledPath is an object that can efficiently store paths to be reused
-# multiple times.
-from .agg import CompiledPath
 
 def font_metrics_provider():
     """ Create an object to be used for querying font metrics.

--- a/kiva/pdfmetrics.py
+++ b/kiva/pdfmetrics.py
@@ -35,7 +35,7 @@ a registry of Font, TypeFace and Encoding objects.  Ideally these
 would be pre-loaded, but due to a nasty circularity problem we
 trap attempts to access them and do it on first access.
 """
-import string, os
+import os
 import warnings
 
 # XXX Kiva specific changes

--- a/kiva/ps.py
+++ b/kiva/ps.py
@@ -19,7 +19,6 @@
 # Major library imports
 from io import StringIO
 import os
-import sys
 import warnings
 
 from numpy import arange, ravel, array

--- a/kiva/quartz/setup.py
+++ b/kiva/quartz/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import platform
 import sys
 
 def configuration(parent_package='', top_path=None):

--- a/kiva/svg.py
+++ b/kiva/svg.py
@@ -37,7 +37,6 @@ Miscellaneous notes:
 # Major library imports
 from io import StringIO
 import os
-import sys
 from numpy import arange, ravel, array
 import warnings
 

--- a/kiva/tests/agg/test_arc.py
+++ b/kiva/tests/agg/test_arc.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from math import pi
 

--- a/kiva/tests/agg/test_image3.py
+++ b/kiva/tests/agg/test_image3.py
@@ -1,4 +1,3 @@
-import os
 import time
 from math import pi
 
@@ -170,9 +169,6 @@ def main5(gc):
     t2 = time.clock()
     print('1st:', t2-t1)
 
-
-    import random
-    import string
     strs = ['012345679',
             'abcdefghi',
             'jklmnopqr',
@@ -199,7 +195,6 @@ def main5(gc):
 
 if __name__ == '__main__':
 
-    import profile
     gc=agg.GraphicsContextArray((800,800))
 
     main()

--- a/kiva/tests/test_affine.py
+++ b/kiva/tests/test_affine.py
@@ -11,8 +11,7 @@
 
 
 import unittest
-import sys
-from numpy import arctan2, alltrue, array, identity, dot, ravel, allclose, pi,cos
+from numpy import alltrue, array, identity, dot, ravel, allclose, pi,cos
 
 from kiva import affine
 

--- a/kiva/tests/test_image.py
+++ b/kiva/tests/test_image.py
@@ -5,7 +5,7 @@ import unittest
 
 from PIL import Image as PILImage
 
-from kiva.image import Image, GraphicsContext
+from kiva.image import Image
 
 
 class TestImage(unittest.TestCase):


### PR DESCRIPTION
This PR fixes a number of flake8 import-related errors e.g. F401 i.e. unused imports and F403 i.e. * imports.

Note that this PR does not fix all of the F401 violations in the codebase - I chose to ignore a number of violations coming from api modules or init files. Those will be added to the list of files ignored when we have flake8 properly setup for enable.

Additionally, there were a number of imports which cause F401 errors that we might not be able to remove - to maintain backwards compatibility.