### PR TITLE
Install SWIG with apt-get

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -44,13 +44,15 @@ jobs:
         run: sudo apt-get install libglu1-mesa-dev
       - name: Install build dependencies
         run: |
+          sudo apt-get install swig
           python -m pip install -U pip setuptools wheel
           python -m pip install numpy
           python -m pip install Cython
-          python -m pip install swig==3.0.11
       - name: Install prebuilt wxPython
         run: python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04 wxPython
         if: matrix.toolkit == 'wx'
+      - name: Install prebuilt celiagg
+        run: python -m pip install celiagg
       - name: Install source dependencies
         run: |
           python -m pip install git+http://github.com/enthought/traits.git#egg=traits


### PR DESCRIPTION
The cron job is still broken because it was trying to get SWIG from PyPI. The correct source for SWIG is `apt-get`.

And after one test run, `celiagg` also needs to be installed but we can get that from PyPI.