### PR TITLE
Use kiva api modules where possible

### DIFF
--- a/docs/source/kiva.rst
+++ b/docs/source/kiva.rst
@@ -343,7 +343,7 @@ Text can be rendered at a point by first setting the font to use, then setting
 the text location using ``set_text_position()`` and then ``show_text()`` to
 render the text::
 
-    from kiva.fonttools import Font
+    from kiva.api import Font
     from kiva.image import GraphicsContext
 
     gc = GraphicsContext((200, 100))

--- a/docs/source/kiva.rst
+++ b/docs/source/kiva.rst
@@ -238,8 +238,8 @@ Thicknesses::
 
 Joins::
 
+    from kiva.api import JOIN_ROUND, JOIN_BEVEL, JOIN_MITER
     from kiva.image import GraphicsContext
-    from kiva.constants import JOIN_ROUND, JOIN_BEVEL, JOIN_MITER
 
     gc = GraphicsContext((200, 100))
     gc.set_line_width(8)
@@ -259,8 +259,8 @@ Joins::
 
 Caps::
 
+    from kiva.api import CAP_ROUND, CAP_BUTT, CAP_SQUARE
     from kiva.image import GraphicsContext
-    from kiva.constants import CAP_ROUND, CAP_BUTT, CAP_SQUARE
 
     gc = GraphicsContext((200, 100))
     gc.set_line_width(8)
@@ -307,8 +307,8 @@ available:
 Winding vs. Even-Odd Fill::
 
     from numpy import pi
+    from kiva.api import FILL, EOF_FILL
     from kiva.image import GraphicsContext
-    from kiva.constants import FILL, EOF_FILL
 
     gc = GraphicsContext((200, 100))
     gc.set_fill_color((0.0, 0.0, 0.0))

--- a/enable/base.py
+++ b/enable/base.py
@@ -24,10 +24,10 @@ Enable package.
 # Enthought library imports
 from traits.api import TraitError
 
