### PR TITLE
Update traitsui.api imports

### DIFF
--- a/enable/savage/compliance/comparator.py
+++ b/enable/savage/compliance/comparator.py
@@ -21,7 +21,9 @@ from traits.api import (
     Any, Button, Dict, HasTraits, HTML, Instance, List, Property, Str,
     on_trait_change
 )
-from traitsui import api as tui
+from traitsui.api import (
+    EnumEditor, HGroup, HSplit, Item, Tabbed, VGroup, View, VSplit
+)
 
 from enable.savage.svg import document
 from enable.savage.trait_defs.ui.svg_editor import SVGEditor
@@ -128,72 +130,72 @@ class Comparator(HasTraits):
     wx_doc_sike = Instance(Sike, args=())
     kiva_doc_sike = Instance(Sike, args=())
 
-    traits_view = tui.View(
-        tui.Tabbed(
-            tui.VGroup(
-                tui.HGroup(
-                    tui.Item(
+    traits_view = View(
+        Tabbed(
+            VGroup(
+                HGroup(
+                    Item(
                         "current_file",
-                        editor=tui.EnumEditor(name="svg_files"),
+                        editor=EnumEditor(name="svg_files"),
                         style="simple",
                         width=1.0,
                         show_label=False,
                     ),
-                    tui.Item(
+                    Item(
                         "move_backward",
                         show_label=False,
                         enabled_when="svg_files.index(current_file) != 0",
                     ),
-                    tui.Item(
+                    Item(
                         "move_forward",
                         show_label=False,
                         enabled_when=("svg_files.index(current_file) "
                                       "!= len(svg_files)-1"),
                     ),
                 ),
-                tui.VSplit(
-                    tui.HSplit(
-                        tui.Item(
+                VSplit(
+                    HSplit(
+                        Item(
                             "description",
                             label="Description",
                             show_label=False,
                         ),
-                        tui.Item(
+                        Item(
                             "current_xml_view",
                             editor=xml_tree_editor,
                             show_label=False,
                         ),
                     ),
-                    tui.HSplit(
-                        tui.Item(
+                    HSplit(
+                        Item(
                             "document", editor=SVGEditor(), show_label=False
                         ),
-                        tui.Item("kiva_component", show_label=False),
-                        tui.Item("ref_component", show_label=False),
-                        # TODO: tui.Item('agg_component', show_label=False),
+                        Item("kiva_component", show_label=False),
+                        Item("ref_component", show_label=False),
+                        # TODO: Item('agg_component', show_label=False),
                     ),
                 ),
                 label="SVG",
             ),
-            tui.Item(
+            Item(
                 "parsing_sike",
                 style="custom",
                 show_label=False,
                 label="Parsing Profile",
             ),
-            tui.Item(
+            Item(
                 "drawing_sike",
                 style="custom",
                 show_label=False,
                 label="Kiva Drawing Profile",
             ),
-            tui.Item(
+            Item(
                 "wx_doc_sike",
                 style="custom",
                 show_label=False,
                 label="Creating WX document",
             ),
-            tui.Item(
+            Item(
                 "kiva_doc_sike",
                 style="custom",
                 show_label=False,

--- a/enable/savage/compliance/sike.py
+++ b/enable/savage/compliance/sike.py
@@ -8,8 +8,10 @@ from traits.api import (
     Any, Bool, Constant, Dict, Event, Float, HasTraits, Instance, Int, List,
     Property, Str, on_trait_change
 )
-from traitsui import api as tui
-from traitsui.tabular_adapter import TabularAdapter
+from traitsui.api import (
+    CodeEditor, Group, HGroup, Item, Label, TabularAdapter, TabularEditor,
+    UItem, VGroup, View,
+)
 
 
 class SuperTuple(tuple):
@@ -127,7 +129,7 @@ class ProfileAdapter(TabularAdapter):
 
 
 def get_profile_editor(adapter):
-    return tui.TabularEditor(
+    return TabularEditor(
         adapter=adapter,
         editable=False,
         operations=[],
@@ -164,9 +166,9 @@ class ProfileResults(HasTraits):
                 name=name, view_element=view_element
             )
 
-        view = tui.View(
-            tui.Group(tui.Item("total_time", style="readonly")),
-            tui.Item(
+        view = View(
+            Group(Item("total_time", style="readonly")),
+            Item(
                 "records",
                 editor=get_profile_editor(self.adapter),
                 show_label=False,
@@ -278,18 +280,18 @@ class Sike(HasTraits):
     line = Int(1)
     code = Str()
 
-    traits_view = tui.View(
-        tui.VGroup(
-            tui.HGroup(tui.Item("basenames"), tui.Item("percentages")),
-            tui.HGroup(
-                tui.UItem("main_results"),
-                tui.VGroup(
-                    tui.Label("Callees"),
-                    tui.UItem("callee_results"),
-                    tui.Label("Callers"),
-                    tui.UItem("caller_results"),
-                    tui.UItem("filename", style="readonly"),
-                    tui.UItem("code", editor=tui.CodeEditor(line="line")),
+    traits_view = View(
+        VGroup(
+            HGroup(Item("basenames"), Item("percentages")),
+            HGroup(
+                UItem("main_results"),
+                VGroup(
+                    Label("Callees"),
+                    UItem("callee_results"),
+                    Label("Callers"),
+                    UItem("caller_results"),
+                    UItem("filename", style="readonly"),
+                    UItem("code", editor=CodeEditor(line="line")),
                 ),
                 style="custom",
             ),

--- a/enable/savage/compliance/xml_view.py
+++ b/enable/savage/compliance/xml_view.py
@@ -4,7 +4,7 @@
 
 
 from traits.api import HasTraits, List, Property, Str
-from traitsui import api as tui
+from traitsui.api import Item, ModelView, TreeEditor, TreeNode, View
 
 
 known_namespaces = {
@@ -83,12 +83,12 @@ def xml_to_tree(root):
     return element
 
 
-xml_tree_editor = tui.TreeEditor(
+xml_tree_editor = TreeEditor(
     nodes=[
-        tui.TreeNode(
+        TreeNode(
             node_for=[Element], children="kids", label="label", menu=False
         ),
-        tui.TreeNode(
+        TreeNode(
             node_for=[Attribute], children="", label="label", menu=False
         ),
     ],
@@ -97,12 +97,12 @@ xml_tree_editor = tui.TreeEditor(
 )
 
 
-class XMLTree(tui.ModelView):
+class XMLTree(ModelView):
     """ Handler for viewing XML trees.
     """
 
-    traits_view = tui.View(
-        tui.Item("model", editor=xml_tree_editor, show_label=False),
+    traits_view = View(
+        Item("model", editor=xml_tree_editor, show_label=False),
         width=1024,
         height=768,
         resizable=True,


### PR DESCRIPTION
This PR fixes a weird usage of the traitsui api module where `traitsui.api` was being imported as `tui` - and users were then doing
`tui.View` or `tui.Group `- instead of simply importing `Group` from `traitsui.api`.