### PR TITLE
Add HiDPI support for the Qt toolkit

### DIFF
--- a/enable/abstract_window.py
+++ b/enable/abstract_window.py
@@ -14,7 +14,7 @@ from numpy import dot
 
 # Enthought library imports
 from traits.api import (
-    Any, Bool, Event, HasTraits, Instance, List, Property, Trait, Tuple,
+    Any, Bool, Event, Float, HasTraits, Instance, List, Property, Trait, Tuple,
 )
 
 
@@ -55,6 +55,14 @@ class AbstractWindow(HasTraits):
     # When a component captures the mouse, it can optionally store a
     # dispatch order for events (until it releases the mouse).
     mouse_owner_dispatch_history = Trait(None, None, List)
+
+    # A scaling constant applied to any GraphicsContext used for drawing the
+    # window's component.
+    base_pixel_scale = Float(1.0)
+
+    # When True, allow `base_pixel_scale` to be greater than 1 if the
+    # underlying toolkit supports it.
+    high_resolution = Bool(True)
 
     # The background window of the window.  The entire window first gets
     # painted with this color before the component gets to draw.

--- a/enable/component.py
+++ b/enable/component.py
@@ -766,16 +766,18 @@ class Component(CoordinateBox, Interactor):
             if not self.draw_valid:
                 # get a reference to the GraphicsContext class from the object
                 GraphicsContext = gc.__class__
-                dpr = self.window._dpr
+                # Some pixels are bigger than others
+                pixel_scale = self.window.base_pixel_scale
+                size = (int(width * pixel_scale), int(height * pixel_scale))
                 if hasattr(GraphicsContext, "create_from_gc"):
                     # For some backends, such as the mac, a much more efficient
                     # backbuffer can be created from the window gc.
-                    bb = GraphicsContext.create_from_gc(
-                        gc, (int(width * dpr), int(height * dpr))
-                    )
+                    bb = GraphicsContext.create_from_gc(gc, size)
                 else:
-                    bb = GraphicsContext((int(width * dpr), int(height * dpr)))
-                bb.scale_ctm(dpr, dpr)
+                    bb = GraphicsContext(size)
+
+                # Always scale by base_pixel_scale here
+                bb.scale_ctm(pixel_scale, pixel_scale)
 
                 # if not fill_padding, then we have to fill the backbuffer
                 # with the window color. This is the only way I've found that

--- a/enable/component.py
+++ b/enable/component.py
@@ -766,14 +766,16 @@ class Component(CoordinateBox, Interactor):
             if not self.draw_valid:
                 # get a reference to the GraphicsContext class from the object
                 GraphicsContext = gc.__class__
+                dpr = self.window._dpr
                 if hasattr(GraphicsContext, "create_from_gc"):
                     # For some backends, such as the mac, a much more efficient
                     # backbuffer can be created from the window gc.
                     bb = GraphicsContext.create_from_gc(
-                        gc, (int(width), int(height))
+                        gc, (int(width * dpr), int(height * dpr))
                     )
                 else:
-                    bb = GraphicsContext((int(width), int(height)))
+                    bb = GraphicsContext((int(width * dpr), int(height * dpr)))
+                bb.scale_ctm(dpr, dpr)
 
                 # if not fill_padding, then we have to fill the backbuffer
                 # with the window color. This is the only way I've found that

--- a/enable/component_editor.py
+++ b/enable/component_editor.py
@@ -15,7 +15,7 @@ from enable.window import Window
 
 from traits.etsconfig.api import ETSConfig
 
-from traits.api import Property, Tuple
+from traits.api import Bool, Property, Tuple
 from traitsui.api import BasicEditorFactory
 
 if ETSConfig.toolkit == "wx":
@@ -42,7 +42,12 @@ class _ComponentEditor(Editor):
 
         size = self._get_initial_size()
 
-        self._window = Window(parent, size=size, component=self.value)
+        self._window = Window(
+            parent,
+            size=size,
+            component=self.value,
+            high_resolution=self.factory.high_resolution,
+        )
 
         self.control = self._window.control
         self._window.bgcolor = self.factory.bgcolor
