### PR TITLE
Add Windows to the GitHub Actions CI test matrix

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -2,7 +2,7 @@
 
 name: Test with EDM
 
-on: pull_request
+on: push
 
 env:
   INSTALL_EDM_VERSION: 3.2.1
@@ -15,9 +15,14 @@ jobs:
   test-with-edm:
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-latest, windows-latest]
         toolkit: ['pyqt', 'pyqt5', 'pyside2', 'wx']
     runs-on: ${{ matrix.os }}
+    env:
+      # Set root directory for Windows, otherwise 'pip install <source-root>'
+      # complains because the Python environment is in C: drive whereas
+      # the source is checked out in D: drive.
+      EDM_ROOT_DIRECTORY: ${{ github.workspace }}/.edm
     steps:
       - uses: actions/checkout@v2
       - name: Cache EDM packages

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -19,9 +19,10 @@ jobs:
         toolkit: ['pyqt', 'pyqt5', 'pyside2', 'wx']
     runs-on: ${{ matrix.os }}
     env:
-      # Set root directory, mainly for Windows, otherwise 'pip install'
-      # complains because the Python environment is in C: drive whereas
-      # the source is checked out in D: drive.
+      # Set root directory, mainly for Windows, so that the EDM Python
+      # environment lives in the same drive as the cloned source. Otherwise
+      # 'pip install' raises an error while trying to compute
+      # relative path between the site-packages and the source directory.
       EDM_ROOT_DIRECTORY: ${{ github.workspace }}/.edm
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -2,7 +2,7 @@
 
 name: Test with EDM
 
-on: push
+on: pull_request
 
 env:
   INSTALL_EDM_VERSION: 3.2.1

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -19,7 +19,7 @@ jobs:
         toolkit: ['pyqt', 'pyqt5', 'pyside2', 'wx']
     runs-on: ${{ matrix.os }}
     env:
-      # Set root directory for Windows, otherwise 'pip install <source-root>'
+      # Set root directory, mainly for Windows, otherwise 'pip install'
       # complains because the Python environment is in C: drive whereas
       # the source is checked out in D: drive.
       EDM_ROOT_DIRECTORY: ${{ github.workspace }}/.edm

--- a/enable/tests/test_component_editor.py
+++ b/enable/tests/test_component_editor.py
@@ -57,9 +57,5 @@ class TestComponentEditor(unittest.TestCase):
 
         size = get_dialog_size(ui.control)
 
-        # leave a few pixel of margin for wx
         self.assertGreater(size[0], ITEM_WIDTH-1)
-        self.assertLess(size[0], ITEM_WIDTH+30)
-
         self.assertGreater(size[1], ITEM_HEIGHT-1)
-        self.assertLess(size[1], ITEM_HEIGHT+30)


### PR DESCRIPTION
This is another incremental step towards moving what we currently have on Travis/Appveyor to GitHub Actions.

This PR adds Windows to the existing CI matrix.

One test being modified fails when we switch to the Windows worker from GitHub Actions. The test is trying to make sure that the `ComponentEditor.width` and `ComponentEditor.height` are taken into account for setting the component view size, but the upper bound in the test is only an approximation, because the window can be a bit larger due to borders and native screen size.

The test failure looks like this:
```
======================================================================
FAIL: test_initial_component_with_item_size (enable.tests.test_component_editor.TestComponentEditor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\a\enable\enable\.edm\envs\enable-test-3.6-wx\lib\site-packages\enable\tests\test_component_editor.py", line 65, in test_initial_component_with_item_size
    self.assertLess(size[1], ITEM_HEIGHT+30)
AssertionError: 241 not less than 230
``` 

The `30` is a tolerance, instead of increasing the tolerance, I removed the assertion altogether.