### PR TITLE
Add documentation for toolkit/backend selection

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,6 +34,7 @@ import sys, os
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     "sphinx.ext.autodoc",
+    'sphinx.ext.intersphinx',
     "sphinx.ext.napoleon",
     # Link to code in sphinx generated API docs
     "sphinx.ext.viewcode",
@@ -206,3 +207,9 @@ latex_documents = [
 
 # If false, no module index is generated.
 #latex_use_modindex = True
+
+# Intersphinx mappings
+intersphinx_mapping = {
+    'traits': ('http://docs.enthought.com/traits', None),
+    'pyface': ('http://docs.enthought.com/pyface', None),
+}

--- a/docs/source/enable_concepts.rst
+++ b/docs/source/enable_concepts.rst
@@ -2,8 +2,8 @@ Enable Concepts
 ===============
 
 This document contains notes from a brain dump session by Peter Wang with
-Janet Swisher on March 19, 2008. It is notes rather than full explanations,
-which we hope to add later.
+Janet Swisher on March 19, 2008. It is notes rather than full explanations, but
+gives good background from the original developer of Enable.
 
 Enable Component
 ----------------
@@ -74,7 +74,7 @@ a bridge between the OS and GUI toolkit. The :attr:`window` trait delegates all
 the way up the containment chain to the top-level component, which has an actual
 reference to the actual window.
 
-The reference to the window is useful because Chaco doesn't make calls directly
+The reference to the window is useful because Enable doesn't make calls directly
 to the GUI toolkit. Rather, it asks the window to do things for it, such as
 creating a context menu.
 
@@ -97,8 +97,8 @@ is to dispatch to:
 5. its listener tools
 
 That logic is in :class:`Component`, in the :meth:`\_new_dispatch` method, which
-is called from :meth:`Component.dispatch` (:meth:`\_old_dispatch` will be
-removed in 3.0). If any of these handlers sets event.handled to True, event
+is called from :meth:`Component.dispatch` (:meth:`\_old_dispatch` is still
+being used by Chaco). If any of these handlers sets event.handled to True, event
 propagation stops. If an event gets as far as the listener tools, then all of
 them get the event.
 
@@ -180,7 +180,6 @@ Currently, this is used for the canvas, and for geophysical plotting. You could
 use it for something like a magnifying-glass view of a portion of a component or
 plot without duplicating it.
 
-.. Recording timestamp: (0:23:52)
 
 Layout
 ~~~~~~
@@ -196,6 +195,9 @@ also have lists of overlays and underlays.
 You can get access to the actual bounds of the component, including its
 padding with the :samp:`outer_{name}` attributes. Those also take into account
 the thickness of any border around the component.
+
+For more control over layout, there is a
+:ref:`constraints-based layout<constraints-layout>` system available.
 
 Rendering
 ~~~~~~~~~
@@ -254,23 +256,3 @@ Enable Container
 nested. Containers are responsible for event dispatch, draw dispatch, and
 layout. Containers override a lot of Component methods, so that they behave more
 like containers than plain components do.
-
-.. Recording timestamp: (0:43:40)
-
-Examples
---------
-
-BasicDraw
-~~~~~~~~~
-
-Just draws a box. Subclasses :class:`Component`, and implements
-:meth:`\_draw_mainlayer`. Uses :class:`DemoFrame` and :func:`demo_main`
-boilerplate code to simplify the example code.
-
-BasicMove
-~~~~~~~~~
-
-Adds interaction. Has a more complex :meth:`\_draw_mainlayer`; defines an event
-handler.
-
-

--- a/docs/source/enable_constraints_layout.rst
+++ b/docs/source/enable_constraints_layout.rst
@@ -1,3 +1,5 @@
+.. _constraints-layout:
+
 Enable Constraints Layout
 =========================
 

--- a/docs/source/enable_toolkit_selection.rst
+++ b/docs/source/enable_toolkit_selection.rst
@@ -1,0 +1,134 @@
+.. _toolkit-selection:
+
+Enable Toolkit Selection
+========================
+
+One of the more complicated aspects of Enable is the way in which it selects
+which widget toolkit (Qt, Wx, etc.) to use when constructing a :class:`Window`
+instance. Further, there is also a second choice of which kiva
+:class:`GraphicsContext` implementation to use along with the selected widget
+toolkit.
+
+There are of course defaults for both toolkit and kiva backend, which might even
+depend on the packages available in the Python environment where code is
+running. For most users, these defaults are sufficient and stable over time. For
+users that have specific needs, the widget toolkit and kiva backend can be
+explicitly specified.
+
+
+ETSConfig
+---------
+
+To control toolkit selection directly from application code, one must use
+:class:`~traits.etsconfig.etsconfig.ETSConfig`. Specifically, the
+``ETSConfig.toolkit`` trait should be set.
+
+.. note::
+  ``ETSConfig.toolkit`` must be set before importing Enable code, directly or
+  indirectly (via Chaco).
+
+Example:
+
+.. code-block:: python
+
+  from traits.etsconfig.api import ETSConfig
+
+  ETSConfig.toolkit = 'qt'
+  from chaco.api import Plot
+  from enable.api import ComponentEditor
+
+  # ...
+
+For the example, the application would use the Qt toolkit and the default kiva
+backend [currently ``image``].
+
+The format of the ``ETSConfig.toolkit`` property is
+``<widget toolkit>[.<kiva backend>]``. The ``.<kiva backend>`` part is
+*optional*. If no value is given for ``<kiva backend>``, the default kiva
+backend is then selected by ``ESTConfig``. That means that if you want to use
+the ``QPainter`` backend in your Qt-based application, you should do this:
+
+.. code-block:: python
+
+  from traits.etsconfig.api import ETSConfig
+  ETSConfig.toolkit = 'qt.qpainter'
+
+As another example, you might have a headless program (like a web server) which
+wants to generate plots with Chaco. So you could use the ``null`` toolkit and
+``image`` backend:
+
+.. code-block:: python
+
+  from traits.etsconfig.api import ETSConfig
+  ETSConfig.toolkit = 'null.image'
+
+``ETSConfig`` has a read-only property ``kiva_backend`` which you can read if
+you'd like to know which kiva backend is currently selected, in case you haven't
+explicitly selected a backend.
+
+
+ETS_TOOLKIT
+-----------
+
+If you wish to test toolkit/backend combinations *without* the need for code
+modifications, you can set the ``ETS_TOOLKIT`` environment variable before
+running your application. ``ETSConfig`` will use the value of that environment
+variable to initialize its ``toolkit`` and ``kiva_backend`` properties. Here's
+what that looks like:
+
+.. code-block:: shell
+
+  $ export ETS_TOOLKIT=qt.qpainter
+  $ python kiva/examples/kiva/kiva_explorer.py
+
+
+enable.toolkits entrypoints
+---------------------------
+
+The allowed values for ``ETSConfig.toolkit`` are determined by the
+``enable.toolkits`` `entrypoint <https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points>`_. An ``enable.toolkits`` entrypoint is a
+:class:`~pyface.base_toolkit.Toolkit` object which when called with the name
+of a class returns the appropriate version for the selected widget toolkit and
+kiva backend.
+
+The objects which are supplied by a toolkit/backend implementation are:
+
+* :class:`CompiledPath`
+* :class:`GraphicsContext`
+* :class:`Window`
+* :class:`NativeScrollBar`
+* :func:`font_metrics_provider`
+
+Because this is done via the setuptools entrypoint mechanism, it means that code
+outside of Enable can contribute a custom toolkit and backends. To create a new
+toolkit, you should need to do the following:
+
+1. Create a package for the toolkit
+2. Add a ``toolkit.py`` module (its name is just a convention) which should
+   contain a :class:`~pyface.base_toolkit.Toolkit` object initialized with the
+   details of your package.
+3. Add an ``enable.toolkits`` list to the ``entry_points`` keyword argument of
+   your package's ``setup.py`` script's call to the ``setup()`` function. This
+   list should contain a string with the format:
+   ``<name> = my.package.toolkit:<Toolkit object name>``. This points to the
+   ``Toolkit`` object created in the previous step.
+4. For every kiva backend supported by your toolkit, add a ``<backend>.py``
+   module to the package. This module must contain the objects listed above
+   (``CompiledPath``, ``GraphicsContext``, etc.)
+
+There's one more wrinkle to consider. :class:`~pyface.base_toolkit.Toolkit`
+normally expects to be called with a ``<module>:<class>`` format string, but
+Enable's usage of the ``Toolkit`` instance only passes a ``<class>`` name when
+resolving objects. This is because ``<module>`` denotes the kiva backend, which
+is not known until runtime. To provide this flexibility, the following wrapper
+is used in Enable's built-in toolkits:
+
+.. code-block:: python
+
+  def _wrapper(func):
+      def wrapped(name):
+          # Prefix object lookups with the name of the configured kiva backend.
+          return func(f"{ETSConfig.kiva_backend}:{name}")
+      return wrapped
+
+  toolkit = _wrapper(Toolkit("enable", "null", "enable.null"))

--- a/docs/source/enable_toolkit_selection.rst
+++ b/docs/source/enable_toolkit_selection.rst
@@ -101,7 +101,7 @@ The objects which are supplied by a toolkit/backend implementation are:
 
 Because this is done via the setuptools entrypoint mechanism, it means that code
 outside of Enable can contribute a custom toolkit and backends. To create a new
-toolkit, you should need to do the following:
+toolkit, you need to do the following:
 
 1. Create a package for the toolkit
 2. Add a ``toolkit.py`` module (its name is just a convention) which should

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ Enable Documentation
   enable_basic_tools.rst
   enable_drag_and_drop.rst
   enable_undo_redo.rst
+  enable_toolkit_selection.rst
 
   kiva.rst
   credits.rst


### PR DESCRIPTION
The banner feature here is an explanation of the `ETS_TOOLKIT`/`ETSConfig.toolkit` mechanism for selecting the GUI toolkit and kiva backend used by an application. In addition to that, I made some minor additions/modifications in other parts of the documentation.