### PR TITLE
Fix Font.findfontname AttributeError when the default font manager has not been initialized

### DIFF
--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -852,11 +852,11 @@ class FontProperties(object):
         Return the name of the font that best matches the font
         properties.
         """
-        filename = str(fontManager.findfont(self))
+        filename = str(default_font_manager().findfont(self))
         if filename.endswith('.afm'):
             return afm.AFM(open(filename)).get_familyname()
 
-        font = fontManager.findfont(self)
+        font = default_font_manager().findfont(self)
         prop_dict = getPropDict(TTFont(str(font)))
         return prop_dict['name']
 
@@ -904,7 +904,7 @@ class FontProperties(object):
                 return float(self._size)
             except ValueError:
                 pass
-        default_size = fontManager.get_default_size()
+        default_size = default_font_manager().get_default_size()
         return default_size * font_scalings.get(self._size)
 
     def get_file(self):
@@ -1350,7 +1350,7 @@ class FontManager:
                 logger.debug(
                     "findfont: Found a missing font file.  Rebuilding cache.")
                 _rebuild()
-                return fontManager.findfont(
+                return default_font_manager().findfont(
                     prop, fontext, directory, True, False)
             else:
                 raise ValueError("No valid font could be found")

--- a/kiva/fonttools/tests/_testing.py
+++ b/kiva/fonttools/tests/_testing.py
@@ -1,4 +1,7 @@
+""" Internal utilities for testing kiva.fonttools
 
+These functions should be used by kiva.fonttools only.
+"""
 from unittest import mock
 
 

--- a/kiva/fonttools/tests/_testing.py
+++ b/kiva/fonttools/tests/_testing.py
@@ -1,0 +1,20 @@
+
+from unittest import mock
+
+
+def patch_global_font_manager(new_value):
+    """ Patch the global FontManager instance at the module level.
+
+    Useful for avoiding test interaction due to the global font manager
+    cache being created at runtime.
+
+    Parameters
+    ----------
+    new_value : FontManager or None
+        Temporary value to be used as the global font manager.
+
+    Returns
+    -------
+    patcher : unittest.mock._patch
+    """
+    return mock.patch("kiva.fonttools.font_manager.fontManager", new_value)

--- a/kiva/fonttools/tests/test_font.py
+++ b/kiva/fonttools/tests/test_font.py
@@ -4,9 +4,17 @@ import os
 import unittest
 
 from kiva.fonttools import Font
+from kiva.fonttools.tests._testing import patch_global_font_manager
 
 
 class TestFont(unittest.TestCase):
+
+    def setUp(self):
+        # Invalidate the global font manager cache to avoid test interaction
+        # as well as catching erroneous assumption on an existing cache.
+        font_manager_patcher = patch_global_font_manager(None)
+        font_manager_patcher.start()
+        self.addCleanup(font_manager_patcher.stop)
 
     def test_find_font_empty_name(self):
         # This test relies on the fact there exists some fonts on the system
@@ -25,3 +33,14 @@ class TestFont(unittest.TestCase):
         with self.assertWarns(UserWarning):
             font_file_path = font.findfont()
         self.assertTrue(os.path.exists(font_file_path))
+
+    def test_find_font_name(self):
+        font = Font(face_name="ProbablyNotFound")
+
+        # There will be warnings as there will be no match for the requested
+        # face name.
+        with self.assertWarns(UserWarning), patch_global_font_manager(None):
+            name = font.findfontname()
+
+        # Name should be nonempty.
+        self.assertGreater(len(name), 0)

--- a/kiva/fonttools/tests/test_font.py
+++ b/kiva/fonttools/tests/test_font.py
@@ -39,7 +39,7 @@ class TestFont(unittest.TestCase):
 
         # There will be warnings as there will be no match for the requested
         # face name.
-        with self.assertWarns(UserWarning), patch_global_font_manager(None):
+        with self.assertWarns(UserWarning):
             name = font.findfontname()
 
         # Name should be nonempty.

--- a/kiva/fonttools/tests/test_font_manager.py
+++ b/kiva/fonttools/tests/test_font_manager.py
@@ -21,6 +21,7 @@ from ..font_manager import (
     FontManager,
     ttfFontProperty,
 )
+from ._testing import patch_global_font_manager
 
 data_dir = resource_filename('kiva.fonttools.tests', 'data')
 
@@ -195,17 +196,6 @@ def change_ets_app_dir(dirpath):
         yield font_manager_module._get_font_cache_path()
     finally:
         ETSConfig.application_data = original_data_dir
-
-
-def patch_global_font_manager(new_value):
-    """ Patch the global FontManager instance at the module level.
-
-    Parameters
-    ----------
-    new_value : FontManager or None
-        Temporary value to be used as the global font manager.
-    """
-    return mock.patch.object(font_manager_module, "fontManager", new_value)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This PR fixes an AttributeError observed in #392. The error is caused by #488 where the import side effect of creating a module level global font manager cache is removed. There still exists usage of the global font manager assuming it had been created.

The first commit adds a test that would fail. The commit f665e53283aefeebc4299d5503933ed450e5c187 fixes the issue (it is by @jwiggins, cherry-picked from #392).

~Marking as draft to get CI run on the first commit in order to verify the test does fail (though I verified locally, I don't trust my setup when the subject is a module level cache), and then I will push the commit that fixes it.~ (Edited: Done)