### PR TITLE
Add a benchmark program for kiva graphics contexts

### DIFF
--- a/enable/gcbench/__main__.py
+++ b/enable/gcbench/__main__.py
@@ -1,0 +1,38 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+import argparse
+import os
+import sys
+
+from pyface.qt import QtGui
+
+from enable.gcbench.bench import benchmark
+from enable.gcbench.publish import publish
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-o', '--output', default=None)
+    args = parser.parse_args()
+
+    # Create a QApplication instance so that the QPainter backend can be tested
+    app = QtGui.QApplication(sys.argv)  # noqa: F841
+
+    outdir = args.output
+    if outdir is not None and not os.path.isdir(outdir):
+        os.mkdir(outdir)
+
+    results = benchmark(outdir=outdir)
+    if outdir is not None:
+        publish(results, outdir)
+
+
+if __name__ == '__main__':
+    main()

--- a/enable/gcbench/bench.py
+++ b/enable/gcbench/bench.py
@@ -1,0 +1,129 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+import importlib
+import inspect
+import os
+import time
+
+import numpy as np
+
+_MAX_DURATION = 1.0
+_SIZE = (512, 512)
+_BACKENDS = {
+    "ui": {
+        "kiva.agg": "enable.null.image",
+        "cairo": "enable.null.cairo",
+        "celiagg": "enable.null.celiagg",
+        "qpainter": "enable.null.qpainter",
+        "quartz": "enable.null.quartz",
+    },
+    "file": {
+        "pdf": "enable.null.pdf",
+        "ps": "enable.null.ps",
+        "svg": "enable.null.svg",
+    },
+}
+
+
+def benchmark(outdir=None):
+    """ Benchmark all backends
+    """
+    suite = gen_suite()
+
+    results = {}
+    # NOTE: Only checking UI backends for now
+    for name, mod_name in _BACKENDS["ui"].items():
+        print(f"Benchmarking backend: {name}", end="")
+        try:
+            module = importlib.import_module(mod_name)
+        except ImportError:
+            print(" ... Not available")
+            continue
+        results[name] = benchmark_backend(suite, name, module, outdir=outdir)
+
+    return results
+
+
+def benchmark_backend(suite, mod_name, module, outdir=None):
+    """ Benchmark a single backend
+    """
+    GraphicsContext = getattr(module, "GraphicsContext")
+    gc = GraphicsContext(_SIZE)
+
+    timings = {}
+    for name, symbol in suite.items():
+        print(f"\n\tBenchmark {name}", end="")
+        try:
+            instance = symbol(gc, module)
+        except Exception:
+            continue
+
+        if name.endswith("2x"):
+            # Double sized
+            with gc:
+                gc.scale_ctm(2, 2)
+                timings[name] = gen_timings(gc, instance)
+        else:
+            # Normal scale
+            timings[name] = gen_timings(gc, instance)
+
+        if timings[name] is None:
+            print(f" ... Failed", end="")
+
+        if timings[name] is not None and outdir is not None:
+            fname = os.path.join(outdir, f"{mod_name}.{name}.png")
+            gc.save(fname)
+
+    print()  # End the line that was left
+    return timings
+
+
+def gen_suite():
+    """ Create a suite of benchmarks to run against each backend
+    """
+    from enable.gcbench import suite
+
+    benchmarks = {}
+    for name in dir(suite):
+        symbol = getattr(suite, name)
+        if inspect.isclass(symbol):
+            benchmarks[name] = symbol
+            benchmarks[f"{name} 2x"] = symbol
+
+    return benchmarks
+
+
+def gen_timings(gc, func):
+    """ Run a function multiple times and generate some stats
+    """
+    duration = 0.0
+    times = []
+    while duration < _MAX_DURATION:
+        gc.clear()
+        t0 = time.perf_counter()
+        try:
+            func()
+        except Exception:
+            # Not all backends support everything
+            break
+        times.append(time.perf_counter() - t0)
+        duration += times[-1]
+
+    if not times:
+        return None
+
+    times = np.array(times)
+    return {
+        "max": times.max() * 1000,
+        "min": times.min() * 1000,
+        "mean": times.mean() * 1000,
+        "std": times.std() * 1000,
+        "count": len(times),
+    }

--- a/enable/gcbench/publish.py
+++ b/enable/gcbench/publish.py
@@ -1,0 +1,91 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+import math
+import os
+
+_DOC_TEMPLATE = """
+<!doctype html>
+<html lang=en>
+<head>
+<meta charset=utf-8>
+<title>Graphics Context Benchmark Results</title>
+</head>
+<body>
+
+<style>
+  table, th, td {{
+    padding: 4px;
+    border: 1px solid gray;
+    border-collapse: collapse;
+  }}
+  th {{
+    text-align: left;
+  }}
+</style>
+<h3>Kiva Backend Benchmark Results</h3>
+<p>
+All results are shown relative to the kiva.agg backend. Numbers less than 1.0
+indicate a slower result and numbers greater than 1.0 indicate a faster result.
+</p>
+{content}
+</body>
+</html>
+"""
+_TABLE_TEMPLATE = """
+<table>
+<tr>
+{headers}
+</tr>
+{rows}
+</table>
+"""
+
+
+def publish(results, outdir):
+    """ Write the test results out as a simple webpage.
+    """
+    backends = list(results)
+    functions = {}
+    for bend in backends:
+        for func, stats in results[bend].items():
+            value = stats["mean"] if stats is not None else math.nan
+            functions.setdefault(func, {})[bend] = value
+
+    # Scale timing values relative to a "baseline" backend implementation
+    for name in functions.keys():
+        functions[name] = _format_stats(functions[name], "kiva.agg")
+
+    # Build some table data
+    headers = ["Draw Function"] + backends
+    headers = "\n".join(f"<th>{head}</th>" for head in headers)
+    rows = [
+        [f"<td>{name}</td>"] + [f"<td>{stats[bend]}</td>" for bend in backends]
+        for name, stats in functions.items()
+    ]
+    rows = ["".join(row) for row in rows]
+    rows = "\n".join(f"<tr>{row}</tr>" for row in rows)
+    table = _TABLE_TEMPLATE.format(headers=headers, rows=rows)
+
+    path = os.path.join(outdir, "index.html")
+    with open(path, "w") as fp:
+        fp.write(_DOC_TEMPLATE.format(content=table))
+
+
+def _format_stats(function, baseline):
+    basevalue = function[baseline]
+    formatted = {}
+    for name, value in function.items():
+        if value is math.nan:
+            formatted[name] = "X"
+        else:
+            relvalue = basevalue / value
+            formatted[name] = f"{relvalue:0.2f}"
+
+    return formatted

