### PR TITLE
Add tox.ini for flake8 control

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[flake8]
+application-package-names = pyface,traits,traitsui
+application-import-names = enable,kiva
+import-order-style = appnexus
+per-file-ignores =
+    # SWIG generated
+    kiva/agg/agg.py: E,F,I,W
+    kiva/gl/gl.py: E,F,I,W
+    # Vendored
+    kiva/agg/freetype2/*: E,F,I,W
+    kiva/_fontdata.py: E,F,I,W
+    kiva/pdfmetrics.py: E,F,I,W
+    # Long lines from data
+    kiva/examples/kiva/agg/lion.py: E501


### PR DESCRIPTION
We're not ready to run flake8 on the code regularly yet, but with #557 and #558 in place we can now work towards that goal. To that end, I'm introducing a `tox.ini` config which adds ignores for machine generated and vendored files that we don't care to see linter errors for.