### PR TITLE
Add a unit test for drawing images

### DIFF
--- a/kiva/pdf.py
+++ b/kiva/pdf.py
@@ -602,7 +602,7 @@ class GraphicsContext(GraphicsContextBase):
             return
 
         if rect is None:
-            rect = (0, 0, img.width(), img.height())
+            rect = (0, 0, pil_img.width, pil_img.height)
 
         # Draw the actual image.
         # Wrap it in an ImageReader object, because that's what reportlab

--- a/kiva/ps.py
+++ b/kiva/ps.py
@@ -17,7 +17,7 @@
 """
 
 # Major library imports
-from io import StringIO
+from io import BytesIO, StringIO
 import os
 import warnings
 
@@ -225,7 +225,7 @@ class PSGC(basecore2d.GraphicsContextBase):
             pil_img = pil_img.convert("RGB")
 
         left, top, width, height = rect
-        if width != img.width() or height != img.height():
+        if width != pil_img.width or height != pil_img.height:
             # This is not strictly required.
             pil_img = pil_img.resize(
                 (int(width), int(height)), PilImage.NEAREST
@@ -240,7 +240,9 @@ class PSGC(basecore2d.GraphicsContextBase):
         )
         self.contents.write("%.3f %.3f translate\n" % (left, top))
         # Rely on PIL's EpsImagePlugin to do the hard work here.
-        pil_img.save(self.contents, "eps", eps=0)
+        fp = BytesIO()
+        pil_img.save(fp, "eps", eps=0)
+        self.contents.write(fp.getvalue().decode('utf8'))
         self.contents.write("grestore\n")
 
     def device_transform_device_ctm(self, func, args):

--- a/kiva/svg.py
+++ b/kiva/svg.py
@@ -275,10 +275,10 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
             return
 
         if rect is None:
-            rect = (0, 0, img.width(), img.height())
+            rect = (0, 0, pil_img.width, pil_img.height)
 
         left, top, width, height = rect
-        if width != img.width() or height != img.height():
+        if width != pil_img.width or height != pil_img.height:
             # This is not strictly required.
             pil_img = pil_img.resize(
                 (int(width), int(height)), PilImage.NEAREST

--- a/kiva/tests/drawing_tester.py
+++ b/kiva/tests/drawing_tester.py
@@ -26,6 +26,12 @@ class DrawingTester(object):
         del self.gc
         shutil.rmtree(self.directory)
 
+    def test_image(self):
+        img = numpy.zeros((20, 20, 4), dtype=numpy.uint8)
+        img[5:15, 5:15, (0, 3)] = 255
+        with self.draw_and_check():
+            self.gc.draw_image(img, (100, 100, 20, 20))
+
     def test_line(self):
         with self.draw_and_check():
             self.gc.begin_path()
@@ -171,4 +177,4 @@ class DrawingImageTester(DrawingTester):
             )
         if check.any():
             return
-        self.fail("The image looks empty, no red pixels where drawn")
+        self.fail("The image looks empty, no red pixels were drawn")

--- a/kiva/tests/test_gl_drawing.py
+++ b/kiva/tests/test_gl_drawing.py
@@ -31,6 +31,13 @@ class TestGLDrawing(DrawingImageTester, unittest.TestCase):
         gc.gl_init()
         return gc
 
+    @unittest.expectedFailure
+    def test_image(self):
+        """ gl image drawing is broken. It depends on pygarrayimage, which
+        is not actively maintained and appears to be broken now.
+        """
+        DrawingImageTester.test_image()
+
     @unittest.skip("gl graphics context does not support star_clip (#164)")
     def test_star_clip(self):
         # FIXME: overriding test since it segfaults

--- a/kiva/tests/test_pdf_drawing.py
+++ b/kiva/tests/test_pdf_drawing.py
@@ -46,6 +46,7 @@ class TestPDFDrawing(DrawingTester, unittest.TestCase):
         # been drawn.
         line = content.getData().splitlines()[-2]
         if not any((line.endswith(b'f'),
+                    line.endswith(b'Q'),
                     line.endswith(b'S'),
                     line.endswith(b'f*'),
                     line.endswith(b'ET') and b'hello kiva' in line)):

--- a/kiva/tests/test_ps_drawing.py
+++ b/kiva/tests/test_ps_drawing.py
@@ -23,5 +23,6 @@ class TestPSDrawing(DrawingTester, unittest.TestCase):
         if not any((line.endswith("fill"),
                     line.endswith("stroke"),
                     line.endswith("cliprestore"),
+                    line.endswith("grestore"),
                     "(hello kiva) show\n" in lines)):
             self.fail("Path was not closed")

--- a/kiva/tests/test_qpainter_drawing.py
+++ b/kiva/tests/test_qpainter_drawing.py
@@ -33,6 +33,11 @@ class TestQPainterDrawing(DrawingImageTester, unittest.TestCase):
 
         return GraphicsContext((width, height))
 
+    @unittest.expectedFailure
+    def test_image(self):
+        """ QPainter interprets images as BGRA. """
+        super().test_image()
+
     @unittest.skipIf(is_qt5 and is_linux, "Currently segfaulting")
     def test_text(self):
         super().test_text()


### PR DESCRIPTION
**NOTE**: I expect this to fail until #569 is merged. This is due to broken implementations of `draw_image` in the PS and SVG backends.

```
======================================================================
ERROR: test_image (kiva.tests.test_ps_drawing.TestPSDrawing)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/.edm/envs/enable-test-3.6-null/lib/python3.6/site-packages/kiva/tests/drawing_tester.py", line 33, in test_image
    self.gc.draw_image(img, (100, 100, 20, 20))
  File "/home/runner/.edm/envs/enable-test-3.6-null/lib/python3.6/site-packages/kiva/basecore2d.py", line 856, in draw_image
    self.device_draw_image(img, rect)
  File "/home/runner/.edm/envs/enable-test-3.6-null/lib/python3.6/site-packages/kiva/ps.py", line 231, in device_draw_image
    if width != img.width() or height != img.height():
AttributeError: 'numpy.ndarray' object has no attribute 'width'

======================================================================
ERROR: test_image (kiva.tests.test_svg_drawing.TestSVGDrawing)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/.edm/envs/enable-test-3.6-null/lib/python3.6/site-packages/kiva/tests/drawing_tester.py", line 33, in test_image
    self.gc.draw_image(img, (100, 100, 20, 20))
  File "/home/runner/.edm/envs/enable-test-3.6-null/lib/python3.6/site-packages/kiva/basecore2d.py", line 856, in draw_image
    self.device_draw_image(img, rect)
  File "/home/runner/.edm/envs/enable-test-3.6-null/lib/python3.6/site-packages/kiva/svg.py", line 284, in device_draw_image
    if width != img.width() or height != img.height():
AttributeError: 'numpy.ndarray' object has no attribute 'width'
```