@@ -93,6 +98,9 @@ class ComponentEditor(BasicEditorFactory):
 
     # The background color for the window
     bgcolor = ColorTrait("sys_window")
+
+    # When available, use HiDPI for GraphicsContext rasterization.
+    high_resolution = Bool(True)
 
     # The default size of the Window wrapping this Enable component
     size = Tuple((400, 400))

--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -365,6 +365,10 @@ class _Window(AbstractWindow):
             parent = parent.parentWidget()
         self.control = self._create_control(parent, self)
 
+        self._dpr = 1.0
+        if hasattr(self.control, "devicePixelRatio"):
+            self._dpr = self.control.devicePixelRatio()
+
         if pos is not None:
             self.control.move(*pos)
 
@@ -573,7 +577,8 @@ class _Window(AbstractWindow):
 
     def _get_control_size(self):
         if self.control:
-            return (self.control.width(), self.control.height())
+            return (int(self.control.width() * self._dpr),
+                    int(self.control.height() * self._dpr))
 
         return None
 
@@ -610,8 +615,10 @@ class _Window(AbstractWindow):
     # ------------------------------------------------------------------------
 
     def _flip_y(self, y):
-        "Converts between a Kiva and a Qt y coordinate"
-        return int(self._size[1] - y - 1)
+        """ Converts between a Kiva and a Qt y coordinate
+        """
+        # Handle the device pixel ratio adjustment here
+        return int(self._size[1] / self._dpr - y - 1)
 
 
 class BaseGLWindow(_Window):

--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -365,9 +365,8 @@ class _Window(AbstractWindow):
             parent = parent.parentWidget()
         self.control = self._create_control(parent, self)
 
-        self._dpr = 1.0
-        if hasattr(self.control, "devicePixelRatio"):
-            self._dpr = self.control.devicePixelRatio()
+        if self.high_resolution and hasattr(self.control, "devicePixelRatio"):
+            self.base_pixel_scale = self.control.devicePixelRatio()
 
         if pos is not None:
             self.control.move(*pos)
@@ -577,8 +576,8 @@ class _Window(AbstractWindow):
 
     def _get_control_size(self):
         if self.control:
-            return (int(self.control.width() * self._dpr),
-                    int(self.control.height() * self._dpr))
+            return (int(self.control.width() * self.base_pixel_scale),
+                    int(self.control.height() * self.base_pixel_scale))
 
         return None
 
@@ -617,8 +616,8 @@ class _Window(AbstractWindow):
     def _flip_y(self, y):
         """ Converts between a Kiva and a Qt y coordinate
         """
-        # Handle the device pixel ratio adjustment here
-        return int(self._size[1] / self._dpr - y - 1)
+        # Handle the pixel scale adjustment here since `self._size` is involved
+        return int(self._size[1] / self.base_pixel_scale - y - 1)
 
 
 class BaseGLWindow(_Window):

--- a/enable/qt4/cairo.py
+++ b/enable/qt4/cairo.py
@@ -18,6 +18,7 @@ from .scrollbar import NativeScrollBar
 class Window(BaseWindow):
     def _create_gc(self, size, pix_format="bgra32"):
         gc = GraphicsContext((size[0] + 1, size[1] + 1))
+        gc.scale_ctm(self._dpr, self._dpr)
         gc.translate_ctm(0.5, 0.5)
 
         return gc
@@ -33,6 +34,6 @@ class Window(BaseWindow):
 
         image = QtGui.QImage(data, w, h, QtGui.QImage.Format_ARGB32)
 
-        rect = QtCore.QRect(0, 0, w, h)
+        rect = QtCore.QRectF(0, 0, self.control.width(), self.control.height())
         painter = QtGui.QPainter(self.control)
         painter.drawImage(rect, image)

