### PR TITLE
Add OSX job to CI using GitHub Actions

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache
-          key: ${{ runner.os }}--${{ hashFiles('ci/edmtool.py') }}
+          key: ${{ runner.os }}-${{ runner.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
       - name: Setup EDM
         uses: enthought/setup-edm-action@v1
         with:

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -9,18 +9,13 @@ env:
 
 jobs:
 
-  # Test against EDM packages on Windows and OSX
+  # Test against EDM packages
   test-with-edm:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest]
         toolkit: ['pyqt', 'pyqt5', 'pyside2', 'wx']
     runs-on: ${{ matrix.os }}
-    env:
-      # Set root directory for Windows, otherwise 'pip install <source-root>'
-      # complains because the Python environment is in C: drive whereas
-      # the source is checked out in D: drive.
-      EDM_ROOT_DIRECTORY: ${{ github.workspace }}/.edm
     steps:
       - uses: actions/checkout@v2
       - name: Cache EDM packages

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache
-          key: ${{ runner.os }}-${{ runner.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
+          key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
       - name: Setup EDM
         uses: enthought/setup-edm-action@v1
         with:

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -1,0 +1,40 @@
+# This workflow targets stable released dependencies from EDM.
+
+name: Test with EDM
+
+on: push
+
+env:
+  INSTALL_EDM_VERSION: 3.2.1
+
+jobs:
+
+  # Test against EDM packages on Windows and OSX
+  test-with-edm:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+        toolkit: ['pyqt', 'pyqt5', 'pyside2', 'wx']
+    runs-on: ${{ matrix.os }}
+    env:
+      # Set root directory for Windows, otherwise 'pip install <source-root>'
+      # complains because the Python environment is in C: drive whereas
+      # the source is checked out in D: drive.
+      EDM_ROOT_DIRECTORY: ${{ github.workspace }}/.edm
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache EDM packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}--${{ hashFiles('ci/edmtool.py') }}
+      - name: Setup EDM
+        uses: enthought/setup-edm-action@v1
+        with:
+          edm-version: ${{ env.INSTALL_EDM_VERSION }}
+      - name: Install click to the default EDM environment
+        run: edm --config ci/.edm.yaml install -y wheel click coverage
+      - name: Install test environment
+        run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }}
+      - name: Run tests
+        run: edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }}

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -2,7 +2,7 @@
 
 name: Test with EDM
 
-on: push
+on: pull_request
 
 env:
   INSTALL_EDM_VERSION: 3.2.1

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -10,6 +10,8 @@ env:
 jobs:
 
   # Test against EDM packages
+  # Note that some packages may not actually be installed from EDM but from
+  # PyPI, see ci/edmtool.py implementations.
   test-with-edm:
     strategy:
       matrix:


### PR DESCRIPTION
Closes #537

Certain components (e.g. kiva) are OSX specific and it would be convenient to developers if the tests are run by CI in an OSX environment, otherwise we rely on developers having an OSX host machine and remembering to run test suite locally.

Background: Other ETS projects are in the middle of moving CI to GitHub Actions (see Traits, TraitsUI, and Traits-Futures).

I also have separate [branch](https://github.com/enthought/enable/compare/ci-github-actions) where I included all the jobs we currently have in Travis/Appveyor. I decided that might be too much to review in one go. The OSX job is trivial enough so it would be more efficient to break this out. Once this gets merged, it can immediately benefit pending PRs such as #392 and #535 which have OSX specific changes.
I am happy to replace this PR with one that includes all the jobs, if the reviewer prefers.