### PR TITLE
Unconditionally list pillow as a runtime dependency

### DIFF
--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -5,13 +5,9 @@
 """
 from ._version import full_version as __version__
 
-__requires__ = ["numpy", "traits", "traitsui", "pyface", "fonttools"]
-
-# Do not force installation of pillow if PIL is already available.
-try:
-    import PIL
-except ImportError:
-    __requires__.append("pillow")
+__requires__ = [
+    "numpy", "pillow", "traits", "traitsui", "pyface", "fonttools"
+]
 
 __extras_require__ = {
     # Dependencies for running enable/kiva's examples


### PR DESCRIPTION
This PR lists `pillow` as a dependency unconditionally instead of conditionally adding it to the list of required packages depending on whether or not `PIL` can be imported.