--- a/enable/qt4/cairo.py
+++ b/enable/qt4/cairo.py
@@ -17,8 +17,10 @@ from .scrollbar import NativeScrollBar
 
 class Window(BaseWindow):
     def _create_gc(self, size, pix_format="bgra32"):
-        gc = GraphicsContext((size[0] + 1, size[1] + 1))
-        gc.scale_ctm(self._dpr, self._dpr)
+        gc = GraphicsContext(
+            (size[0] + 1, size[1] + 1),
+            base_pixel_scale=self.base_pixel_scale,
+        )
         gc.translate_ctm(0.5, 0.5)
 
         return gc

--- a/enable/qt4/celiagg.py
+++ b/enable/qt4/celiagg.py
@@ -22,8 +22,11 @@ class Window(BaseWindow):
     _shuffle_buffer = Array(shape=(None, None, 4), dtype=np.uint8)
 
     def _create_gc(self, size, pix_format="rgba32"):
-        gc = GraphicsContext((size[0] + 1, size[1] + 1), pix_format=pix_format)
-        gc.scale_ctm(self._dpr, self._dpr)
+        gc = GraphicsContext(
+            (size[0] + 1, size[1] + 1),
+            pix_format=pix_format,
+            base_pixel_scale=self.base_pixel_scale,
+        )
         gc.translate_ctm(0.5, 0.5)
 
         self._shuffle_buffer = np.empty(

--- a/enable/qt4/celiagg.py
+++ b/enable/qt4/celiagg.py
@@ -23,6 +23,7 @@ class Window(BaseWindow):
 
     def _create_gc(self, size, pix_format="rgba32"):
         gc = GraphicsContext((size[0] + 1, size[1] + 1), pix_format=pix_format)
+        gc.scale_ctm(self._dpr, self._dpr)
         gc.translate_ctm(0.5, 0.5)
 
         self._shuffle_buffer = np.empty(
@@ -44,7 +45,7 @@ class Window(BaseWindow):
         image = QtGui.QImage(
             self._shuffle_buffer, w, h, QtGui.QImage.Format_RGB32
         )
-        rect = QtCore.QRect(0, 0, w, h)
+        rect = QtCore.QRectF(0, 0, self.control.width(), self.control.height())
         painter = QtGui.QPainter(self.control)
         painter.drawImage(rect, image)
 

--- a/enable/qt4/gl.py
+++ b/enable/qt4/gl.py
@@ -19,6 +19,7 @@ class Window(BaseGLWindow):
         gc = GraphicsContext((size[0] + 1, size[1] + 1))
         self._fake_pyglet_context = FakePygletContext()
         gc.gl_init()
+        gc.scale_ctm(self._dpr, self._dpr)
         gc.translate_ctm(0.5, 0.5)
         return gc
 

--- a/enable/qt4/gl.py
+++ b/enable/qt4/gl.py
@@ -16,10 +16,12 @@ class Window(BaseGLWindow):
     def _create_gc(self, size, pix_format=None):
         """ Create a GraphicsContext instance.
         """
-        gc = GraphicsContext((size[0] + 1, size[1] + 1))
+        gc = GraphicsContext(
+            (size[0] + 1, size[1] + 1),
+            base_pixel_scale=self.base_pixel_scale,
+        )
         self._fake_pyglet_context = FakePygletContext()
         gc.gl_init()
-        gc.scale_ctm(self._dpr, self._dpr)
         gc.translate_ctm(0.5, 0.5)
         return gc
 

--- a/enable/qt4/image.py
+++ b/enable/qt4/image.py
@@ -20,12 +20,11 @@ class Window(BaseWindow):
         gc = GraphicsContext(
             (size[0] + 1, size[1] + 1),
             pix_format=pix_format,
+            base_pixel_scale=self.base_pixel_scale,
             # We have to set bottom_up=0 or otherwise the PixelMap will
             # appear upside down in the QImage.
             bottom_up=0,
         )
-
-        gc.scale_ctm(self._dpr, self._dpr)
         gc.translate_ctm(0.5, 0.5)
 
         return gc

--- a/enable/qt4/image.py
+++ b/enable/qt4/image.py
@@ -25,6 +25,7 @@ class Window(BaseWindow):
             bottom_up=0,
         )
 
+        gc.scale_ctm(self._dpr, self._dpr)
         gc.translate_ctm(0.5, 0.5)
 
         return gc
@@ -38,7 +39,7 @@ class Window(BaseWindow):
         h = self._gc.height()
         data = self._gc.pixel_map.convert_to_argb32string()
         image = QtGui.QImage(data, w, h, QtGui.QImage.Format_ARGB32)
-        rect = QtCore.QRect(0, 0, w, h)
+        rect = QtCore.QRectF(0, 0, self.control.width(), self.control.height())
         painter = QtGui.QPainter(self.control)
         painter.drawImage(rect, image)
 

--- a/enable/qt4/qpainter.py
+++ b/enable/qt4/qpainter.py
@@ -17,6 +17,8 @@ from .scrollbar import NativeScrollBar
 class Window(BaseWindow):
     def _create_gc(self, size, pix_format=None):
         gc = GraphicsContext((size[0] + 1, size[1] + 1), parent=self.control)
+        # NOTE: We don't set the scale to the device pixel ratio here as with
+        # other kiva backends. It's handled internally by Qt.
         gc.translate_ctm(0.5, 0.5)
 
         return gc

--- a/enable/qt4/qpainter.py
+++ b/enable/qt4/qpainter.py
@@ -16,9 +16,11 @@ from .scrollbar import NativeScrollBar
 
 class Window(BaseWindow):
     def _create_gc(self, size, pix_format=None):
-        gc = GraphicsContext((size[0] + 1, size[1] + 1), parent=self.control)
-        # NOTE: We don't set the scale to the device pixel ratio here as with
-        # other kiva backends. It's handled internally by Qt.
+        gc = GraphicsContext(
+            (size[0] + 1, size[1] + 1),
+            base_pixel_scale=self.base_pixel_scale,
+            parent=self.control,
+        )
         gc.translate_ctm(0.5, 0.5)
 
         return gc

--- a/kiva/agg/__init__.py
+++ b/kiva/agg/__init__.py
@@ -31,7 +31,8 @@ try:
 
     class GraphicsContextSystem(GraphicsContextArray):
         def __init__(self, size, pix_format=default_pix_format,
-                     interpolation="nearest", bottom_up=True):
+                     interpolation="nearest", base_pixel_scale=1.0,
+                     bottom_up=True):
             assert isinstance(size, tuple), repr(size)
             width, height = size
             pixel_map = PixelMap(
@@ -42,7 +43,8 @@ try:
                 bool(bottom_up),
             ).set_bmp_array()
             GraphicsContextArray.__init__(
-                self, pixel_map.bmp_array, pix_format, interpolation, bottom_up
+                self, pixel_map.bmp_array, pix_format, interpolation,
+                base_pixel_scale, bottom_up
             )
             self.pixel_map = pixel_map
 

