### PR TITLE
Add module docstrings to api modules in enable

### DIFF
--- a/enable/drawing/api.py
+++ b/enable/drawing/api.py
@@ -1,3 +1,18 @@
+""" API for enable.drawing subpackage.
+
+- :class:`~.DragLine`
+- :class:`~.DragPolygon`
+- :class:`~.PointLine`
+- :class:`~.PointPolygon`
+- :class:`~.DragSegment`
+- :class:`~.DragBox`
+- :class:`~.DrawingTool`
+- :class:`~.Button`
+- :class:`~.ToolbarButton`
+- :class:`~.DrawingCanvasToolbar`
+- :class:`~.DrawingCanvas`
+"""
+
 from .drag_line import DragLine
 from .drag_polygon import DragPolygon
 from .point_line import PointLine

--- a/enable/layout/api.py
+++ b/enable/layout/api.py
@@ -3,6 +3,18 @@
 #  All rights reserved.
 # -----------------------------------------------------------------------------
 
+""" API for enable.layout subpackage.
+
+- :func:`~.align`
+- :func:`~.expand_constraints`
+- :func:`~.grid`
+- :func:`~.hbox`
+- :func:`~.horizontal`
+- :func:`~.is_spacer`
+- :attr:`~.spacer`
+- :func:`~.vbox`
+- :func:`~.vertical`
+"""
 from .layout_helpers import (
     align, expand_constraints, grid, hbox, horizontal, is_spacer, spacer,
     vbox, vertical

--- a/enable/primitives/api.py
+++ b/enable/primitives/api.py
@@ -1,3 +1,12 @@
+""" API for enable.primitives subpackage.
+
+- :class:`~.Annotater`
+- :class:`~.Box`
+- :class:`~.Line`
+- :class:`~.Polygon`
+- :class:`~.Shape`
+"""
+
 from .annotater import Annotater
 from .box import Box
 from .line import Line

--- a/enable/tools/api.py
+++ b/enable/tools/api.py
@@ -1,3 +1,16 @@
+""" API for enable.tools subpackage.
+
+- :class:`~.DragTool`
+- :class:`~.HoverTool`
+- :class:`~.MoveTool`
+- :class:`~.ResizeTool`
+- :class:`~.TraitsTool`
+- :class:`~.ViewportPanTool`
+- :class:`~.ViewportZoomTool`
+- :class:`~.ValueDragTool`
+- :class:`~.AttributeDragTool`
+"""
+
 from .drag_tool import DragTool
 from .hover_tool import HoverTool
 from .move_tool import MoveTool

--- a/enable/tools/pyface/api.py
+++ b/enable/tools/pyface/api.py
@@ -6,6 +6,17 @@
 # LICENSE.txt
 #
 
+""" API for enable.tools.pyface subpackage.
+
+- :class:`~.ComponentCommand`
+- :class:`~.MoveCommand`
+- :class:`~.ResizeCommand`
+- :class:`~.BaseCommandTool`
+- :class:`~.BaseUndoTool`
+- :class:`~.MoveCommandTool`
+- :class:`~.ResizeCommandTool`
+- :class:`~.UndoTool`
+"""
 # Support for Undo/Redo with Enable
 from .commands import ComponentCommand, MoveCommand, ResizeCommand
 from .command_tool import BaseCommandTool, BaseUndoTool

--- a/enable/trait_defs/api.py
+++ b/enable/trait_defs/api.py
@@ -1,1 +1,6 @@
+""" API for enable.trait_defs subpackage.
+
+- :attr:`~.RGBAColor`
+"""
+
 from .rgba_color_trait import RGBAColor


### PR DESCRIPTION
This PR adds module docstrings to the api modules in enable - which improves the readability of the published API documentation.