### PR TITLE
Declare setuptools as a test dependency

### DIFF
--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -49,5 +49,6 @@ __extras_require__ = {
     'test': [
         'hypothesis',
         'PyPDF2',    # for pdf drawing tests in kiva.
+        "setuptools",
     ]
 }


### PR DESCRIPTION
Closes #545

`pkg_resources` is used in tests. One will get import error if `setuptools` is absent (hard to replicate in CI because `setuptool` often exists). Strictly speaking, one cannot assume a Python environment must have `setuptools`.