### PR TITLE
Remove outdated/broken debugging constructs

### DIFF
--- a/enable/abstract_window.py
+++ b/enable/abstract_window.py
@@ -245,8 +245,6 @@ class AbstractWindow(HasTraits):
         else:
             self._update_region = None
 
-    #        print damaged_regions
-
     # -------------------------------------------------------------------------
     #  Generic keyboard event handler:
     # -------------------------------------------------------------------------

--- a/enable/savage/compliance/drawer.py
+++ b/enable/savage/compliance/drawer.py
@@ -107,11 +107,9 @@ class DrawFrame(wx.Frame):
 
     def FillPath(self, path):
         for row in range(100):
-            # ~ print row,
             operation = self.grid.GetCellValue(row, 0)
             if not operation:
                 return
-            # ~ print operation,
             args = []
             for col in range(1, 20):
                 v = self.grid.GetCellValue(row, col)
@@ -119,7 +117,6 @@ class DrawFrame(wx.Frame):
                     break
                 args.append(float(v))
             self.pathOps[operation](path, *args)
-            # ~ print args
 
 
 if __name__ == "__main__":

--- a/enable/savage/svg/css/transform.py
+++ b/enable/savage/svg/css/transform.py
@@ -49,9 +49,3 @@ matrix = Literal("matrix") + Parenthised(
 transform = skewY | skewX | rotate | scale | translate | matrix
 
 transformList = delimitedList(Group(transform), delim=maybeComma)
-
-if __name__ == "__main__":
-    import unittest
-    from tests.test_css import *
-
-    unittest.main()

--- a/enable/savage/svg/document.py
+++ b/enable/savage/svg/document.py
@@ -117,10 +117,6 @@ def valueToPixels(val, defaultUnits="px"):
     try:
         val, unit = values.length.parseString(val)
     except ParseException:
-        import pdb
-
-        pdb.set_trace()
-        print("valueToPixels(%r, %r)" % (val, defaultUnits))
         raise
     val *= units_to_px.get(unit, 1)
     return val
@@ -1116,12 +1112,3 @@ class SVGDocument(object):
         for op, args in self.ops:
             op(context, *args)
 
-
-if __name__ == "__main__":
-    from tests.test_document import (
-        TestBrushFromColourValue,
-        TestValueToPixels,
-        unittest,
-    )
-
-    unittest.main()

--- a/enable/savage/svg/pathdata.py
+++ b/enable/savage/svg/pathdata.py
@@ -206,7 +206,4 @@ def ptest():
 
 
 if __name__ == "__main__":
-
-    # ~ from tests.test_pathdata import *
-    # ~ unittest.main()
     profile()

--- a/enable/savage/svg/tests/css/test_values.py
+++ b/enable/savage/svg/tests/css/test_values.py
@@ -52,7 +52,6 @@ class TestLength(unittest.TestCase):
 
     def testValidValues(self):
         for string, expected in self.valid:
-            # ~ print string, expected
             got = self.parser.parseString(string)
             self.assertEqual(expected, tuple(got))
 

--- a/enable/stacked_container.py
+++ b/enable/stacked_container.py
@@ -65,7 +65,6 @@ class HStackedContainer(StackedContainer):
         else:
             align = "max"
 
-        # import pdb; pdb.set_trace()
         return stack_layout(self, components, align)
 
 
@@ -103,5 +102,4 @@ class VStackedContainer(StackedContainer):
         else:
             align = "max"
 
-        # import pdb; pdb.set_trace()
         return stack_layout(self, components, align)

--- a/enable/tests/test_constraints_container.py
+++ b/enable/tests/test_constraints_container.py
@@ -337,7 +337,3 @@ class GeometryTestCase(unittest.TestCase):
         self.assertTrue(size_f == SizeF((40.5, 20.5)))
         self.assertTrue(size_f.width == 40.5)
         self.assertTrue(size_f.height == 20.5)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/enable/tests/test_drag_tool.py
+++ b/enable/tests/test_drag_tool.py
@@ -73,7 +73,3 @@ class DragToolTestCase(EnableTestAssistant, unittest.TestCase):
         self.assertEqual(tool.canceled, 1)
         self.assertEqual(tool._drag_state, "dragging")
         self.assertFalse(event.handled)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/enable/tests/test_kiva_graphics_context.py
+++ b/enable/tests/test_kiva_graphics_context.py
@@ -18,7 +18,3 @@ class TestGCErrors(unittest.TestCase):
 
         # Pass in a 3D array, but with an invalid size in the last dimension.
         self.assertRaises(ValueError, gc.draw_image, arr.reshape(2, 2, 1))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/enable/tests/test_resize_tool.py
+++ b/enable/tests/test_resize_tool.py
@@ -144,7 +144,3 @@ class DragToolTestCase(unittest.TestCase):
             self.tool.set_delta(value, x, y)
             self.assertEqual(self.component.position, position)
             self.assertEqual(self.component.bounds, bounds)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/agg/tests/test_affine_matrix.py
+++ b/kiva/agg/tests/test_affine_matrix.py
@@ -121,27 +121,3 @@ class AffineMatrixTestCase(unittest.TestCase):
         desired = array([1.0, 1.0, 1.0, 1.0, 0.0, 0.0])
         actual = val.asarray()
         assert allclose(desired, actual)
-
-
-# ----------------------------------------------------------------------------
-# test setup code.
-# ----------------------------------------------------------------------------
-
-
-def test_suite(level=1):
-    suites = []
-    if level > 0:
-        suites.append(unittest.makeSuite(AffineMatrixTestCase, "test_"))
-    total_suite = unittest.TestSuite(suites)
-    return total_suite
-
-
-def test(level=10):
-    all_tests = test_suite(level)
-    runner = unittest.TextTestRunner()
-    runner.run(all_tests)
-    return runner
-
-
-if __name__ == "__main__":
-    test()

--- a/kiva/agg/tests/test_clip_to_rect.py
+++ b/kiva/agg/tests/test_clip_to_rect.py
@@ -383,7 +383,3 @@ class ClipToRectsTestCase(unittest.TestCase):
         # self.failUnlessRaises(
         #     NotImplementedError, gc.clip_to_rects, [[0, 0, 1, 1]]
         # )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/agg/tests/test_compiled_path.py
+++ b/kiva/agg/tests/test_compiled_path.py
@@ -6,16 +6,6 @@ from kiva import agg
 
 from .test_utils import Utils
 
-# UNCOMMENT THIS TO SEE THE IMPORT ISSUES FROM TICKET
-# https://svn.enthought.com/enthought/ticket/537 (agg causes python crash
-# during unit tests)
-#
-# import sys
-# module_names = [name for name in sys.modules.keys() if name.find('agg') >= 0]
-# module_names.sort()
-# for name in module_names:
-#    print name, sys.modules[name]
-
 
 class TestCompiledPath(unittest.TestCase, Utils):
     def test_init(self):
@@ -261,7 +251,3 @@ class TestCompiledPath(unittest.TestCase, Utils):
     def test_rects_list(self):
         rects = [[1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 1.0, 1.0]]
         self.base_helper_rects(rects)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/agg/tests/test_graphics_context.py
+++ b/kiva/agg/tests/test_graphics_context.py
@@ -364,7 +364,3 @@ class GraphicsContextArrayTestCase(unittest.TestCase):
         gc.set_text_matrix(m)
         m2 = gc.get_text_matrix()
         self.assertEqual(m2, agg.AffineMatrix(1.0, 2.0, 3.0, 4.0, 5.0, 6.0))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/agg/tests/test_graphics_context_system.py
+++ b/kiva/agg/tests/test_graphics_context_system.py
@@ -12,29 +12,3 @@ class GraphicsContextSystemTestCase(unittest.TestCase):
         for i in range(10):
             gc = GraphicsContextSystem((100, 100), "rgba32")
             del gc
-
-
-# ----------------------------------------------------------------------------
-# test setup code.
-# ----------------------------------------------------------------------------
-
-
-def check_suite(level=1):
-    suites = []
-    if level > 0:
-        suites.append(
-            unittest.makeSuite(GraphicsContextSystemTestCase, "test_")
-        )
-    total_suite = unittest.TestSuite(suites)
-    return total_suite
-
-
-def test(level=10):
-    all_tests = check_suite(level)
-    runner = unittest.TextTestRunner()
-    runner.run(all_tests)
-    return runner
-
-
-if __name__ == "__main__":
-    test()

--- a/kiva/agg/tests/test_join_stroke_path.py
+++ b/kiva/agg/tests/test_join_stroke_path.py
@@ -185,7 +185,3 @@ class JoinStrokePathTestCase(unittest.TestCase, Utils):
             ]
         )
         self.assertRavelEqual(actual, desired)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/agg/tests/test_rgba.py
