### PR TITLE
Add null to the list of toolkits tested on GitHub Actions

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -15,7 +15,7 @@ jobs:
   test-edm-linux:
     strategy:
       matrix:
-        toolkit: ['pyqt', 'pyqt5', 'pyside2', 'wx']
+        toolkit: ['null', 'pyqt', 'pyqt5', 'pyside2', 'wx']
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds the null GUI toolkit to the test matrix. This will catch most omissions to declare GUI dependencies in tests (e.g. tests with `skip_if_null` decorator).

Note that CI setup on Appveyor Windows does tests against null backend and I have not added it here.

I am wondering if it is enough to test null backend on one platform only (motivated by a desire to conserve free resources shared among OSS community).  If this is good enough, I think we have all the pieces from Travis/Appveyor ported to GitHub Actions after this PR.  If not, it is also easy for me to extend the matrix for Windows to include the null backend.
