### PR TITLE
Stop using deprecated trait handlers

### DIFF
--- a/enable/controls.py
+++ b/enable/controls.py
@@ -20,7 +20,7 @@ import os.path
 
 # Enthought library imports
 from enable.colors import ColorTrait
-from traits.api import Bool, Delegate, HasTraits, Str, Trait, TraitPrefixList
+from traits.api import Bool, Delegate, HasTraits, PrefixList, Str, Trait
 from traitsui.api import View, Group
 
 # Local relative imports
@@ -45,7 +45,7 @@ LEFT_OR_RIGHT = LEFT | RIGHT
 TOP_OR_BOTTOM = TOP | BOTTOM
 
 
-orientation_trait = Trait("text", TraitPrefixList(["text", "component"]))
+orientation_trait = PrefixList(["text", "component"], default_value="text")
 
 
 class LabelTraits(HasTraits):

--- a/enable/enable_traits.py
+++ b/enable/enable_traits.py
@@ -3,13 +3,11 @@ Define the base Enable object traits
 """
 
 # Major library imports
-from numpy import arange, array
+from numpy import array, ndarray
 
 # Enthought library imports
 from kiva.trait_defs.api import KivaFont
-from traits.api import (
-    List, Range, Trait, TraitFactory, TraitPrefixList, TraitPrefixMap
-)
+from traits.api import List, PrefixList, PrefixMap, Range, Trait, TraitFactory
 from traitsui.api import ImageEnumEditor, EnumEditor
 
 # Try to get the CList trait; for traits 2 backwards compatibility, fall back
@@ -28,7 +26,7 @@ from .base import default_font_name
 # -----------------------------------------------------------------------------
 
 # numpy 'array' type:
-ArrayType = type(arange(1.0))
+ArrayType = ndarray
 
 # Basic sequence types:
 basic_sequence_types = (list, tuple)
@@ -134,10 +132,10 @@ ComponentMinSize = Range(0.0, 99999.0)
 ComponentMaxSize = ComponentMinSize(99999.0)
 
 # Pointer shape trait:
-Pointer = Trait("arrow", TraitPrefixList(pointer_shapes))
+Pointer = PrefixList(pointer_shapes, default_value="arrow")
 
 # Cursor style trait:
-cursor_style_trait = Trait("default", TraitPrefixMap(cursor_styles))
+cursor_style_trait = PrefixMap(cursor_styles, default_value="default")
 
 spacing_trait = Range(0, 63, value=4)
 padding_trait = Range(0, 63, value=4)

--- a/enable/primitives/annotater.py
+++ b/enable/primitives/annotater.py
@@ -3,7 +3,7 @@ Define an Annotater component that allows a user to annotate an underlying
 component
 """
 
-from traits.api import Event, Trait, TraitPrefixList
+from traits.api import Event, PrefixList
 from traitsui.api import Group, View
 
 from enable.api import Component
@@ -13,7 +13,8 @@ from enable.colors import ColorTrait
 class Annotater(Component):
 
     color = ColorTrait((0.0, 0.0, 0.0, 0.2))
-    style = Trait("rectangular", TraitPrefixList(["rectangular", "freehand"]))
+    style = PrefixList(["rectangular", "freehand"],
+                       default_value="rectangular")
     annotation = Event
 
     traits_view = View(


### PR DESCRIPTION
Closes #433.

There's still a deprecation warning about using `TraitMap`, but this is coming from traits internal code, so I'm not sure anything can be done within enable.

```
/Users/jwiggins/.edm/envs/enable-test-3.6-pyqt5/lib/python3.6/site-packages/traits/traits.py:330: DeprecationWarning: 'TraitMap' trait handler has been deprecated. Use Map instead.
  other.append(TraitMap(map))
```