+++ b/kiva/agg/tests/test_rgba.py
@@ -57,7 +57,3 @@ class RgbaTestCase(unittest.TestCase, Utils):
         actual = first.premultiply().asarray()
         desired = array((0.5, 0.5, 0.5, 0.5))
         self.assertRavelEqual(actual, desired)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/agg/tests/test_stroke_path.py
+++ b/kiva/agg/tests/test_stroke_path.py
@@ -436,7 +436,3 @@ class StrokePathTestCase(unittest.TestCase, Utils):
         )
         actual = gc.bmp_array[:, :, 0]
         self.assertRavelEqual(desired, actual)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/agg/tests/test_unicode_font.py
+++ b/kiva/agg/tests/test_unicode_font.py
@@ -14,7 +14,3 @@ class UnicodeTest(unittest.TestCase):
         f1 = AggFontType("Arial")
         f2 = AggFontType(b"Arial")
         self.assertEqual(f1, f2)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/examples/kiva/agg/simple.py
+++ b/kiva/examples/kiva/agg/simple.py
@@ -7,7 +7,6 @@ gc.set_stroke_color((1, 0, 0))
 # gc.move_to(0,0)
 # gc.line_to(100,100)
 # gc.stroke_path()
-# print gc.bmp_array[:6,:6,0]
 
 gc.set_fill_color((0, 0, 1))
 # gc.rect(0,0,5,5)

