### PR TITLE
Add an 'oldagg' backend pointing to kiva.agg

### DIFF
--- a/enable/null/oldagg.py
+++ b/enable/null/oldagg.py
@@ -1,0 +1,31 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+from kiva.agg import CompiledPath, GraphicsContextArray as GraphicsContext
+
+__all__ = [
+    "CompiledPath", "GraphicsContext", "NativeScrollBar", "Window",
+    "font_metrics_provider"
+]
+
+
+class NativeScrollBar(object):
+    pass
+
+
+class Window(object):
+    pass
+
+
+def font_metrics_provider():
+    from kiva.api import Font
+
+    gc = GraphicsContext((1, 1))
+    gc.set_font(Font())
+    return gc

--- a/enable/qt4/oldagg.py
+++ b/enable/qt4/oldagg.py
@@ -1,0 +1,55 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+from pyface.qt import QtCore, QtGui
+
+from enable.qt4.base_window import BaseWindow
+from enable.qt4.scrollbar import NativeScrollBar
+from kiva.agg import CompiledPath, GraphicsContextSystem as GraphicsContext
+
+__all__ = [
+    "CompiledPath", "GraphicsContext", "NativeScrollBar", "Window",
+    "font_metrics_provider"
+]
+
+
+class Window(BaseWindow):
+    def _create_gc(self, size, pix_format="bgra32"):
+        gc = GraphicsContext(
+            (size[0] + 1, size[1] + 1),
+            pix_format=pix_format,
+            base_pixel_scale=self.base_pixel_scale,
+            # We have to set bottom_up=0 or otherwise the PixelMap will
+            # appear upside down in the QImage.
+            bottom_up=0,
+        )
+        gc.translate_ctm(0.5, 0.5)
+
+        return gc
+
+    def _window_paint(self, event):
+        if self.control is None:
+            return
+
+        # self._gc is an image context
+        w = self._gc.width()
+        h = self._gc.height()
+        data = self._gc.pixel_map.convert_to_argb32string()
+        image = QtGui.QImage(data, w, h, QtGui.QImage.Format_ARGB32)
+        rect = QtCore.QRectF(0, 0, self.control.width(), self.control.height())
+        painter = QtGui.QPainter(self.control)
+        painter.drawImage(rect, image)
+
+
+def font_metrics_provider():
+    from kiva.api import Font
+
+    gc = GraphicsContext((1, 1))
+    gc.set_font(Font())
+    return gc

--- a/enable/qt4/oldagg.py
+++ b/enable/qt4/oldagg.py
@@ -7,49 +7,12 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-from pyface.qt import QtCore, QtGui
-
-from enable.qt4.base_window import BaseWindow
-from enable.qt4.scrollbar import NativeScrollBar
-from kiva.agg import CompiledPath, GraphicsContextSystem as GraphicsContext
+from .image import (
+    CompiledPath, font_metrics_provider, GraphicsContext, NativeScrollBar,
+    Window
+)
 
 __all__ = [
     "CompiledPath", "GraphicsContext", "NativeScrollBar", "Window",
     "font_metrics_provider"
 ]
-
-
-class Window(BaseWindow):
-    def _create_gc(self, size, pix_format="bgra32"):
-        gc = GraphicsContext(
-            (size[0] + 1, size[1] + 1),
-            pix_format=pix_format,
-            base_pixel_scale=self.base_pixel_scale,
-            # We have to set bottom_up=0 or otherwise the PixelMap will
-            # appear upside down in the QImage.
-            bottom_up=0,
-        )
-        gc.translate_ctm(0.5, 0.5)
-
-        return gc
-
-    def _window_paint(self, event):
-        if self.control is None:
-            return
-
-        # self._gc is an image context
-        w = self._gc.width()
-        h = self._gc.height()
-        data = self._gc.pixel_map.convert_to_argb32string()
-        image = QtGui.QImage(data, w, h, QtGui.QImage.Format_ARGB32)
-        rect = QtCore.QRectF(0, 0, self.control.width(), self.control.height())
-        painter = QtGui.QPainter(self.control)
-        painter.drawImage(rect, image)
-
-
-def font_metrics_provider():
-    from kiva.api import Font
-
-    gc = GraphicsContext((1, 1))
-    gc.set_font(Font())
-    return gc

