### PR TITLE
Use fonttools.afmLib instead of ad-hoc AFM parser

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,7 +16,7 @@ recursive-include kiva/agg *.py *.i *.cpp *.h *.c
 recursive-include kiva/agg/agg-24 *
 recursive-include kiva/agg/freetype2 *
 recursive-include kiva/agg/LICENSES *
-recursive-include kiva/fonttools/tests/data *.ttc *.ttf
+recursive-include kiva/fonttools/tests/data *.ttc *.ttf *.afm
 recursive-include kiva/fonttools/LICENSES *
 recursive-include kiva/gl *.h *.cpp *.i LICENSE_*
 recursive-include kiva/quartz *.pyx *.pxi *.pxd mac_context*.*

--- a/kiva/fonttools/LICENSES/LICENSE_fonttools
+++ b/kiva/fonttools/LICENSES/LICENSE_fonttools
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Just van Rossum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/kiva/fonttools/tests/data/TestAFM.afm
+++ b/kiva/fonttools/tests/data/TestAFM.afm
@@ -1,0 +1,37 @@
+StartFontMetrics 2.0
+Comment UniqueID 2123703
+Comment Panose 2 0 6 3 3 0 0 2 0 4
+FontName TestFont-Regular
+FullName TestFont-Regular
+FamilyName TestFont
+Weight Regular
+ItalicAngle 0.00
+IsFixedPitch false
+FontBBox -94 -317 1316 1009
+UnderlinePosition -296
+UnderlineThickness 111
+Version 001.000
+Notice [c] Copyright 2017. All Rights Reserved.
+EncodingScheme FontSpecific
+CapHeight 700
+XHeight 500
+Ascender 750
+Descender -250
+StdHW 181
+StdVW 194
+StartCharMetrics 4
+C 32 ; WX 200 ; N space ; B 0 0 0 0 ;
+C 65 ; WX 668 ; N A ; B 8 -25 660 666 ;
+C 66 ; WX 543 ; N B ; B 36 0 522 666 ;
+C 67 ; WX 582 ; N C ; B 24 -21 564 687 ;
+EndCharMetrics
+StartKernData
+StartKernPairs 5
+KPX T c 30
+KPX T comma -100
+KPX T period -100
+KPX V A -60
+KPX V d 30
+EndKernPairs
+EndKernData
+EndFontMetrics

--- a/kiva/fonttools/tests/test_scan_parse.py
+++ b/kiva/fonttools/tests/test_scan_parse.py
@@ -76,34 +76,28 @@ class TestAFMFontEntry(unittest.TestCase):
             entries = _build_afm_entries("nonexistant.path")
         self.assertListEqual([], entries)
 
-        # XXX: Once AFM code has been converted to expect bytestrings:
         # Add a test which passes an existing file (non-afm) to
-        # _build_afm_entries.
+        ttf_fontpath = os.path.join(data_dir, "TestTTF.ttf")
+        entries = _build_afm_entries(ttf_fontpath)
+        self.assertListEqual([], entries)
+
+        # Add a test which passes an existing file (non-afm) to
+        afm_fontpath = os.path.join(data_dir, "TestAFM.afm")
+        entries = _build_afm_entries(afm_fontpath)
+        self.assertEqual(len(entries), 1)
 
     def test_property_branches(self):
-        fake_path = os.path.join(data_dir, "TestAFM.afm")
+        fake_path = os.path.join(data_dir, "FakeAFM.afm")
 
         class FakeAFM:
             def __init__(self, name, family, angle, weight):
-                self.name = name
-                self.family = family
-                self.angle = angle
-                self.weight = weight
-
-            def get_angle(self):
-                return self.angle
-
-            def get_familyname(self):
-                return self.family
-
-            def get_fontname(self):
-                return self.name
-
-            def get_weight(self):
-                return self.weight
+                self.FullName = name
+                self.FamilyName = family
+                self.ItalicAngle = angle
+                self.Weight = weight
 
         # Given
-        fake_font = FakeAFM("TestyFont", "Testy", 0, "Bold")
+        fake_font = FakeAFM("TestyFont", "Testy", "0.0", "Bold")
         exp_family = "Testy"
         exp_style = "normal"
         exp_variant = "normal"

--- a/kiva/fonttools/tests/test_scan_sys.py
+++ b/kiva/fonttools/tests/test_scan_sys.py
@@ -26,18 +26,24 @@ class TestFontDirectoryScanning(unittest.TestCase):
         expected = [
             os.path.join(data_dir, fname)
             for fname in os.listdir(data_dir)
+            if os.path.splitext(fname)[-1] in (".ttf", ".ttc")
         ]
         fonts = scan_system_fonts(data_dir, fontext="ttf")
         self.assertListEqual(sorted(expected), sorted(fonts))
 
-        # There are no AFM fonts in the test data
+        expected = [
+            os.path.join(data_dir, fname)
+            for fname in os.listdir(data_dir)
+            if os.path.splitext(fname)[-1] == ".afm"
+        ]
         fonts = scan_system_fonts(data_dir, fontext="afm")
-        self.assertListEqual([], fonts)
+        self.assertListEqual(sorted(expected), sorted(fonts))
 
     def test_directories_scanning(self):
         expected = sorted([
             os.path.join(data_dir, fname)
             for fname in os.listdir(data_dir)
+            if os.path.splitext(fname)[-1] in (".ttf", ".ttc")
         ])
         # Pass a list of directories instead of a single path string
         fonts = scan_system_fonts([data_dir], fontext="ttf")

--- a/setup.py
+++ b/setup.py
@@ -495,6 +495,7 @@ if __name__ == "__main__":
                                   'demo/*/*/*/*/*'],
               'enable.savage.trait_defs.ui.wx': ['data/*.svg'],
               'kiva': ['tests/agg/doubleprom_soho_full.jpg',
+                       'fonttools/tests/data/*.afm',
                        'fonttools/tests/data/*.ttc',
                        'fonttools/tests/data/*.ttf',
                        'fonttools/tests/data/*.txt'],


### PR DESCRIPTION
`kiva.fonttools.afm` should not exist. Once all this font chaos is done, it won't.

This PR starts the ball rolling by changing the AFM parsing in the new code to use `fonttools.afmLib:AFM`. While I was at it, I copied `fonttools` test AFM file. Now we're actually exercising the code with some real data!