### PR TITLE
Normalize some signatures of Kiva methods

### DIFF
--- a/enable/gcbench/pdf.py
+++ b/enable/gcbench/pdf.py
@@ -27,4 +27,4 @@ class GraphicsContext(pdf_backend.GraphicsContext):
     def save(self, filename, *args, **kw):
         # Reportlab is a bit silly
         self.gc._filename = filename
-        super().save()
+        super().save(filename, *args, **kw)

--- a/kiva/abstract_graphics_context.py
+++ b/kiva/abstract_graphics_context.py
@@ -116,7 +116,8 @@ class AbstractGraphicsContext(object, metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def linear_gradient(self, x1, y1, x2, y2, stops, spread_method, units):
+    def linear_gradient(self, x1, y1, x2, y2, stops, spread_method,
+                        units="userSpaceOnUse"):
         """ Modify the fill color to be a linear gradient
 
         Parameters
@@ -142,7 +143,8 @@ class AbstractGraphicsContext(object, metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def radial_gradient(self, cx, cy, r, fx, fy, stops, spread_method, units):
+    def radial_gradient(self, cx, cy, r, fx, fy, stops, spread_method,
+                        units="userSpaceOnUse"):
         """ Modify the fill color to be a radial gradient
 
         Parameters

--- a/kiva/abstract_graphics_context.py
+++ b/kiva/abstract_graphics_context.py
@@ -84,7 +84,7 @@ class AbstractGraphicsContext(object, metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def set_line_dash(self, line_dash):
+    def set_line_dash(self, line_dash, phase=0):
         """ Set the dash style to use when stroking a path
 
         Parameters
@@ -92,6 +92,8 @@ class AbstractGraphicsContext(object, metaclass=ABCMeta):
             line_dash
                 An even-lengthed tuple of floats that represents
                 the width of each dash and gap in the dash pattern.
+            phase : float
+                Specifies how many units into the dash pattern to start.
         """
 
     @abstractmethod

--- a/kiva/abstract_graphics_context.py
+++ b/kiva/abstract_graphics_context.py
@@ -659,7 +659,8 @@ class EnhancedAbstractGraphicsContext(AbstractGraphicsContext):
         """
 
     @abstractmethod
-    def draw_path_at_points(self, point_array, compiled_path, draw_mode):
+    def draw_path_at_points(self, point_array, compiled_path,
+                            draw_mode=FILL_STROKE):
         """ Draw a compiled path at a collection of points
 
         The starting point of the paths are specified by the points,

--- a/kiva/abstract_graphics_context.py
+++ b/kiva/abstract_graphics_context.py
@@ -96,7 +96,8 @@ class AbstractGraphicsContext(object, metaclass=ABCMeta):
 
     @abstractmethod
     def set_fill_color(self, color):
-        """ Set the color used to fill the region bounded by a path
+        """ Set the color used to fill the region bounded by a path or when
+        drawing text.
 
         Parameters
         ----------
@@ -108,7 +109,9 @@ class AbstractGraphicsContext(object, metaclass=ABCMeta):
 
     @abstractmethod
     def get_fill_color(self):
-        """ Get the color used to fill the region bounded by a path """
+        """ Get the color used to fill the region bounded by a path or when
+        drawing text.
+        """
 
     @abstractmethod
     def linear_gradient(self, x1, y1, x2, y2, stops, spread_method, units):
@@ -493,7 +496,7 @@ class AbstractGraphicsContext(object, metaclass=ABCMeta):
         """ Get the current point where text will be drawn """
 
     @abstractmethod
-    def show_text(self, text):
+    def show_text(self, text, point=None):
         """ Draw the specified string at the current point """
 
     @abstractmethod

--- a/kiva/basecore2d.py
+++ b/kiva/basecore2d.py
@@ -1003,7 +1003,7 @@ class GraphicsContextBase(AbstractGraphicsContext):
         """
         return self.state.text_matrix.copy()
 
-    def show_text(self, text):
+    def show_text(self, text, point=None):
         """ Draws text on the device at the current text position.
 
             This calls the device dependent device_show_text() method to
@@ -1011,7 +1011,12 @@ class GraphicsContextBase(AbstractGraphicsContext):
 
             It is not clear yet how this should affect the current point.
         """
-        self.device_show_text(text)
+        if point is not None:
+            with self:
+                self.set_text_position(*point)
+                self.device_show_text(text)
+        else:
+            self.device_show_text(text)
 
     def show_text_tanslate(self, text, dx, dy):
         """ Draws text at the specified offset. """

--- a/kiva/basecore2d.py
+++ b/kiva/basecore2d.py
@@ -811,11 +811,13 @@ class GraphicsContextBase(AbstractGraphicsContext):
         """
         return self.state.fill_color
 
-    def linear_gradient(self, x1, y1, x2, y2, stops, spread_method, units):
+    def linear_gradient(self, x1, y1, x2, y2, stops, spread_method,
+                        units="userSpaceOnUse"):
         """ Modify the fill color to be a linear gradient """
         pass
 
-    def radial_gradient(self, cx, cy, r, fx, fy, stops, spread_method, units):
+    def radial_gradient(self, cx, cy, r, fx, fy, stops, spread_method,
+                        units="userSpaceOnUse"):
         """ Modify the fill color to be a linear gradient """
         pass
 

--- a/kiva/cairo.py
+++ b/kiva/cairo.py
@@ -1082,11 +1082,15 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
         """
         return copy.copy(self.text_matrix)
 
-    def show_text(self, text, point=(0.0, 0.0)):
+    def show_text(self, text, point=None):
         """ Draws text on the device at the current text position.
             Leaves the current point unchanged.
         """
-        self.show_text_at_point(text, point[0], point[1])
+        if point is not None:
+            x, y = point
+        else:
+            x, y = 0.0, 0.0
+        self.show_text_at_point(text, x, y)
 
     def show_glyphs(self):
         """

--- a/kiva/celiagg.py
+++ b/kiva/celiagg.py
@@ -631,6 +631,10 @@ class GraphicsContext(object):
         msg = "set_character_spacing not implemented on celiagg yet."
         raise NotImplementedError(msg)
 
+    def get_character_spacing(self):
+        msg = "get_character_spacing not implemented on celiagg yet."
+        raise NotImplementedError(msg)
+
     def set_text_drawing_mode(self, mode):
         try:
             tmode = text_modes[mode]

--- a/kiva/celiagg.py
+++ b/kiva/celiagg.py
@@ -608,15 +608,15 @@ class GraphicsContext(object):
     # Drawing Text
     # ----------------------------------------------------------------
 
-    def select_font(self, name, size, textEncoding):
+    def select_font(self, face_name, size=12, style='regular', encoding=None):
         """ Set the font for the current graphics context.
         """
-        self.font = agg.Font(name, size)
+        self.set_font(Font(face_name, size=size, style=style))
 
     def set_font(self, font):
         """ Set the font for the current graphics context.
         """
-        self.select_font(font.findfont(), font.size, None)
+        self.font = agg.Font(font.findfont(), font.size)
 
     def set_font_size(self, size):
         """ Set the font size for the current graphics context.

--- a/kiva/pdf.py
+++ b/kiva/pdf.py
@@ -656,20 +656,6 @@ class GraphicsContext(GraphicsContextBase):
         font = self.gc._fontname
         self.gc.setFont(font, size)
 
-    def set_character_spacing(self):
-        """
-        """
-        pass
-
-    def get_character_spacing(self):
-        """ Get the current font """
-        raise NotImplementedError
-
-    def set_text_drawing_mode(self):
-        """
-        """
-        pass
-
     def set_text_position(self, x, y):
         """
         """
@@ -692,22 +678,22 @@ class GraphicsContext(GraphicsContextBase):
         a, b, c, d, tx, ty = self.gc._textMatrix
         return affine.affine_from_values(a, b, c, d, tx, ty)
 
-    def show_text(self, text, x=None, y=None):
+    def show_text(self, text, point=None):
         """ Draws text on the device at current text position.
 
             This is also used for showing text at a particular point
-            specified by x and y.
+            specified by ``point``.
 
             This ignores the text matrix for now.
         """
-        if x and y:
-            pass
+        if point:
+            x, y = point
         else:
             x, y = self.text_xy
         self.gc.drawString(x, y, text)
 
     def show_text_at_point(self, text, x, y):
-        self.show_text(text, x, y)
+        self.show_text(text, point=(x, y))
 
     def show_glyphs(self):
         """

--- a/kiva/pdf.py
+++ b/kiva/pdf.py
@@ -50,6 +50,12 @@ join_style[constants.JOIN_ROUND] = 1
 join_style[constants.JOIN_BEVEL] = 2
 join_style[constants.JOIN_MITER] = 0
 
+font_styles = {}
+font_styles["regular"] = ""
+font_styles["bold"] = "-Bold"
+font_styles["italic"] = "-Oblique"
+font_styles["bold italic"] = "-BoldOblique"
+
 # stroke, fill, mode
 path_mode = {}
 path_mode[constants.FILL_STROKE] = (1, 1, canvas.FILL_NON_ZERO)
@@ -612,9 +618,10 @@ class GraphicsContext(GraphicsContextBase):
     # Drawing Text
     # ----------------------------------------------------------------
 
-    def select_font(self, name, size, textEncoding):
+    def select_font(self, name, size, style="regular", encoding=None):
         """ PDF ignores the Encoding variable.
         """
+        name += font_styles.get(style, "")
         self.gc.setFont(name, size)
 
     def set_font(self, font):
@@ -625,6 +632,8 @@ class GraphicsContext(GraphicsContextBase):
         if face_name == "":
             face_name = "Helvetica"
 
+        # Apply the style as a suffix to the face name
+        face_name += font_styles.get(font.style, "")
         try:
             self.gc.setFont(face_name, font.size)
         except KeyError:

--- a/kiva/qpainter.py
+++ b/kiva/qpainter.py
@@ -644,16 +644,22 @@ class GraphicsContext(object):
         self.gc.setFont(font)
 
     def set_character_spacing(self, spacing):
-        """
+        """ Set the spacing between characters when drawing text
         """
         font = self.gc.font()
         font.setLetterSpacing(QtGui.QFont.AbsoluteSpacing, spacing)
         self.gc.setFont(font)
 
-    def set_text_drawing_mode(self):
+    def get_character_spacing(self):
+        """ Get the spacing between characters when drawing text
         """
+        font = self.gc.font()
+        return font.letterSpacing()
+
+    def set_text_drawing_mode(self, mode):
+        """ Set the drawing mode to use with text
         """
-        pass
+        raise NotImplementedError()
 
     def set_text_position(self, x, y):
         """

--- a/kiva/qpainter.py
+++ b/kiva/qpainter.py
@@ -690,10 +690,14 @@ class GraphicsContext(object):
         unflip_trans.translate(0, self._height)
         unflip_trans.scale(1.0, -1.0)
 
-        self.gc.save()
-        self.gc.setTransform(unflip_trans, True)
-        self.gc.drawText(QtCore.QPointF(pos[0], self._flip_y(pos[1])), text)
-        self.gc.restore()
+        # Make some temporary modifications to the state
+        with self:
+            # Kiva uses the fill color for text
+            brush = self.gc.brush()
+            self.gc.setPen(brush.color())
+            self.gc.setTransform(unflip_trans, True)
+            pos = QtCore.QPointF(pos[0], self._flip_y(pos[1]))
+            self.gc.drawText(pos, text)
 
     def show_text_at_point(self, text, x, y):
         """ Draw text at some point (x, y).

--- a/kiva/quartz/ABCGI.pyx
+++ b/kiva/quartz/ABCGI.pyx
@@ -826,12 +826,18 @@ cdef class CGContext:
         self.current_font = self.font_cache[key]
 
     def set_character_spacing(self, float spacing):
+        """ Set the spacing between characters when drawing text
         """
-        """
-
         # XXX: Perhaps this should be handled by the kerning attribute
         # in the attributed string that is used to make a line of text?
         CGContextSetCharacterSpacing(self.context, spacing)
+
+    def get_character_spacing(self):
+        """ Get the current spacing between characters when drawing text
+        """
+        # XXX: There is no "get" counterpart for CGContextSetCharacterSpacing
+        msg = "get_character_spacing not implemented for Quartz yet."
+        raise NotImplementedError(msg)
 
     def set_text_drawing_mode(self, object mode):
         """

--- a/kiva/quartz/ABCGI.pyx
+++ b/kiva/quartz/ABCGI.pyx
@@ -787,8 +787,8 @@ cdef class CGContext:
     # Drawing Text
     #----------------------------------------------------------------
 
-    def select_font(self, object name, float size, style='regular'):
-        """
+    def select_font(self, object name, float size, style='regular', encoding=None):
+        """ Select a font to use.
         """
         key = (name, size, style)
         if key not in self.font_cache:


### PR DESCRIPTION
This is part of an ongoing effort to address #648

* Changes to method signatures were made in `AbstractGraphicsContext` to reflect how a majority of backends have something implemented (gradients, `show_text`, `draw_path_at_points`, `set_line_dash`).
* `show_text` with the `point=` kwarg was refactored for many of the lesser-used backends.
* `select_font` now has the correct signature on celiagg, PDF, and Quartz backends.
* QPainter uses the fill color for text now, matching the behavior of AGG