### PR TITLE
Mention in the README libglu1-mesa-dev is a build dependency on Linux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,7 @@ the Enable/Kiva project:
 - `SWIG <http://www.swig.org/>`_
 - `fonttools <https://pypi.org/project/FontTools>`_
 - (on Linux) X11-devel (development tools for X11)
+- (on Linux) libglu1-mesa-dev (OpenGL utility library for development)
 - (on Mac OS X) `Cython <https://cython.org/>`_
 
 Enable/Kiva also have the following requirements:


### PR DESCRIPTION
From the exercise of setting up CI, it is evident that `libglu1-mesa-dev` is a build dependency on Linux, `pip install ` fails with lots of compilation errors if the package is absent.

This PR adds the required `libglu1-mesa-dev` (as is named on Ubuntu) on the README. The package name may vary slightly from linux distribution to distribution, though.