### PR TITLE
fix edmtool test-all command

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -386,10 +386,10 @@ def test_clean(runtime, toolkit):
         '--runtime={}'.format(runtime),
     ]
     try:
-        install(args=args)
-        test(args=args)
+        install(args=args, standalone_mode=False)
+        test(args=args, standalone_mode=False)
     finally:
-        cleanup(args=args)
+        cleanup(args=args, standalone_mode=False)
 
 
 @cli.command()
@@ -417,7 +417,7 @@ def test_all():
         for toolkit in toolkits:
             args = ['--toolkit={}'.format(toolkit),
                     '--runtime={}'.format(runtime)]
-            test_clean(args)
+            test_clean(args, standalone_mode=True)
 
 
 # ----------------------------------------------------------------------------

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -386,10 +386,10 @@ def test_clean(runtime, toolkit):
         '--runtime={}'.format(runtime),
     ]
     try:
-        install(args=args, standalone_mode=False)
-        test(args=args, standalone_mode=False)
+        install(args=args)
+        test(args=args)
     finally:
-        cleanup(args=args, standalone_mode=False)
+        cleanup(args=args)
 
 
 @cli.command()
@@ -417,7 +417,7 @@ def test_all():
         for toolkit in toolkits:
             args = ['--toolkit={}'.format(toolkit),
                     '--runtime={}'.format(runtime)]
-            test_clean(args, standalone_mode=True)
+            test_clean(args)
 
 
 # ----------------------------------------------------------------------------

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -413,11 +413,17 @@ def test_all():
     """ Run test_clean across all supported environment combinations.
 
     """
+    failed_command = False
     for runtime, toolkits in supported_combinations.items():
         for toolkit in toolkits:
             args = ['--toolkit={}'.format(toolkit),
                     '--runtime={}'.format(runtime)]
-            test_clean(args, standalone_mode=True)
+            try:
+                test_clean(args, standalone_mode=True)
+            except SystemExit:
+                failed_command = True
+    if failed_command:
+        sys.exit(1)
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
This solution is lifted directly from traitsUI.
Previously running `python ci/edmtool.py test-all` would only run the test suite on one (randomly chosen - first item in a set) toolkit.  Now all toolkits are run.