### PR TITLE
Provide the right path to the version file on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -405,8 +405,13 @@ def macos_extensions():
 
 
 if __name__ == "__main__":
-    write_version_py(filename='enable/_version.py')
-    write_version_py(filename='kiva/_version.py')
+    if sys.platform.startswith("win"):
+        write_version_py(filename='enable\\_version.py')
+        write_version_py(filename='kiva\\_version.py')
+    else:
+        write_version_py(filename='enable/_version.py')
+        write_version_py(filename='kiva/_version.py')
+
     from enable import __version__, __extras_require__, __requires__
 
     with open('README.rst', 'r') as fp:

--- a/setup.py
+++ b/setup.py
@@ -405,12 +405,8 @@ def macos_extensions():
 
 
 if __name__ == "__main__":
-    if sys.platform.startswith("win"):
-        write_version_py(filename='enable\\_version.py')
-        write_version_py(filename='kiva\\_version.py')
-    else:
-        write_version_py(filename='enable/_version.py')
-        write_version_py(filename='kiva/_version.py')
+    write_version_py(filename=os.path.join('enable', '_version.py'))
+    write_version_py(filename=os.path.join('kiva', '_version.py'))
 
     from enable import __version__, __extras_require__, __requires__
 


### PR DESCRIPTION
On the main branch, the `_version.py` files don't get generated in `enable` and `kiva` - because of the path provided to `write_version_py` function. The changes made here enable the generation of the version file - which also fixes an issue where documentation build is broken on windows because of the lack of the version file.

This is the right fix for the problem I was trying to solve in #519 .