### PR TITLE
Allow scaling in agg's draw_marker_at_points

### DIFF
--- a/kiva/agg/src/kiva_graphics_context.h
+++ b/kiva/agg/src/kiva_graphics_context.h
@@ -1170,7 +1170,7 @@ namespace kiva
         int success = 0;
         agg24::trans_affine ctm = this->get_ctm();
 
-        if ( only_translation(ctm) &&
+        if ( only_scale_and_translation(ctm) &&
             (this->state.line_width == 1.0 ||
              this->state.line_width == 0.0))
              //&& this->state.line_join == JOIN_MITER )
@@ -1184,12 +1184,16 @@ namespace kiva
             line_color.a *= this->state.line_width;
             m.line_color(line_color);
 
-            double tx, ty;
-            get_translation(ctm, &tx, &ty);
+            double mx, my, sx, sy;
+            get_scale(ctm, &sx, &sy);
 
             for(int i = 0; i < Npts*2; i+=2)
             {
-                m.marker((int)(pts[i]+tx), int(pts[i+1]+ty), size, type);
+                mx = pts[i];
+                my = pts[i+1];
+                ctm.transform(&mx, &my);
+                // XXX: Assuming scale is uniform in both directions
+                m.marker(int(mx), int(my), size * sx, type);
             }
             success = 1;
         }


### PR DESCRIPTION
This will be need to keep Chaco's colormapped scatterplot renderer working if #591 is merged.