--- a/kiva/pdf.py
+++ b/kiva/pdf.py
@@ -796,21 +796,3 @@ class GraphicsContext(GraphicsContextBase):
 
     def save(self):
         self.gc.save()
-
-
-def simple_test():
-    pdf = canvas.Canvas("bob.pdf")
-    gc = GraphicsContext(pdf)
-    gc.begin_path()
-    gc.move_to(50, 50)
-    gc.line_to(100, 100)
-    gc.draw_path()
-    gc.flush()
-    pdf.save()
-
-
-if __name__ == "__main__":
-    import sys
-
-    if len(sys.argv) == 1:
-        sys.exit("Usage: %s output_file" % sys.argv[0])

--- a/kiva/tests/agg/test_arc.py
+++ b/kiva/tests/agg/test_arc.py
@@ -115,7 +115,3 @@ class TestAffineMatrix(unittest.TestCase):
         desired = numpy.array([1.0, 1.0, 1.0, 1.0, 0.0, 0.0])
         actual = val.asarray()
         assert numpy.allclose(desired, actual)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/tests/agg/test_draw_dash.py
+++ b/kiva/tests/agg/test_draw_dash.py
@@ -31,7 +31,3 @@ class TestDrawDash(unittest.TestCase):
             gc.stroke_path()
             gc.translate_ctm(10, 0)
         save(gc, "dash.bmp")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/tests/agg/test_image.py
+++ b/kiva/tests/agg/test_image.py
@@ -258,7 +258,3 @@ class test_interpolation_image(unittest.TestCase):
     def test_sinc144_timing(self):
         scheme = "sinc144"
         self.generic_timing(scheme, self.size)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/tests/test_affine.py