-from kiva.constants import (
-    BOLD, DECORATIVE, DEFAULT, ITALIC, MODERN, NORMAL, ROMAN, SCRIPT, SWISS
+from kiva.api import (
+    BOLD, DECORATIVE, DEFAULT, ITALIC, MODERN, NORMAL, ROMAN, SCRIPT, SWISS,
+    Font,
 )
-from kiva.fonttools import Font
 
 from .colors import color_table, transparent_color
 

--- a/enable/canvas.py
+++ b/enable/canvas.py
@@ -2,7 +2,7 @@
 
 # Enthought library imports
 from traits.api import Bool, List, Trait, Tuple
-from kiva.constants import FILL
+from kiva.api import FILL
 
 
 # Local relative imports

--- a/enable/component.py
+++ b/enable/component.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from traits.api import (
     Any, Bool, Delegate, Enum, Float, Instance, Int, List, Property, Str, Trait
 )
-from kiva.constants import FILL, STROKE
+from kiva.api import FILL, STROKE
 
 # Local relative imports
 from .colors import black_color_trait, white_color_trait

--- a/enable/drawing/drawing_canvas.py
+++ b/enable/drawing/drawing_canvas.py
@@ -1,6 +1,6 @@
 from enable.api import Container, Component, ColorTrait
 from kiva.api import FILL, FILL_STROKE
-from kiva.trait_defs.kiva_font_trait import KivaFont
+from kiva.trait_defs.api import KivaFont
 from traits.api import Any, Bool, Delegate, Enum, Instance, Int, List, Str
 
 

--- a/enable/drawing/drawing_canvas.py
+++ b/enable/drawing/drawing_canvas.py
@@ -1,5 +1,5 @@
 from enable.api import Container, Component, ColorTrait
-from kiva.constants import FILL, FILL_STROKE
+from kiva.api import FILL, FILL_STROKE
 from kiva.trait_defs.kiva_font_trait import KivaFont
 from traits.api import Any, Bool, Delegate, Enum, Instance, Int, List, Str
 

--- a/enable/enable_traits.py
+++ b/enable/enable_traits.py
@@ -6,7 +6,7 @@ Define the base Enable object traits
 from numpy import arange, array
 
 # Enthought library imports
-from kiva.trait_defs.kiva_font_trait import KivaFont
+from kiva.trait_defs.api import KivaFont
 from traits.api import (
     List, Range, Trait, TraitFactory, TraitPrefixList, TraitPrefixMap
 )

--- a/enable/examples/demo/enable/container_demo.py
+++ b/enable/examples/demo/enable/container_demo.py
@@ -4,7 +4,7 @@ from traits.api import Enum, Float, Int, Str, Tuple
 from enable.api import ColorTrait
 from enable.example_support import DemoFrame, demo_main
 from enable.tools.api import DragTool
-from kiva.trait_defs.kiva_font_trait import KivaFont
+from kiva.trait_defs.api import KivaFont
 
 
 class Region(PlotComponent, DragTool):

--- a/enable/examples/demo/enable/latency_demo.py
+++ b/enable/examples/demo/enable/latency_demo.py
@@ -8,8 +8,7 @@ from traits.api import Float
 
 from enable.api import Component, Container, ColorTrait, black_color_trait
 from enable.example_support import DemoFrame, demo_main
-from kiva.constants import SWISS
-from kiva.fonttools import Font
+from kiva.api import SWISS, Font
 
 font = Font(family=SWISS)
 

--- a/enable/examples/demo/enable/tools/button_tool.py
+++ b/enable/examples/demo/enable/tools/button_tool.py
@@ -11,7 +11,7 @@ Button Tool
 """
 
 from traits.api import Bool
-from kiva.constants import FILL, STROKE
+from kiva.api import FILL, STROKE
 
 from enable.api import Container, transparent_color
 from enable.colors import ColorTrait

--- a/enable/examples/demo/savage/buttons_on_canvas.py
+++ b/enable/examples/demo/savage/buttons_on_canvas.py
@@ -13,8 +13,7 @@ import xml.etree.cElementTree as etree
 from enable.api import BaseTool, Component, ComponentEditor, Container
 from enable.savage.svg.backends.kiva.renderer import Renderer as KivaRenderer
 from enable.savage.svg.document import SVGDocument
-from kiva.constants import MODERN
-from kiva.fonttools import Font
+from kiva.api import MODERN, Font
 from traits.api import Callable, Enum, HasTraits, Instance, List, Str
 from traitsui.api import Item, View
 

--- a/enable/gadgets/vu_meter.py
+++ b/enable/gadgets/vu_meter.py
@@ -2,7 +2,7 @@ import math
 
 from traits.api import Float, Property, List, Str, Range
 from enable.api import Component
-from kiva.trait_defs.kiva_font_trait import KivaFont
+from kiva.trait_defs.api import KivaFont
 from kiva import affine
 
 

--- a/enable/graphics_context.py
+++ b/enable/graphics_context.py
@@ -1,4 +1,4 @@
-from kiva.constants import FILL
+from kiva.api import FILL
 
 # Relative imports
 from .abstract_window import AbstractWindow

--- a/enable/interactor.py
+++ b/enable/interactor.py
@@ -1,7 +1,7 @@
 """ Defines the Interactor class """
 
 # Enthought library imports
-from kiva.affine import affine_identity
+from kiva.api import affine_identity
 from traits.api import Any, Bool, HasTraits, List, Property, Str, Trait
 
 # Local relative imports

--- a/enable/label.py
+++ b/enable/label.py
@@ -6,7 +6,7 @@ from math import pi
 from numpy import asarray
 
 # Enthought library imports
-from kiva.constants import FILL, STROKE
+from kiva.api import FILL, STROKE
 from kiva.trait_defs.kiva_font_trait import KivaFont
 from traits.api import Bool, Enum, Float, HasTraits, Int, List, Str
 

--- a/enable/label.py
+++ b/enable/label.py
@@ -7,7 +7,7 @@ from numpy import asarray
 
 # Enthought library imports
 from kiva.api import FILL, STROKE
-from kiva.trait_defs.kiva_font_trait import KivaFont
+from kiva.trait_defs.api import KivaFont
 from traits.api import Bool, Enum, Float, HasTraits, Int, List, Str
 
 # Local, relative imports

--- a/enable/markers.py
+++ b/enable/markers.py
@@ -8,7 +8,7 @@ from numpy import array, pi
 # Enthought library imports
 from traits.api import HasTraits, Bool, Instance, Trait
 from traitsui.api import EnumEditor
-from kiva.constants import (
+from kiva.api import (
     CIRCLE_MARKER, CROSS_MARKER, DIAMOND_MARKER, DOT_MARKER, FILL_STROKE,
     INVERTED_TRIANGLE_MARKER, NO_MARKER, PIXEL_MARKER, PLUS_MARKER,
     SQUARE_MARKER, STROKE, TRIANGLE_MARKER
@@ -22,12 +22,12 @@ class AbstractMarker(HasTraits):
     """ Abstract class for markers.
     """
 
-    # How this marker is to be stroked (from kiva.constants).
+    # How this marker is to be stroked (from kiva.api).
     # Since this needs to be a class variable, it can't be a trait.
     draw_mode = STROKE
     # draw_mode = Enum(FILL, EOF_FILL, STROKE, FILL_STROKE, EOF_FILL_STROKE)
 
-    # The kiva marker type (from kiva.constants).
+    # The kiva marker type (from kiva.api).
     kiva_marker = NO_MARKER
 
     # Close the path object after drawing this marker?

--- a/enable/null/celiagg.py
+++ b/enable/null/celiagg.py
@@ -20,7 +20,7 @@ class Window(object):
 
 
 def font_metrics_provider():
-    from kiva.fonttools import Font
+    from kiva.api import Font
 
     gc = GraphicsContext((1, 1))
     gc.set_font(Font())

--- a/enable/null/pdf.py
+++ b/enable/null/pdf.py
@@ -23,7 +23,7 @@ class Window(object):
 def font_metrics_provider():
     from reportlab.pdfgen.canvas import Canvas
     from reportlab.lib.pagesizes import letter
-    from kiva.fonttools import Font
+    from kiva.api import Font
 
     # a file will not be created unless save() is called on the context
     pdf_canvas = Canvas(filename="enable_tmp.pdf", pagesize=letter)

--- a/enable/null/ps.py
+++ b/enable/null/ps.py
@@ -21,7 +21,7 @@ class Window(object):
 
 
 def font_metrics_provider():
-    from kiva.fonttools import Font
+    from kiva.api import Font
 
     gc = GraphicsContext((1, 1))
     gc.set_font(Font())

--- a/enable/null/quartz.py
+++ b/enable/null/quartz.py
@@ -11,7 +11,7 @@
 
 import numpy as np
 
-from kiva.fonttools import Font
+from kiva.api import Font
 from kiva.quartz import ABCGI
 
 

--- a/enable/primitives/box.py
+++ b/enable/primitives/box.py
@@ -4,7 +4,7 @@
 # Parent package imports
 from enable.api import border_size_trait, Component, transparent_color
 from enable.colors import ColorTrait
-from kiva.constants import FILL, STROKE
+from kiva.api import FILL, STROKE
 
 
 class Box(Component):

--- a/enable/primitives/line.py
+++ b/enable/primitives/line.py
@@ -3,7 +3,7 @@
 from numpy import array, resize
 
 # Enthought library imports.
-from kiva.constants import FILL, FILL_STROKE, STROKE
+from kiva.api import FILL, FILL_STROKE, STROKE
 from traits.api import Any, Event, Float, List, Trait, Bool
 
 # Local imports.

--- a/enable/primitives/shape.py
+++ b/enable/primitives/shape.py
@@ -7,8 +7,7 @@ import math
 from enable.colors import ColorTrait
 from enable.component import Component
 from enable.enable_traits import Pointer
-from kiva.constants import MODERN
-from kiva.fonttools import Font
+from kiva.api import MODERN, Font
 from traits.api import Float, Property, Str, Tuple
 
 

--- a/enable/qt4/celiagg.py
+++ b/enable/qt4/celiagg.py
@@ -74,7 +74,7 @@ class Window(BaseWindow):
 
 
 def font_metrics_provider():
-    from kiva.fonttools import Font
+    from kiva.api import Font
 
     gc = GraphicsContext((1, 1))
     gc.set_font(Font())

--- a/enable/qt4/gl.py
+++ b/enable/qt4/gl.py
@@ -51,7 +51,7 @@ class Window(BaseGLWindow):
 
 
 def font_metrics_provider():
-    from kiva.fonttools import Font
+    from kiva.api import Font
 
     gc = GraphicsContext((1, 1))
     gc.set_font(Font())

--- a/enable/qt4/image.py
+++ b/enable/qt4/image.py
@@ -45,7 +45,7 @@ class Window(BaseWindow):
 
 
 def font_metrics_provider():
-    from kiva.fonttools import Font
+    from kiva.api import Font
 
     gc = GraphicsContext((1, 1))
     gc.set_font(Font())

--- a/enable/qt4/quartz.py
+++ b/enable/qt4/quartz.py
@@ -10,7 +10,7 @@
 # -----------------------------------------------------------------------------
 import numpy as np
 
-from kiva.fonttools import Font
+from kiva.api import Font
 from kiva.quartz import get_mac_context, ABCGI
 
 from .base_window import BaseWindow

--- a/enable/savage/compliance/svg_component.py
+++ b/enable/savage/compliance/svg_component.py
@@ -6,7 +6,7 @@ import time
 
 from enable.api import Component
 from traits.api import Any, Array, Bool, Float
-from kiva.fonttools import Font
+from kiva.api import Font
 
 
 if sys.platform == "win32":

--- a/enable/savage/svg/backends/kiva/renderer.py
+++ b/enable/savage/svg/backends/kiva/renderer.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from enable.compiled_path import CompiledPath as KivaCompiledPath
 from kiva import affine, constants, fonttools
-from kiva.fonttools import Font
+from kiva.api import Font
 
 from enable.savage.svg import svg_extras
 from enable.savage.svg.backends.null.null_renderer import (

--- a/enable/slider.py
+++ b/enable/slider.py
@@ -1,7 +1,7 @@
 from numpy import linspace, zeros
 
 # Enthought library imports
-from kiva.constants import STROKE
+from kiva.api import STROKE
 from traits.api import (
     Any, Bool, Enum, Float, Int, Property, Trait, on_trait_change,
 )

--- a/enable/text_grid.py
+++ b/enable/text_grid.py
@@ -9,7 +9,7 @@ from numpy import arange, array, dstack, repeat, newaxis
 from traits.api import (
     Any, Array, Bool, Int, List, Property, Trait, Tuple, on_trait_change,
 )
-from kiva.trait_defs.kiva_font_trait import KivaFont
+from kiva.trait_defs.api import KivaFont
 
 # Relative imports
 from .component import Component

--- a/enable/tools/toolbars/toolbar_buttons.py
+++ b/enable/tools/toolbars/toolbar_buttons.py
@@ -1,7 +1,7 @@
 # Enthought library imports
 from enable.api import ColorTrait, Component
 from enable.font_metrics_provider import font_metrics_provider
-from kiva.trait_defs.kiva_font_trait import KivaFont
+from kiva.trait_defs.api import KivaFont
 from traits.api import Bool, Enum, Int, Str, Tuple
 
 

--- a/enable/trait_defs/ui/wx/enable_rgba_color_editor.py
+++ b/enable/trait_defs/ui/wx/enable_rgba_color_editor.py
@@ -22,7 +22,7 @@ import wx
 
 from enable import ColorPicker
 from enable.wx import Window
-from kiva.trait_defs.kiva_font_trait import KivaFont
+from kiva.trait_defs.api import KivaFont
 from traits.api import Bool, Enum, Str
 from traitsui.api import View
 from traitsui.wx.editor import Editor

--- a/enable/wx/gl.py
+++ b/enable/wx/gl.py
@@ -71,7 +71,7 @@ class Window(BaseWindow):
 
 
 def font_metrics_provider():
-    from kiva.fonttools import Font
+    from kiva.api import Font
 
     gc = GraphicsContext((1, 1))
     gc.set_font(Font())

--- a/enable/wx/image.py
+++ b/enable/wx/image.py
@@ -72,7 +72,7 @@ class Window(BaseWindow):
 
 
 def font_metrics_provider():
-    from kiva.fonttools import Font
+    from kiva.api import Font
 
     gc = GraphicsContext((1, 1))
     gc.set_font(Font())

--- a/enable/wx/quartz.py
+++ b/enable/wx/quartz.py
@@ -7,7 +7,7 @@ import numpy as np
 import wx
 
 # Enthought library imports.
-from kiva.fonttools import Font
+from kiva.api import Font
 from kiva.quartz import get_macport, ABCGI
 
 # Local imports.

--- a/kiva/agg/tests/test_font_loading.py
+++ b/kiva/agg/tests/test_font_loading.py
@@ -1,7 +1,7 @@
 import time
 
 from kiva.image import font_metrics_provider as FMP
-from kiva.fonttools import Font
+from kiva.api import Font
 
 counts = (500,)
 strings = ("hello",)  # ascii_lowercase + ascii_uppercase)

--- a/kiva/agg/tests/test_graphics_context.py
+++ b/kiva/agg/tests/test_graphics_context.py
@@ -3,7 +3,7 @@ import unittest
 from numpy import all, allclose, array, dtype, pi, ones
 
 from kiva import agg
-from kiva.fonttools import Font
+from kiva.api import Font
 
 
 class GraphicsContextArrayTestCase(unittest.TestCase):

--- a/kiva/agg/tests/test_unicode_font.py
+++ b/kiva/agg/tests/test_unicode_font.py
@@ -1,7 +1,7 @@
 import unittest
 
 from kiva.agg import AggFontType, GraphicsContextArray
-from kiva.fonttools import Font
+from kiva.api import Font
 
 
 class UnicodeTest(unittest.TestCase):

--- a/kiva/examples/kiva/agg/compiled_path.py
+++ b/kiva/examples/kiva/agg/compiled_path.py
@@ -1,6 +1,6 @@
 from numpy import array
 
-from kiva.constants import STROKE
+from kiva.api import STROKE
 from kiva.image import CompiledPath, GraphicsContext
 
 cross = CompiledPath()

--- a/kiva/examples/kiva/agg/text_ex.py
+++ b/kiva/examples/kiva/agg/text_ex.py
@@ -1,8 +1,7 @@
 from time import perf_counter
 
 from kiva.agg import AffineMatrix, GraphicsContextArray
-from kiva.constants import MODERN
-from kiva.fonttools import Font
+from kiva.api import MODERN, Font
 
 gc = GraphicsContextArray((200, 200))
 

--- a/kiva/examples/kiva/compiled_path.py
+++ b/kiva/examples/kiva/compiled_path.py
@@ -8,7 +8,7 @@ import tempfile
 from enable.api import ConstraintsContainer
 from enable.example_support import DemoFrame, demo_main
 from enable.primitives.image import Image
-from kiva.constants import STROKE
+from kiva.api import STROKE
 from kiva.image import GraphicsContext, CompiledPath
 
 

--- a/kiva/examples/kiva/dummy.py
+++ b/kiva/examples/kiva/dummy.py
@@ -1,6 +1,6 @@
 from enable.kiva_graphics_context import GraphicsContext
 from kiva import agg
-from kiva.fonttools import Font
+from kiva.api import Font
 
 # Do some basic drawing tests and write the results out to PNG files.
 # This is mostly a python translation of the tests in kiva/agg/src/dummy.cpp

--- a/kiva/examples/kiva/kiva_explorer.py
+++ b/kiva/examples/kiva/kiva_explorer.py
@@ -17,8 +17,7 @@ default_script = """# Write your code here.
 # The graphics context is available as gc.
 
 from math import pi
-from kiva import constants
-from kiva.fonttools import Font
+from kiva.api import CAP_ROUND, JOIN_ROUND, Font
 
 with gc:
     gc.set_fill_color((1.0, 1.0, 0.0, 1.0))
@@ -35,8 +34,8 @@ with gc:
 
     gc.set_stroke_color((0.0, 0.0, 1.0, 1.0))
     gc.set_line_width(7)
-    gc.set_line_join(constants.JOIN_ROUND)
-    gc.set_line_cap(constants.CAP_ROUND)
+    gc.set_line_join(JOIN_ROUND)
+    gc.set_line_cap(CAP_ROUND)
     gc.rect(100, 400, 50, 50)
     gc.stroke_path()
 

--- a/kiva/examples/kiva/pyglet_gl.py
+++ b/kiva/examples/kiva/pyglet_gl.py
@@ -1,7 +1,7 @@
 from numpy import array
 from pyglet.window import key, Window
 
-from kiva.constants import STROKE
+from kiva.api import STROKE
 
 try:
     from kiva.gl import GraphicsContext

--- a/kiva/examples/kiva/star_path.py
+++ b/kiva/examples/kiva/star_path.py
@@ -1,6 +1,6 @@
 from numpy import cos, sin, arange, pi, array
 
-from kiva.constants import FILL, EOF_FILL, STROKE, FILL_STROKE, EOF_FILL_STROKE
+from kiva.api import FILL, EOF_FILL, STROKE, FILL_STROKE, EOF_FILL_STROKE
 from kiva.image import GraphicsContext
 
 

--- a/kiva/fonttools/tests/test_font.py
+++ b/kiva/fonttools/tests/test_font.py
@@ -3,7 +3,7 @@
 import os
 import unittest
 
-from kiva.fonttools import Font
+from kiva.api import Font
 from kiva.fonttools.tests._testing import patch_global_font_manager
 
 

--- a/kiva/tests/agg/test_image.py
+++ b/kiva/tests/agg/test_image.py
@@ -10,7 +10,7 @@ from numpy import (
 )
 
 from kiva import agg
-from kiva.fonttools import Font
+from kiva.api import Font
 from kiva.compat import pilfromstring, piltostring
 
 

--- a/kiva/tests/agg/test_image3.py
+++ b/kiva/tests/agg/test_image3.py
@@ -4,7 +4,7 @@ import time
 import numpy as np
 
 from kiva import agg
-from kiva.fonttools import Font
+from kiva.api import Font
 
 ArialFont = Font("arial")
 

--- a/kiva/tests/agg/test_text.py
+++ b/kiva/tests/agg/test_text.py
@@ -3,7 +3,7 @@ import locale
 import unittest
 
 from kiva import agg
-from kiva.fonttools import Font
+from kiva.api import Font
 
 
 @contextmanager

--- a/kiva/tests/drawing_tester.py
+++ b/kiva/tests/drawing_tester.py
@@ -6,8 +6,7 @@ import tempfile
 import numpy
 from PIL import Image
 
-from kiva.fonttools import Font
-from kiva.constants import MODERN
+from kiva.api import MODERN, Font
 
 
 class DrawingTester(object):

--- a/kiva/tests/dummy.py
+++ b/kiva/tests/dummy.py
@@ -1,6 +1,5 @@
 from enable.kiva_graphics_context import GraphicsContext
-from kiva import affine
-from kiva.fonttools import Font
+from kiva.api import Font, affine_from_rotation, invert
 
 # Do some basic drawing tests and write the results out to files.
 # This is mostly a python translation of the tests in kiva/agg/src/dummy.cpp
@@ -228,10 +227,10 @@ def test_handling_text(gc):
     gc.line_to(0, -5)
     gc.move_to(0, 0)
     gc.stroke_path()
-    txtRot = affine.affine_from_rotation(PI / 6)
+    txtRot = affine_from_rotation(PI / 6)
     gc.set_text_matrix(txtRot)
     gc.show_text("Hello")
-    txtRot = affine.invert(txtRot)
+    txtRot = invert(txtRot)
     gc.set_text_matrix(txtRot)
     gc.show_text("inverted")
 


### PR DESCRIPTION
This PR updates the enable and kiva testsuite to use `kiva.api` or `kiva.trait_defs.api` where possible - instead of explicitly importing from `kiva.affine`, `kiva.constants`, `kiva.fonttools` or `kiva.trait_defs.kiva_font_trait`