### PR TITLE
Handle ETSConfig.toolkit == 'qt'

### DIFF
--- a/enable/colors.py
+++ b/enable/colors.py
@@ -282,7 +282,7 @@ if ETSConfig.toolkit == "wx":
         editor=ColorEditorFactory,
     )
 
-elif ETSConfig.toolkit == "qt4":
+elif ETSConfig.toolkit.startswith("qt"):
     from pyface.qt import QtGui
     from traitsui.qt4.color_editor import (
         ToolkitEditorFactory as StandardColorEditorFactory,

--- a/enable/component_editor.py
+++ b/enable/component_editor.py
@@ -20,7 +20,7 @@ from traitsui.api import BasicEditorFactory
 
 if ETSConfig.toolkit == "wx":
     from traitsui.wx.editor import Editor
-elif ETSConfig.toolkit == "qt4":
+elif ETSConfig.toolkit.startswith("qt"):
     from traitsui.qt4.editor import Editor
 else:
     Editor = object

--- a/enable/tools/hover_tool.py
+++ b/enable/tools/hover_tool.py
@@ -33,7 +33,7 @@ if ETSConfig.toolkit == "wx":
             raise RuntimeError("Unable to determine mouse position")
 
 
-elif ETSConfig.toolkit == "qt4":
+elif ETSConfig.toolkit.startswith("qt"):
     from pyface.qt import QtGui
 
     def GetGlobalMousePosition():

--- a/enable/trait_defs/rgba_color_trait.py
+++ b/enable/trait_defs/rgba_color_trait.py
@@ -31,7 +31,7 @@ if ETSConfig.toolkit == "wx":
             color.Blue() / 255.0,
             1.0,
         )
-elif ETSConfig.toolkit == "qt4":
+elif ETSConfig.toolkit.startswith("qt"):
     from traitsui.qt4.color_trait import standard_colors
 
     def rgba_color(color):

--- a/enable/trait_defs/ui/rgba_color_editor.py
+++ b/enable/trait_defs/ui/rgba_color_editor.py
@@ -11,7 +11,7 @@ from traits.etsconfig.api import ETSConfig
 
 if ETSConfig.toolkit == "wx":
     from .wx.rgba_color_editor import RGBAColorEditor
-elif ETSConfig.toolkit == "qt4":
+elif ETSConfig.toolkit.startswith("qt"):
     from .qt4.rgba_color_editor import RGBAColorEditor
 else:
     RGBAColorEditor = None

--- a/kiva/trait_defs/kiva_font_trait.py
+++ b/kiva/trait_defs/kiva_font_trait.py
@@ -18,7 +18,7 @@ from traits.etsconfig.api import ETSConfig
 
 if ETSConfig.toolkit == "wx":
     from .ui.wx.kiva_font_editor import KivaFontEditor
-elif ETSConfig.toolkit == "qt4":
+elif ETSConfig.toolkit.startswith("qt"):
     # FIXME
     # from .ui.qt4.kiva_font_editor import KivaFontEditor
     KivaFontEditor = None


### PR DESCRIPTION
Missed this in #571. The majority of the Qt toolkit conditionals were checking `ETSConfig.toolkit == "qt4"`. This PR switches to `ETSConfig.toolkit.startswith("qt")` instead.

@rahulporuri, @aaronayres35: This should be cherry-picked into the 5.0.0 branch.