### PR TITLE
Update celiagg backend to use 2.0.0 API

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -90,7 +90,7 @@ supported_combinations = {
 
 dependencies = {
     "apptools",
-    "celiagg^=1.0.3",
+    "celiagg^=2.0.0",
     "coverage",
     "Cython",
     "fonttools",


### PR DESCRIPTION
Celiagg 2.0.0 was _just_ released. It fixes the text rendering bugs introduced by 1.1.1. Once it's available in EDM, this can be merged.