### PR TITLE
Add cron job to GitHub Actions and expand extras_require

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -22,10 +22,17 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Qt dependencies for Linux
+      - name: Install PySide2 (from PyPI) dependencies for Linux
         run: |
           sudo apt-get update
+          sudo apt-get install qt5-default
           sudo apt-get install libxkbcommon-x11-0
+          sudo apt-get install libxcb-icccm4
+          sudo apt-get install libxcb-image0
+          sudo apt-get install libxcb-keysyms1
+          sudo apt-get install libxcb-randr0
+          sudo apt-get install libxcb-render-util0
+          sudo apt-get install libxcb-xinerama0
         if: matrix.toolkit != 'wx'
       - name: Install Wx dependencies for Linux
         run: |

--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -1,0 +1,62 @@
+# This workflow installs dependencies from master
+
+name: ETS from source
+
+# TODO: Switch to schedule!
+on: push
+
+jobs:
+  test-ets:
+    strategy:
+      matrix:
+        # Note that Ubuntu 20 cannot be used because its SWIG version is 4.0
+        # (enthought/enable#360)
+        os: [ubuntu-18.04]
+        toolkit: ['pyside2', 'wx']
+        python-version: [3.8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Qt dependencies for Linux
+        run: |
+          sudo apt-get update
+          sudo apt-get install libxkbcommon-x11-0
+        if: matrix.toolkit != 'wx'
+      - name: Install Wx dependencies for Linux
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsdl2-2.0-0
+        if: matrix.toolkit == 'wx'
+      - name: Install GL dependencies for Linux
+        run: sudo apt-get install libglu1-mesa-dev
+      - name: Install build dependencies
+        run: python -m pip install numpy
+      - name: Install prebuilt wxPython
+        run: python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04 wxPython
+        if: matrix.toolkit == 'wx'
+      - name: Install source dependencies
+        run: |
+          python -m pip install git+http://github.com/enthought/traits.git#egg=traits
+          python -m pip install git+http://github.com/enthought/pyface.git#egg=pyface[${{ matrix.toolkit }}]
+          python -m pip install git+http://github.com/enthought/traitsui.git#egg=traitsui[${{ matrix.toolkit }}]
+      - name: Install local packages
+        run: python -m pip install .[gl,layout,pdf,svg,test]
+      - name: Sanity check package version
+        run: python -m pip list
+      - name: Run enable test suite
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          # kiva agg requires at least 15-bit color depth.
+          # The --server-args assumes xvfb-run is called, hence Linux only.
+          run: --server-args="-screen 0 1024x768x24" python -m unittest discover -v enable
+          working-directory: ${{ runner.temp }}
+      - name: Run kiva test suite
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: python -m unittest discover -v kiva
+          working-directory: ${{ runner.temp }}

--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -2,8 +2,9 @@
 
 name: ETS from source
 
-# TODO: Switch to schedule!
-on: push
+on:
+  schedule:
+    - cron:  '0 0 * * 5'
 
 jobs:
   test-ets:

--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Install GL dependencies for Linux
         run: sudo apt-get install libglu1-mesa-dev
       - name: Install build dependencies
-        run: python -m pip install numpy
+        run: |
+          python -m pip install -U pip setuptools wheel
+          python -m pip install numpy
       - name: Install prebuilt wxPython
         run: python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04 wxPython
         if: matrix.toolkit == 'wx'

--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -20,6 +20,7 @@ except ImportError:
     __requires__.append('pillow')
 
 __extras_require__ = {
+    # Dependencies for running enable/kiva's examples
     'examples': [
         'chaco',
         'mayavi',
@@ -27,19 +28,24 @@ __extras_require__ = {
         'kiwisolver',
         'pyglet'
     ],
+    # Dependencies for GL backend support
     'gl': [
         'pygarrayimage',
         'pyglet',
     ],
+    # Dependencies for constrained layout
     'layout': [
         'kiwisolver',
     ],
+    # Dependencies for PDF backend
     'pdf': [
         'reportlab',
     ],
+    # Dependencies for SVG backend
     'svg': [
         'pyparsing',
     ],
+    # Dependencies purely for running tests.
     'test': [
         'hypothesis',
         'PyPDF2',    # for pdf drawing tests in kiva.

--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -40,5 +40,8 @@ __extras_require__ = {
     'svg': [
         'pyparsing',
     ],
-    'test': ['hypothesis']
+    'test': [
+        'hypothesis',
+        'PyPDF2',    # for pdf drawing tests in kiva.
+    ]
 }

--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -27,5 +27,18 @@ __extras_require__ = {
         'kiwisolver',
         'pyglet'
     ],
+    'gl': [
+        'pygarrayimage',
+        'pyglet',
+    ],
+    'layout': [
+        'kiwisolver',
+    ],
+    'pdf': [
+        'reportlab',
+    ]
+    'svg': [
+        'pyparsing',
+    ],
     'test': ['hypothesis']
 }

--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -36,7 +36,7 @@ __extras_require__ = {
     ],
     'pdf': [
         'reportlab',
-    ]
+    ],
     'svg': [
         'pyparsing',
     ],


### PR DESCRIPTION
This PR adds a cron job to the GitHub Actions workflow.

Different from the cron job currently setup on Travis which uses EDM, this cron job is setup to install everything from `pip`. 

This exercise also helps flush out missing dependency declaration in `setup.py`, which isn't used by `ci/edmtool.py`. With that, the `extras_require` declarations for optional dependencies is expanded here so that CI setup can call `pip install .[flag,...]`.  This will further benefit package distributors who will be looking for these declarations when they build enable.

As the names of the optional dependencies are tied to the cron job setup, I keep these two changes in the same PR.

Since tests on optional features are skipped if the optional dependency is absent (apart from the ones on SVG, see #543), I checked the CI job output to look out for unexpected skips.

Note to reviewer
--- 
The current trigger is `on: push`, for testing purposes. Once the reviewer is happy with the change, I will switch the event trigger to:
```
on:
  schedule:
    - cron:  '0 0 * * 5'
```
and request one more review again before merging.