### PR TITLE
Celiagg's clip_to_rect() should respect the transform matrix

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -90,6 +90,7 @@ supported_combinations = {
 
 dependencies = {
     "apptools",
+    "celiagg",
     "coverage",
     "Cython",
     "fonttools",

--- a/kiva/celiagg.py
+++ b/kiva/celiagg.py
@@ -816,13 +816,16 @@ class GraphicsContext(object):
         if file_format is None:
             file_format = ''
 
-        # Data is BGRA; Convert to RGBA
         pixels = self.gc.array
-        data = np.empty(pixels.shape, dtype=np.uint8)
-        data[..., 0] = pixels[..., 2]
-        data[..., 1] = pixels[..., 1]
-        data[..., 2] = pixels[..., 0]
-        data[..., 3] = pixels[..., 3]
+        if self.pix_format.startswith('bgra'):
+            # Data is BGRA; Convert to RGBA
+            data = np.empty(pixels.shape, dtype=np.uint8)
+            data[..., 0] = pixels[..., 2]
+            data[..., 1] = pixels[..., 1]
+            data[..., 2] = pixels[..., 0]
+            data[..., 3] = pixels[..., 3]
+        else:
+            data = pixels
         img = Image.fromarray(data, 'RGBA')
 
         # Check the output format to see if it can handle an alpha channel.

--- a/kiva/celiagg.py
+++ b/kiva/celiagg.py
@@ -455,8 +455,12 @@ class GraphicsContext(object):
 
             Region should be a 4-tuple or a sequence.
         """
-        tx, ty = self.transform.tx, self.transform.ty
-        self.canvas_state.clip_box = agg.Rect(tx + x, ty + y, w, h)
+        # The passed in rect should be transformed.
+        # NOTE: Rotations will have an undefined result
+        x0, y0 = self.transform.worldToScreen(x, y)
+        x1, y1 = self.transform.worldToScreen(x + w, y + h)
+        w, h = abs(x1 - x0), abs(y1 - y0)
+        self.canvas_state.clip_box = agg.Rect(x0, y0, w, h)
 
     def clip_to_rects(self, rects):
         """ Clip context to a collection of rectangles

--- a/kiva/tests/test_celiagg_drawing.py
+++ b/kiva/tests/test_celiagg_drawing.py
@@ -1,0 +1,25 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+import unittest
+
+from kiva.celiagg import GraphicsContext
+from kiva.tests.drawing_tester import DrawingImageTester
+
+
+class TestCeliaggDrawing(DrawingImageTester, unittest.TestCase):
+    def create_graphics_context(self, width, height, pixel_scale):
+        return GraphicsContext((width, height), base_pixel_scale=pixel_scale)
+
+    def test_clip_rect_transform(self):
+        with self.draw_and_check():
+            self.gc.clip_to_rect(0, 0, 100, 100)
+            self.gc.begin_path()
+            self.gc.rect(75, 75, 25, 25)
+            self.gc.fill_path()


### PR DESCRIPTION
As part of the exploration for #591, I discovered that `clip_to_rect` should respect the current transformation and the celiagg backend was not doing this.

Fixes #304 (as a side effect of adding unit tests for celiagg)