--- a/kiva/agg/src/graphics_context.i
+++ b/kiva/agg/src/graphics_context.i
@@ -305,7 +305,8 @@ namespace kiva {
             %{
             # We define our own constructor AND destructor.
             def __init__(self, ary_or_size, pix_format="bgra32",
-                         interpolation="nearest", bottom_up=1):
+                         interpolation="nearest", base_pixel_scale=1.0,
+                         bottom_up=1):
                 """ When specifying size, it must be a two element tuple.
                     Array input is always treated as an image.
 
@@ -357,6 +358,9 @@ namespace kiva {
 
                 obj = graphics_context_from_array(ary,pix_format_id,interpolation_id,
                                                   bottom_up)
+
+                # Apply base scale for a HiDPI context
+                _agg.GraphicsContextArray_scale_ctm(obj, base_pixel_scale, base_pixel_scale)
 
                 _swig_setattr(self, GraphicsContextArray, 'this', obj)
                 # swig 1.3.28 does not have real thisown, thisown is mapped

--- a/kiva/cairo.py
+++ b/kiva/cairo.py
@@ -221,6 +221,10 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
             ctx.set_source_rgb(1, 1, 1)
             ctx.scale(1, -1)
 
+        # For HiDPI support
+        base_scale = kw.pop("base_pixel_scale", 1)
+        ctx.scale(base_scale, base_scale)
+
         self._ctx = ctx
         self.state = GraphicsState()
         self.state_stack = []

--- a/kiva/celiagg.py
+++ b/kiva/celiagg.py
@@ -102,6 +102,10 @@ class GraphicsContext(object):
         self.font = None
         self.__state_stack = []
 
+        # For HiDPI support
+        base_scale = kwargs.pop('base_pixel_scale', 1)
+        self.transform.scale(base_scale, base_scale)
+
     # ----------------------------------------------------------------
     # Size info
     # ----------------------------------------------------------------

--- a/kiva/gl/__init__.py
+++ b/kiva/gl/__init__.py
@@ -447,8 +447,12 @@ class GraphicsContext(GraphicsContextGL):
     def __init__(self, size, *args, **kw):
         # Ignore the pix_format argument for now
         kw.pop("pix_format", None)
+        base_scale = kw.pop("base_pixel_scale", 1)
         GraphicsContextGL.__init__(self, size[0], size[1], *args, **kw)
         self.corner_pixel_origin = True
+
+        # For HiDPI support
+        self.scale_ctm(base_scale, base_scale)
 
         self._font_stack = []
         self._current_font = None

--- a/kiva/qpainter.py
+++ b/kiva/qpainter.py
@@ -76,14 +76,12 @@ class GraphicsContext(object):
         self.gc = QtGui.QPainter(self.qt_dc)
         self.path = CompiledPath()
 
-        # Have to know the device pixel ratio to compute the base transform
-        dpr = 1.0
-        if hasattr(self.qt_dc, "devicePixelRatio"):
-            dpr = self.qt_dc.devicePixelRatio()
+        # For HiDPI support, we only need to adjust for `size`
+        base_pixel_scale = kwargs.pop("base_pixel_scale", 1)
 
         # flip y
         trans = QtGui.QTransform()
-        trans.translate(0, size[1] / dpr)
+        trans.translate(0, size[1] / base_pixel_scale)
         trans.scale(1.0, -1.0)
         self.gc.setWorldTransform(trans)
 

--- a/kiva/qpainter.py
+++ b/kiva/qpainter.py
@@ -76,9 +76,14 @@ class GraphicsContext(object):
         self.gc = QtGui.QPainter(self.qt_dc)
         self.path = CompiledPath()
 
+        # Have to know the device pixel ratio to compute the base transform
+        dpr = 1.0
+        if hasattr(self.qt_dc, "devicePixelRatio"):
+            dpr = self.qt_dc.devicePixelRatio()
+
         # flip y
         trans = QtGui.QTransform()
-        trans.translate(0, size[1])
+        trans.translate(0, size[1] / dpr)
         trans.scale(1.0, -1.0)
         self.gc.setWorldTransform(trans)
 

--- a/kiva/tests/drawing_tester.py
+++ b/kiva/tests/drawing_tester.py
@@ -161,6 +161,19 @@ class DrawingTester(object):
 class DrawingImageTester(DrawingTester):
     """ Basic drawing tests for graphics contexts of gui toolkits.
     """
+    def setUp(self):
+        self.directory = tempfile.mkdtemp()
+        self.filename = os.path.join(self.directory, "rendered")
+        self.gc = self.create_graphics_context(600, 600, 2.0)
+        self.gc.clear()
+        self.gc.set_stroke_color((1.0, 0.0, 0.0))
+        self.gc.set_fill_color((1.0, 0.0, 0.0))
+        self.gc.set_line_width(5)
+
+    def create_graphics_context(self, width, length, pixel_scale):
+        """ Create the desired graphics context
+        """
+        raise NotImplementedError()
 
     @contextlib.contextmanager
     def draw_and_check(self):
@@ -175,7 +188,7 @@ class DrawingImageTester(DrawingTester):
         image = numpy.array(Image.open(filename))
         # default is expected to be a totally white image
 
-        self.assertEqual(image.shape[:2], (300, 300))
+        self.assertEqual(image.shape[:2], (600, 600))
         if image.shape[2] == 3:
             check = numpy.sum(image == [255, 0, 0], axis=2) == 3
         elif image.shape[2] == 4:

--- a/kiva/tests/test_agg_drawing.py
+++ b/kiva/tests/test_agg_drawing.py
@@ -16,8 +16,8 @@ from kiva.image import GraphicsContext
 
 
 class TestAggDrawing(DrawingImageTester, unittest.TestCase):
-    def create_graphics_context(self, width, height):
-        return GraphicsContext((width, height))
+    def create_graphics_context(self, width, height, pixel_scale):
+        return GraphicsContext((width, height), base_pixel_scale=pixel_scale)
 
     def test_unicode_gradient_args(self):
         color_nodes = [(0.0, 1.0, 0.0, 0.0), (1.0, 0.0, 0.0, 0.0)]

--- a/kiva/tests/test_cairo_drawing.py
+++ b/kiva/tests/test_cairo_drawing.py
@@ -21,7 +21,7 @@ else:
 
 @unittest.skipIf(CAIRO_NOT_AVAILABLE, "Cannot import cairo")
 class TestCairoDrawing(DrawingImageTester, unittest.TestCase):
-    def create_graphics_context(self, width, height):
+    def create_graphics_context(self, width, height, pixel_scale):
         from kiva.cairo import GraphicsContext
 
-        return GraphicsContext((width, height))
+        return GraphicsContext((width, height), base_pixel_scale=pixel_scale)

--- a/kiva/tests/test_gl_drawing.py
+++ b/kiva/tests/test_gl_drawing.py
@@ -32,11 +32,15 @@ class TestGLDrawing(DrawingImageTester, unittest.TestCase):
             del self.window
         DrawingImageTester.tearDown(self)
 
-    def create_graphics_context(self, width, height):
+    def create_graphics_context(self, width, height, pixel_scale):
         from kiva.gl import GraphicsContext
 
-        self.window = pyglet.window.Window(width=width, height=height)
-        gc = GraphicsContext((width, height))
+        # Back out the pixel scaling when creating the Window
+        self.window = pyglet.window.Window(
+            width=int(width / pixel_scale),
+            height=int(height / pixel_scale),
+        )
+        gc = GraphicsContext((width, height), base_pixel_scale=pixel_scale)
         gc.gl_init()
         return gc
 
@@ -58,6 +62,12 @@ class TestGLDrawing(DrawingImageTester, unittest.TestCase):
     )
     def test_text(self):
         DrawingImageTester.test_text(self)
+
+    @unittest.expectedFailure
+    def test_quarter_circle(self):
+        """ Something about HiDPI isn't quite working here.
+        """
+        DrawingImageTester.test_quarter_circle(self)
 
     @unittest.skip("gl graphics context does not clip text properly (#165)")
     def test_text_clip(self):

--- a/kiva/tests/test_gl_drawing.py
+++ b/kiva/tests/test_gl_drawing.py
@@ -17,6 +17,10 @@ except ImportError:
     PYGLET_NOT_AVAILABLE = True
 else:
     PYGLET_NOT_AVAILABLE = False
+try:
+    from pyface.qt import is_qt5
+except ImportError:
+    is_qt5 = False
 
 from kiva.tests.drawing_tester import DrawingImageTester
 
@@ -34,6 +38,10 @@ class TestGLDrawing(DrawingImageTester, unittest.TestCase):
 
     def create_graphics_context(self, width, height, pixel_scale):
         from kiva.gl import GraphicsContext
+
+        # XXX: Testing GL for the null toolkit made me do this!
+        if not is_qt5:
+            pixel_scale = 1.0
 
         # Back out the pixel scaling when creating the Window
         self.window = pyglet.window.Window(

--- a/kiva/tests/test_gl_drawing.py
+++ b/kiva/tests/test_gl_drawing.py
@@ -17,10 +17,6 @@ except ImportError:
     PYGLET_NOT_AVAILABLE = True
 else:
     PYGLET_NOT_AVAILABLE = False
-try:
-    from pyface.qt import is_qt5
-except ImportError:
-    is_qt5 = False
 
 from kiva.tests.drawing_tester import DrawingImageTester
 
@@ -39,16 +35,10 @@ class TestGLDrawing(DrawingImageTester, unittest.TestCase):
     def create_graphics_context(self, width, height, pixel_scale):
         from kiva.gl import GraphicsContext
 
-        # XXX: Testing GL for the null toolkit made me do this!
-        if not is_qt5:
-            pixel_scale = 1.0
-
-        # Back out the pixel scaling when creating the Window
-        self.window = pyglet.window.Window(
-            width=int(width / pixel_scale),
-            height=int(height / pixel_scale),
-        )
-        gc = GraphicsContext((width, height), base_pixel_scale=pixel_scale)
+        # XXX: Ignore scaling in the unit tests so this works on CI.
+        # But really, we should just get rid of this rotted backend.
+        self.window = pyglet.window.Window(width=width, height=height)
+        gc = GraphicsContext((width, height), base_pixel_scale=1.0)
         gc.gl_init()
         return gc
 
@@ -70,12 +60,6 @@ class TestGLDrawing(DrawingImageTester, unittest.TestCase):
     )
     def test_text(self):
         DrawingImageTester.test_text(self)
-
-    @unittest.expectedFailure
-    def test_quarter_circle(self):
-        """ Something about HiDPI isn't quite working here.
-        """
-        DrawingImageTester.test_quarter_circle(self)
 
     @unittest.skip("gl graphics context does not clip text properly (#165)")
     def test_text_clip(self):

--- a/kiva/tests/test_qpainter_drawing.py
+++ b/kiva/tests/test_qpainter_drawing.py
@@ -42,9 +42,8 @@ class TestQPainterDrawing(DrawingImageTester, unittest.TestCase):
 
         return GraphicsContext((width, height), base_pixel_scale=pixel_scale)
 
-    @unittest.expectedFailure
+    @unittest.skip("QPainter interprets images as BGRA.")
     def test_image(self):
-        """ QPainter interprets images as BGRA. """
         super().test_image()
 
     @unittest.skipIf(is_qt5 and is_linux, "Currently segfaulting")

--- a/kiva/tests/test_qpainter_drawing.py
+++ b/kiva/tests/test_qpainter_drawing.py
@@ -37,10 +37,10 @@ class TestQPainterDrawing(DrawingImageTester, unittest.TestCase):
 
         DrawingImageTester.setUp(self)
 
-    def create_graphics_context(self, width, height):
+    def create_graphics_context(self, width, height, pixel_scale):
         from kiva.qpainter import GraphicsContext
 
-        return GraphicsContext((width, height))
+        return GraphicsContext((width, height), base_pixel_scale=pixel_scale)
 
     @unittest.expectedFailure
     def test_image(self):


### PR DESCRIPTION
This is the Qt half of #412 and #517. I haven't looked into how Wx does HiDPI display yet, but figuring out how to do it for Qt5 first will likely make adding Wx "easy".

Known broken:
* ~`Component.use_backbuffer` creates a low resolution buffer.~
* OpenGL clipping is a bit off
* ~`GraphicsContext.clip_to_rect` uses absolute coordinates, so supporting HiDPI by changing the scale of a GC will break lots of code [but not all] which uses `clip_to_rect`~ `GraphicsContext.clip_to_rect` is not uniformly implemented with respect to the affine transformation across all kiva backends! (#592)
* ~`GraphicsContext.draw_marker_at_points` in the `kiva.agg` backend will draw nothing if there's anything more than a translation applied to the transformation matrix.~ Covered by #594