+++ b/kiva/tests/test_affine.py
@@ -185,7 +185,3 @@ class TransformPointsTestCase(unittest.TestCase):
         ctm = affine.scale(ctm, 10, 10)
         new_pt = affine.transform_points(ctm, pt)
         assert sum(new_pt[0] - array((-5.0, -5.0))) < 1e-15
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/tests/test_agg_drawing.py
+++ b/kiva/tests/test_agg_drawing.py
@@ -23,7 +23,3 @@ class TestAggDrawing(DrawingImageTester, unittest.TestCase):
                 0, 0, w, 0, grad_stops, "pad", b"userSpaceOnUse"
             )
             self.gc.fill_path()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/tests/test_basecore2d.py
+++ b/kiva/tests/test_basecore2d.py
@@ -484,20 +484,3 @@ class GraphicsContextTestCase(unittest.TestCase):
         gc.move_to(x, y)
         gc.line_to(x, y)
         self.assertTrue(not gc.is_path_empty())
-
-    # -------------------------------------------------------------------------
-    # Test drawing path add line
-    #
-    # Testing needed!
-    # -------------------------------------------------------------------------
-
-    def test_add_line(self):
-        """
-        """
-        pass
-
-
-##################################################
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/tests/test_cairo_drawing.py
+++ b/kiva/tests/test_cairo_drawing.py
@@ -16,7 +16,3 @@ class TestCairoDrawing(DrawingImageTester, unittest.TestCase):
         from kiva.cairo import GraphicsContext
 
         return GraphicsContext((width, height))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/tests/test_gl_drawing.py
+++ b/kiva/tests/test_gl_drawing.py
@@ -65,7 +65,3 @@ class TestGLDrawing(DrawingImageTester, unittest.TestCase):
                 filename, file=file_handle, encoder=PNGImageEncoder()
             )
         self.assertImageSavedWithContent(filename)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/tests/test_image.py
+++ b/kiva/tests/test_image.py
@@ -23,7 +23,3 @@ class TestImage(unittest.TestCase):
         self.assertEqual(image.width(), 100)
         self.assertEqual(image.height(), 120)
         self.assertEqual(image.format(), "rgb24")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/tests/test_kiva_test_assistant.py
+++ b/kiva/tests/test_kiva_test_assistant.py
@@ -44,7 +44,3 @@ class TestKivaTestAssistant(KivaTestAssistant, unittest.TestCase):
         # drawing something
         drawable.should_process = True
         self.assertPathsAreProcessed(drawable)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/tests/test_pdf_drawing.py
+++ b/kiva/tests/test_pdf_drawing.py
@@ -50,7 +50,3 @@ class TestPDFDrawing(DrawingTester, unittest.TestCase):
                     line.endswith(b'f*'),
                     line.endswith(b'ET') and b'hello kiva' in line)):
             self.fail('Path was not closed')
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/tests/test_points_in_polygon.py
+++ b/kiva/tests/test_points_in_polygon.py
@@ -141,7 +141,3 @@ class TestPointsInPolygon(unittest.TestCase):
 
         result = points_in_polygon(points, polygon)
         self.assertTrue(allclose(array([1, 1]), result))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/tests/test_ps_drawing.py
+++ b/kiva/tests/test_ps_drawing.py
@@ -25,7 +25,3 @@ class TestPSDrawing(DrawingTester, unittest.TestCase):
                     line.endswith("cliprestore"),
                     "(hello kiva) show\n" in lines)):
             self.fail("Path was not closed")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/tests/test_qpainter_drawing.py
+++ b/kiva/tests/test_qpainter_drawing.py
@@ -40,7 +40,3 @@ class TestQPainterDrawing(DrawingImageTester, unittest.TestCase):
     @unittest.skipIf(is_qt5 and is_linux, "Currently segfaulting")
     def test_text_clip(self):
         super().test_text_clip()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/kiva/tests/test_svg_drawing.py
+++ b/kiva/tests/test_svg_drawing.py
@@ -19,7 +19,3 @@ class TestSVGDrawing(DrawingTester, unittest.TestCase):
         elements = [element for element in tree.iter()]
         if not len(elements) in [4, 7]:
             self.fail("The expected number of elements was not found")
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
This PR removes the following : 

- remove the old style `print` statements and a few new style print functions
- remove `if __name__ == "__main__"` constructs in the test modules
- remove pdb uses