--- a/enable/gcbench/suite.py
+++ b/enable/gcbench/suite.py
@@ -1,0 +1,139 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
+def gen_image():
+    import numpy as np
+
+    img = np.zeros((256, 256, 4), dtype=np.uint8)
+    img[50:150, 50:150, (0, 3)] = 255
+    img[5:200, 5:50, (1, 3)] = 255
+    img[85:195, 85:195, (2, 3)] = 255
+    img[205:250, 205:250, :] = 255
+    return img
+
+
+def gen_large_path(obj):
+    import math
+
+    obj.arc(125, 125, 100, 0.0, 2 * math.pi)
+    for x in range(0, 250, 25):
+        obj.move_to(x, 10)
+        obj.line_to(x, 250)
+    for y in range(0, 250, 25):
+        obj.move_to(10, y)
+        obj.line_to(250, y)
+
+    return obj
+
+
+def gen_small_path(obj):
+    for x in range(5, 25, 5):
+        obj.move_to(x, 5)
+        obj.line_to(x, 20)
+    for y in range(5, 25, 5):
+        obj.move_to(5, y)
+        obj.line_to(20, y)
+
+    return obj
+
+
+def gen_points(count=100):
+    import numpy as np
+
+    points = (np.random.random(size=count) * 250.0)
+    return points.reshape(count // 2, 2)
+
+
+class draw_path:
+    def __init__(self, gc, module):
+        self.gc = gc
+
+    def __call__(self):
+        with self.gc:
+            gen_large_path(self.gc)
+            self.gc.set_stroke_color((0.33, 0.66, 0.99, 1.0))
+            self.gc.stroke_path()
+
+
+class draw_rect:
+    def __init__(self, gc, module):
+        self.points = gen_points()
+        self.gc = gc
+
+    def __call__(self):
+        with self.gc:
+            self.gc.set_fill_color((0.33, 0.66, 0.99, 1.0))
+            for pt in self.points:
+                self.gc.rect(pt[0], pt[1], 20.0, 20.0)
+            self.gc.fill_path()
+
+
+class draw_marker_at_points:
+    def __init__(self, gc, module):
+        self.points = gen_points(1000)
+        self.gc = gc
+
+    def __call__(self):
+        from kiva import constants
+
+        self.gc.draw_marker_at_points(
+            self.points, 5.0, constants.PLUS_MARKER
+        )
+
+
+class draw_path_at_points:
+    def __init__(self, gc, module):
+        self.points = gen_points()
+        self.path = gen_small_path(getattr(module, 'CompiledPath')())
+        self.gc = gc
+
+    def __call__(self):
+        from kiva.api import STROKE
+
+        with self.gc:
+            self.gc.set_stroke_color((0.99, 0.66, 0.33, 0.75))
+            self.gc.set_line_width(1.5)
+            self.gc.draw_path_at_points(
+                self.points, self.path, STROKE
+            )
+
+
+class draw_image:
+    def __init__(self, gc, module):
+        self.img = gen_image()
+        self.gc = gc
+
+    def __call__(self):
+        self.gc.draw_image(self.img, (0, 0, 256, 256))
+
+
+class show_text:
+    def __init__(self, gc, module):
+        from kiva.api import Font
+
+        self.text = [
+            'The quick brown',
+            'fox jumped over',
+            'the lazy dog',
+            '狐假虎威',
+        ]
+        self.font = Font('Times New Roman', size=36)
+        self.gc = gc
+
+    def __call__(self):
+        with self.gc:
+            self.gc.set_fill_color((0.5, 0.5, 0.0, 1.0))
+            self.gc.set_font(self.font)
+            y = 256 - self.font.size * 1.4
+            for line in self.text:
+                self.gc.set_text_position(4, y)
+                self.gc.show_text(line)
+                y -= self.font.size * 1.4


### PR DESCRIPTION
This is a small program which collects timing information for key drawing methods of `GraphicsContext` for each [available] backend and then optionally generates a report in HTML format.

I'd like to continue to improve this program, but I wanted to keep this initial PR under 500 LOC. Ideas for future improvements:
* Add hyperlinks for the image outputs written by each benchmark to the timings table
* "Benchmark" the non-UI backends to get a clearer picture of feature coverage.
* Add a GitHub action which generates this report and adds it to the documentation site so that we can get an idea about relative performance over time.
* Don't ignore the GL backend.