### PR TITLE
Fix font selection in the QPainter backend

### DIFF
--- a/kiva/qpainter.py
+++ b/kiva/qpainter.py
@@ -42,6 +42,12 @@ draw_modes[constants.STROKE] = 0
 draw_modes[constants.FILL_STROKE] = QtCore.Qt.OddEvenFill
 draw_modes[constants.EOF_FILL_STROKE] = QtCore.Qt.WindingFill
 
+font_styles = {}
+font_styles["regular"] = constants.NORMAL
+font_styles["bold"] = constants.BOLD
+font_styles["italic"] = constants.ITALIC
+font_styles["bold italic"] = constants.BOLD_ITALIC
+
 gradient_coord_modes = {}
 gradient_coord_modes["userSpaceOnUse"] = QtGui.QGradient.LogicalMode
 gradient_coord_modes["objectBoundingBox"] = QtGui.QGradient.ObjectBoundingMode
@@ -612,15 +618,23 @@ class GraphicsContext(object):
     # Drawing Text
     # ----------------------------------------------------------------
 
-    def select_font(self, name, size, textEncoding):
+    def select_font(self, name, size, style="regular", encoding=None):
         """ Set the font for the current graphics context.
         """
-        self.gc.setFont(QtGui.QFont(name, size))
+        style = font_styles.get(style, constants.NORMAL)
+        font = Font(name, size=size, style=style)
+        self.set_font(font)
 
     def set_font(self, font):
         """ Set the font for the current graphics context.
         """
-        self.select_font(font.face_name, font.size, None)
+        qfont = QtGui.QFont(font.face_name, font.size)
+
+        if font.style in (constants.BOLD, constants.BOLD_ITALIC):
+            qfont.setBold(True)
+        if font.style in (constants.ITALIC, constants.BOLD_ITALIC):
+            qfont.setItalic(True)
+        self.gc.setFont(qfont)
 
     def set_font_size(self, size):
         """


### PR DESCRIPTION
This is a bit of a drive-by fix. While testing #605 and comparing to the `kiva.qpainter` backend, I realized that it was ignoring bold and italic preferences for fonts. This corrects that, such that the `style` attribute of a `Font` is now honored.