### PR TITLE
Accept a PIL Image as input to draw_image()

### DIFF
--- a/kiva/cairo.py
+++ b/kiva/cairo.py
@@ -867,6 +867,18 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
             )
         elif isinstance(img, Image.Image):
             converted_img = img.convert("RGBA")
+            img_width, img_height = img.width, img.height
+            img_surface = cairo.ImageSurface.create_for_data(
+                converted_img.flatten(),
+                cairo.FORMAT_RGB24,
+                img_width,
+                img_height,
+            )
+        elif hasattr(img, "bmp_array"):
+            # a kiva agg context
+            if hasattr(img, "convert_pixel_format"):
+                img = img.convert_pixel_format("rgba32", inplace=0)
+            converted_img = Image.fromarray(img.bmp_array)
             flipped_array = numpy.flipud(numpy.array(converted_img))
             img_width, img_height = img.width, img.height
             img_surface = cairo.ImageSurface.create_for_data(

--- a/kiva/cairo.py
+++ b/kiva/cairo.py
@@ -850,13 +850,10 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
 
     def draw_image(self, img, rect=None):
         """
-        img is either a N*M*3 or N*M*4 numpy array, or a Kiva image
-
-        rect - what is this? assume it's a tuple (x,y, w, h)
-        Only works with numpy arrays. What is a "Kiva Image" anyway?
-        Not Yet Tested.
+        `img` is either a N*M*3 or N*M*4 numpy array, or a PIL Image
+        `rect` is a tuple (x, y, w, h)
         """
-        from kiva import agg
+        from PIL import Image
 
         if isinstance(img, numpy.ndarray):
             # Numeric array
@@ -868,18 +865,15 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
             img_surface = cairo.ImageSurface.create_for_data(
                 img.astype(numpy.uint8), format, img_width, img_height
             )
-        elif isinstance(img, agg.GraphicsContextArray):
-            converted_img = img.convert_pixel_format("rgba32", inplace=0)
-            flipped_array = numpy.flipud(converted_img.bmp_array)
-            img_width, img_height = (
-                converted_img.width(),
-                converted_img.height(),
-            )
+        elif isinstance(img, Image.Image):
+            converted_img = img.convert("RGBA")
+            flipped_array = numpy.flipud(numpy.array(converted_img))
+            img_width, img_height = img.width, img.height
             img_surface = cairo.ImageSurface.create_for_data(
                 flipped_array.flatten(),
                 cairo.FORMAT_RGB24,
-                img_width,
-                img_height,
+                img.width,
+                img.height,
             )
         elif isinstance(img, GraphicsContext):
             # Another cairo kiva context

--- a/kiva/examples/kiva/image_explorer.py
+++ b/kiva/examples/kiva/image_explorer.py
@@ -16,7 +16,7 @@ Interactive editor for exploring Kiva image drawing.
 import numpy as np
 from PIL import Image
 
-from traits.api import Any, Enum, Instance
+from traits.api import Enum, Instance
 from traitsui.api import HSplit, Item, ModelView, VGroup, View
 
 from enable.api import Component, ComponentEditor
@@ -26,7 +26,7 @@ class ImageComponent(Component):
     """ An Enable component that draws an image
     """
     #: The image data to draw
-    image = Any()
+    image = Instance(Image.Image)
 
     #: What's the color space of the image?
     image_mode = Enum('RGB', 'RGBA', 'L', 'P')
@@ -54,8 +54,7 @@ class ImageComponent(Component):
         if components == 4:
             img[:, :, 3] = np.linspace(0, 255, num=512*512).reshape(512, 512)
 
-        pilimg = Image.fromarray(img).convert(mode)
-        return np.array(pilimg)
+        return Image.fromarray(img).convert(mode)
 
     def _image_mode_changed(self):
         self.image = self._image_default()

--- a/kiva/gl/__init__.py
+++ b/kiva/gl/__init__.py
@@ -28,14 +28,23 @@ def image_as_array(img):
     Typically, this is used to adapt an agg GraphicsContextArray which has been
     used for image storage in Kiva applications.
     """
+    from PIL import Image
+
     if hasattr(img, "bmp_array"):
         # Yup, a GraphicsContextArray.
-        return img.bmp_array
+        img = Image.fromarray(img.bmp_array)
     elif isinstance(img, ndarray):
-        return img
+        img = Image.fromarray(img)
+    elif isinstance(img, Image.Image):
+        pass
     else:
         msg = "can't convert %r into a numpy array" % (img,)
         raise NotImplementedError(msg)
+
+    # Ensure RGB or RGBA formats
+    if not img.mode.startswith("RGB"):
+        img = img.convert("RGB")
+    return array(img)
 
 
 def get_dpi():

--- a/kiva/pdf.py
+++ b/kiva/pdf.py
@@ -566,8 +566,7 @@ class GraphicsContext(GraphicsContextBase):
         pixel size.  If 'rect' is provided, then the image is resized
         into the (w, h) given and drawn into this GC at point (x, y).
 
-        img_gc is either a Numeric array (WxHx3 or WxHx4) or a GC from Kiva's
-        Agg backend (kiva.agg.GraphicsContextArray).
+        img_gc is either a Numeric array (WxHx3 or WxHx4) or a PIL Image.
 
         Requires the Python Imaging Library (PIL).
         """
@@ -579,22 +578,15 @@ class GraphicsContext(GraphicsContextBase):
         # it brute-force using Agg.
         from reportlab.lib.utils import ImageReader
         from PIL import Image
-        from kiva import agg
 
         if isinstance(img, ndarray):
             # Conversion from numpy array
-            pil_img = Image.fromarray(img, "RGBA")
-        elif isinstance(img, agg.GraphicsContextArray):
-            converted_img = img
-            if img.format().startswith("RGBA"):
-                pilformat = "RGBA"
-            elif img.format().startswith("RGB"):
-                pilformat = "RGB"
-            else:
-                converted_img = img.convert_pixel_format("rgba32", inplace=0)
-                pilformat = "RGBA"
-            # Conversion from GraphicsContextArray
-            pil_img = Image.fromarray(converted_img.bmp_array, pilformat)
+            pil_img = Image.fromarray(img)
+        elif isinstance(img, Image.Image):
+            pil_img = img
+        elif hasattr(img, "bmp_array"):
+            # An offscreen kiva agg context
+            pil_img = Image.fromarray(img.bmp_array)
         else:
             warnings.warn(
                 "Cannot render image of type %r into PDF context." % type(img)

--- a/kiva/pdf.py
+++ b/kiva/pdf.py
@@ -586,6 +586,8 @@ class GraphicsContext(GraphicsContextBase):
             pil_img = img
         elif hasattr(img, "bmp_array"):
             # An offscreen kiva agg context
+            if hasattr(img, "convert_pixel_format"):
+                img = img.convert_pixel_format("rgba32", inplace=0)
             pil_img = Image.fromarray(img.bmp_array)
         else:
             warnings.warn(

--- a/kiva/ps.py
+++ b/kiva/ps.py
@@ -23,7 +23,6 @@ import warnings
 from numpy import arange, ndarray, ravel
 
 # Local, relative Kiva imports
-from kiva import agg
 from . import affine
 from . import basecore2d
 from . import constants
@@ -186,30 +185,23 @@ class PSGC(basecore2d.GraphicsContextBase):
         pixel size.  If 'rect' is provided, then the image is resized
         into the (w,h) given and drawn into this GC at point (x,y).
 
-        img_gc is either a Numeric array (WxHx3 or WxHx4) or a GC from Kiva's
-        Agg backend (kiva.agg.GraphicsContextArray).
+        img_gc is either a Numeric array (WxHx3 or WxHx4) or a PIL Image.
 
         Requires the Python Imaging Library (PIL).
         """
-        from PIL import Image as PilImage
+        from PIL import Image
 
         if isinstance(img, ndarray):
             # From numpy array
-            pilformat = "RGBA"
-            pil_img = PilImage.fromarray(img, pilformat)
-        elif isinstance(img, agg.GraphicsContextArray):
-            converted_img = img
-            if img.format().startswith("RGBA"):
-                pilformat = "RGBA"
-            elif img.format().startswith("RGB"):
-                pilformat = "RGB"
-            else:
-                converted_img = img.convert_pixel_format("rgba32", inplace=0)
-                pilformat = "RGBA"
-            # Should probably take this into account
-            # interp = img.get_image_interpolation()
-            # Conversion from GraphicsContextArray
-            pil_img = PilImage.fromarray(converted_img.bmp_array, pilformat)
+            pil_img = Image.fromarray(img)
+            pilformat = pil_img.mode
+        elif isinstance(img, Image.Image):
+            pil_img = img
+            pilformat = img.mode
+        elif hasattr(img, "bmp_array"):
+            # An offscreen kiva agg context
+            pil_img = Image.fromarray(img.bmp_array)
+            pilformat = img.mode
         else:
             warnings.warn(
                 "Cannot render image of type %r into EPS context." % type(img)
@@ -226,9 +218,7 @@ class PSGC(basecore2d.GraphicsContextBase):
         left, top, width, height = rect
         if width != pil_img.width or height != pil_img.height:
             # This is not strictly required.
-            pil_img = pil_img.resize(
-                (int(width), int(height)), PilImage.NEAREST
-            )
+            pil_img = pil_img.resize((int(width), int(height)), Image.NEAREST)
 
         self.contents.write("gsave\n")
         self.contents.write("initmatrix\n")

--- a/kiva/ps.py
+++ b/kiva/ps.py
@@ -200,6 +200,8 @@ class PSGC(basecore2d.GraphicsContextBase):
             pilformat = img.mode
         elif hasattr(img, "bmp_array"):
             # An offscreen kiva agg context
+            if hasattr(img, "convert_pixel_format"):
+                img = img.convert_pixel_format("rgba32", inplace=0)
             pil_img = Image.fromarray(img.bmp_array)
             pilformat = img.mode
         else:

--- a/kiva/quartz/ABCGI.pyx
+++ b/kiva/quartz/ABCGI.pyx
@@ -732,10 +732,14 @@ cdef class CGContext:
     def draw_image(self, object image, object rect=None):
         """ Draw an image or another CGContext onto a region.
         """
+        from PIL import Image
+
         if rect is None:
             rect = (0, 0, self.width(), self.height())
         if isinstance(image, numpy.ndarray):
             self._draw_cgimage(CGImage(image), rect)
+        elif isinstance(image, Image.Image):
+            self._draw_cgimage(CGImage(numpy.array(image)), rect)
         elif isinstance(image, CGImage):
             self._draw_cgimage(image, rect)
         elif hasattr(image, 'bmp_array'):

--- a/kiva/svg.py
+++ b/kiva/svg.py
@@ -251,6 +251,8 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
             pil_img = img
         elif hasattr(img, "bmp_array"):
             # An offscreen kiva agg context
+            if hasattr(img, "convert_pixel_format"):
+                img = img.convert_pixel_format("rgba32", inplace=0)
             pil_img = Image.fromarray(img.bmp_array)
         else:
             warnings.warn(

--- a/kiva/svg.py
+++ b/kiva/svg.py
@@ -39,7 +39,6 @@ import warnings
 from numpy import arange, ndarray, ravel
 
 # Local, relative Kiva imports
-from kiva import agg
 from . import affine
 from . import basecore2d
 from . import constants
@@ -237,36 +236,22 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
         pixel size.  If 'rect' is provided, then the image is resized
         into the (w,h) given and drawn into this GC at point (x,y).
 
-        img_gc is either a Numeric array (WxHx3 or WxHx4) or a GC from Kiva's
-        Agg backend (kiva.agg.GraphicsContextArray).
+        img_gc is either a Numeric array (WxHx3 or WxHx4) or a PIL Image.
 
         Requires the Python Imaging Library (PIL).
         """
-        from PIL import Image as PilImage
+        from PIL import Image
 
         # We turn img into a PIL object, since that is what ReportLab
-        # requires.  To do this, we first determine if the input image
-        # GC needs to be converted to RGBA/RGB.  If so, we see if we can
-        # do it nicely (using convert_pixel_format), and if not, we do
-        # it brute-force using Agg.
-
+        # requires.
         if isinstance(img, ndarray):
             # From numpy array
-            pilformat = "RGBA"
-            pil_img = PilImage.fromarray(img, pilformat)
-        elif isinstance(img, agg.GraphicsContextArray):
-            converted_img = img
-            if img.format().startswith("RGBA"):
-                pilformat = "RGBA"
-            elif img.format().startswith("RGB"):
-                pilformat = "RGB"
-            else:
-                converted_img = img.convert_pixel_format("rgba32", inplace=0)
-                pilformat = "RGBA"
-            # Should probably take this into account
-            # interp = img.get_image_interpolation()
-            # Conversion from GraphicsContextArray
-            pil_img = PilImage.fromarray(converted_img.bmp_array, pilformat)
+            pil_img = Image.fromarray(img)
+        elif isinstance(img, Image.Image):
+            pil_img = img
+        elif hasattr(img, "bmp_array"):
+            # An offscreen kiva agg context
+            pil_img = Image.fromarray(img.bmp_array)
         else:
             warnings.warn(
                 "Cannot render image of type %r into SVG context." % type(img)
@@ -279,9 +264,7 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
         left, top, width, height = rect
         if width != pil_img.width or height != pil_img.height:
             # This is not strictly required.
-            pil_img = pil_img.resize(
-                (int(width), int(height)), PilImage.NEAREST
-            )
+            pil_img = pil_img.resize((int(width), int(height)), Image.NEAREST)
 
         png_buffer = BytesIO()
         pil_img.save(png_buffer, "png")

--- a/kiva/tests/test_qpainter_drawing.py
+++ b/kiva/tests/test_qpainter_drawing.py
@@ -42,10 +42,6 @@ class TestQPainterDrawing(DrawingImageTester, unittest.TestCase):
 
         return GraphicsContext((width, height), base_pixel_scale=pixel_scale)
 
-    @unittest.skip("QPainter interprets images as BGRA.")
-    def test_image(self):
-        super().test_image()
-
     @unittest.skipIf(is_qt5 and is_linux, "Currently segfaulting")
     def test_text(self):
         super().test_text()


### PR DESCRIPTION
This adds `Image` from the Python Imaging Library as an acceptable argument for `draw_image` on all relevant kiva backends. Further, it uses `Image` internally to handle conversion of color modes to something which is compatible with the color mode of the graphics context.

Fixes #574