--- a/enable/wx/oldagg.py
+++ b/enable/wx/oldagg.py
@@ -1,0 +1,86 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+import sys
+
+import numpy as np
+import wx
+
+from enable.wx.base_window import BaseWindow
+from enable.wx.scrollbar import NativeScrollBar
+from kiva.agg import CompiledPath, GraphicsContextSystem as GraphicsContext
+
+__all__ = [
+    "CompiledPath", "GraphicsContext", "NativeScrollBar", "Window",
+    "font_metrics_provider"
+]
+
+
+def _wx_bitmap_from_buffer(buf, width, height):
+    """ Given a pixel buffer in ARGB order, return a WX bitmap
+        object with the pixels in BGRA order.
+    """
+    arr = np.frombuffer(buf, dtype=np.uint8).reshape((width, height, 4))
+    copy = np.zeros_like(arr)
+    copy[..., 0::4] = arr[..., 2::4]
+    copy[..., 1::4] = arr[..., 1::4]
+    copy[..., 2::4] = arr[..., 0::4]
+    copy[..., 3::4] = arr[..., 3::4]
+    return wx.Bitmap.FromBufferRGBA(width, height, np.ravel(copy))
+
+
+class Window(BaseWindow):
+    def _create_gc(self, size, pix_format="bgra32"):
+        """ Create a Kiva graphics context of a specified size
+        """
+        # We have to set bottom_up=0 or otherwise the PixelMap will
+        # appear upside down when blitting. Note that this is not the
+        # case on Windows.
+        bottom_up = 0 if sys.platform != "win32" else 1
+        gc = GraphicsContext(
+            (size[0] + 1, size[1] + 1),
+            pix_format=pix_format,
+            base_pixel_scale=self.base_pixel_scale,
+            bottom_up=bottom_up,
+        )
+        gc.translate_ctm(0.5, 0.5)
+        return gc
+
+    def _window_paint(self, event):
+        """ Do a GUI toolkit specific screen update
+        """
+        if self.control is None:
+            event.Skip()
+            return
+
+        control = self.control
+        pixel_map = self._gc.pixel_map
+        wdc = control._dc = wx.PaintDC(control)
+
+        if hasattr(pixel_map, "draw_to_wxwindow"):
+            pixel_map.draw_to_wxwindow(control, 0, 0)
+        else:
+            # This should just be the Mac OS X code path
+            bmp = _wx_bitmap_from_buffer(
+                pixel_map.convert_to_argb32string(),
+                self._gc.width(),
+                self._gc.height(),
+            )
+            bmp.SetSize(control.GetSize())
+            wdc.DrawBitmap(bmp, 0, 0)
+
+        control._dc = None
+
+
+def font_metrics_provider():
+    from kiva.api import Font
+
+    gc = GraphicsContext((1, 1))
+    gc.set_font(Font())
+    return gc

--- a/enable/wx/oldagg.py
+++ b/enable/wx/oldagg.py
@@ -7,80 +7,12 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-import sys
-
-import numpy as np
-import wx
-
-from enable.wx.base_window import BaseWindow
-from enable.wx.scrollbar import NativeScrollBar
-from kiva.agg import CompiledPath, GraphicsContextSystem as GraphicsContext
+from .image import (
+    CompiledPath, font_metrics_provider, GraphicsContext, NativeScrollBar,
+    Window
+)
 
 __all__ = [
     "CompiledPath", "GraphicsContext", "NativeScrollBar", "Window",
     "font_metrics_provider"
 ]
-
-
-def _wx_bitmap_from_buffer(buf, width, height):
-    """ Given a pixel buffer in ARGB order, return a WX bitmap
-        object with the pixels in BGRA order.
-    """
-    arr = np.frombuffer(buf, dtype=np.uint8).reshape((width, height, 4))
-    copy = np.zeros_like(arr)
-    copy[..., 0::4] = arr[..., 2::4]
-    copy[..., 1::4] = arr[..., 1::4]
-    copy[..., 2::4] = arr[..., 0::4]
-    copy[..., 3::4] = arr[..., 3::4]
-    return wx.Bitmap.FromBufferRGBA(width, height, np.ravel(copy))
-
-
-class Window(BaseWindow):
-    def _create_gc(self, size, pix_format="bgra32"):
-        """ Create a Kiva graphics context of a specified size
-        """
-        # We have to set bottom_up=0 or otherwise the PixelMap will
-        # appear upside down when blitting. Note that this is not the
-        # case on Windows.
-        bottom_up = 0 if sys.platform != "win32" else 1
-        gc = GraphicsContext(
-            (size[0] + 1, size[1] + 1),
-            pix_format=pix_format,
-            base_pixel_scale=self.base_pixel_scale,
-            bottom_up=bottom_up,
-        )
-        gc.translate_ctm(0.5, 0.5)
-        return gc
-
-    def _window_paint(self, event):
-        """ Do a GUI toolkit specific screen update
-        """
-        if self.control is None:
-            event.Skip()
-            return
-
-        control = self.control
-        pixel_map = self._gc.pixel_map
-        wdc = control._dc = wx.PaintDC(control)
-
-        if hasattr(pixel_map, "draw_to_wxwindow"):
-            pixel_map.draw_to_wxwindow(control, 0, 0)
-        else:
-            # This should just be the Mac OS X code path
-            bmp = _wx_bitmap_from_buffer(
-                pixel_map.convert_to_argb32string(),
-                self._gc.width(),
-                self._gc.height(),
-            )
-            bmp.SetSize(control.GetSize())
-            wdc.DrawBitmap(bmp, 0, 0)
-
-        control._dc = None
-
-
-def font_metrics_provider():
-    from kiva.api import Font
-
-    gc = GraphicsContext((1, 1))
-    gc.set_font(Font())
-    return gc

--- a/kiva/oldagg.py
+++ b/kiva/oldagg.py
@@ -7,12 +7,12 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-from .image import (
-    CompiledPath, font_metrics_provider, GraphicsContext, NativeScrollBar,
-    Window
+from kiva.image import (
+    CompiledPath, font_metrics_provider, FontType, GraphicsContext,
+    GraphicsContextSystem, Image
 )
 
 __all__ = [
-    "CompiledPath", "GraphicsContext", "NativeScrollBar", "Window",
-    "font_metrics_provider"
+    "CompiledPath", "font_metrics_provider", "FontType", "GraphicsContext",
+    "GraphicsContextSystem", "Image"
 ]


### PR DESCRIPTION
This is step 3 from #414. Before switching the `image` kiva backend to celiagg, we need to make `kiva.agg` accessible via an unambiguous name.