### PR TITLE
Unskip most of TestGLDrawing tests on OSX

### DIFF
--- a/kiva/tests/test_gl_drawing.py
+++ b/kiva/tests/test_gl_drawing.py
@@ -12,8 +12,9 @@ else:
 
 from kiva.tests.drawing_tester import DrawingImageTester
 
+is_windows = (sys.platform in ('win32', 'cygwin'))
 
-@unittest.skipIf("win" in sys.platform, "Pyglet/GL backend issues on Windows")
+@unittest.skipIf(is_windows, "Pyglet/GL backend issues on Windows")
 @unittest.skipIf(PYGLET_NOT_AVAILABLE, "Cannot import pyglet")
 class TestGLDrawing(DrawingImageTester, unittest.TestCase):
 

--- a/kiva/tests/test_gl_drawing.py
+++ b/kiva/tests/test_gl_drawing.py
@@ -36,6 +36,12 @@ class TestGLDrawing(DrawingImageTester, unittest.TestCase):
         # FIXME: overriding test since it segfaults
         DrawingImageTester.test_star_clip(self)
 
+    @unittest.skipIf(
+        sys.platform == "darwin",
+        "Error getting sfnt font name on OSX (enthought/enable#541)")
+    def test_text(self):
+        DrawingImageTester.test_text(self)
+
     @unittest.skip("gl graphics context does not clip text properly (#165)")
     def test_text_clip(self):
         # gl graphics context does not clip text properly (#165).


### PR DESCRIPTION
The `TestGLDrawing` was meant to be skipped on Windows when Appveyor CI was put up (see #347), but the skip condition skips OSX as well, because the `sys.platform` for OSX is `"darwin"`, and matches `"win" in sys.platform`.

I believe one of the tests is actually failing on master + OSX, and may have been like that for a long time but CI has not tested against OSX until recently.

The first commit will relax the skip to reveal the error, and then depending on how easy it is to fix, I may just skip that one test and open an issue referencing this PR. (edited: I went for the latter)

This is motivated by #392 which also fixed the skip condition but subsequently skipping the test case again for other reasons. The second skip may mask the existing failure, and make tracking on that existing failure more difficult. 