### PR TITLE
Pin celiagg to a working version

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -90,7 +90,7 @@ supported_combinations = {
 
 dependencies = {
     "apptools",
-    "celiagg",
+    "celiagg^=1.0.3",
     "coverage",
     "Cython",
     "fonttools",


### PR DESCRIPTION
Celiagg 1.1.1 breaks text rendering on Windows. Until that's fixed, we should pin the installed celiagg version to the previous release (1.0.3).