### PR TITLE
Undo removal of get_mac_context import

### DIFF
--- a/kiva/quartz/__init__.py
+++ b/kiva/quartz/__init__.py
@@ -10,6 +10,8 @@
 import sys
 
 if sys.platform == "darwin":
+    from kiva.quartz.mac_context import get_mac_context  # noqa: F401
+
     def get_macport(dc):
         """ Returns the Port or the CGContext of a wxDC (or child class)
         instance.


### PR DESCRIPTION
I removed this import in error as part of #558. It's needed by the Qt Quartz backend (`enable.qt4.quartz`).

@rahulporuri, @aaronayres35: This should be cherry-picked into the 5.0.0 branch.