### PR TITLE
Set encoding when writing gcbench output

### DIFF
--- a/enable/gcbench/publish.py
+++ b/enable/gcbench/publish.py
@@ -99,7 +99,7 @@ def publish(results, outdir):
 
     comparison_table = _build_comparison_table(backends, comparisons)
     path = os.path.join(outdir, "index.html")
-    with open(path, "w") as fp:
+    with open(path, "w", encoding="utf-8") as fp:
         fp.write(_INDEX_TEMPLATE.format(comparison_table=comparison_table))
 
 


### PR DESCRIPTION
fixes #670

#666 broke gcbench on windows. The fix is to simply set `encoding` when writing the gcbench output.