### PR TITLE
Break out the font scoring methods and test them

### DIFF
--- a/kiva/fonttools/_score.py
+++ b/kiva/fonttools/_score.py
@@ -1,0 +1,135 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+"""
+####### NOTE #######
+This is based heavily on matplotlib's font_manager.py SVN rev 8713
+(git commit f8e4c6ce2408044bc89b78b3c72e54deb1999fb5),
+but has been modified quite a bit in the decade since it was copied.
+####################
+"""
+from kiva.fonttools._constants import (
+    font_family_aliases, font_scalings, preferred_fonts, stretch_dict,
+    weight_dict
+)
+
+# Each of the scoring functions below should return a value between
+# 0.0 (perfect match) and 1.0 (terrible match)
+
+
+def score_family(families, family2):
+    """ Returns a match score between the list of font families in
+    *families* and the font family name *family2*.
+
+    An exact match anywhere in the list returns 0.0.
+
+    A match by generic font name will return 0.1.
+
+    No match will return 1.0.
+    """
+    family2 = family2.lower()
+    for i, family1 in enumerate(families):
+        family1 = family1.lower()
+        if family1 in font_family_aliases:
+            if family1 in {"sans", "sans serif", "modern"}:
+                family1 = "sans-serif"
+            options = preferred_fonts[family1]
+            options = [x.lower() for x in options]
+            if family2 in options:
+                idx = options.index(family2)
+                return 0.1 * (float(idx) / len(options))
+        elif family1 == family2:
+            return 0.0
+    return 1.0
+
+
+def score_size(size1, size2, default):
+    """ Returns a match score between *size1* and *size2*.
+
+    If *size2* (the size specified in the font file) is 'scalable', this
+    function always returns 0.0, since any font size can be generated.
+
+    Otherwise, the result is the absolute distance between *size1* and
+    *size2*, normalized so that the usual range of font sizes (6pt -
+    72pt) will lie between 0.0 and 1.0.
+    """
+    if size2 == "scalable":
+        return 0.0
+    # Size value should have already been
+    try:
+        sizeval1 = float(size1)
+    except ValueError:
+        sizeval1 = default * font_scalings.get(size1, 1.0)
+    try:
+        sizeval2 = float(size2)
+    except ValueError:
+        return 1.0
+    return abs(sizeval1 - sizeval2) / 72.0
+
+
+def score_stretch(stretch1, stretch2):
+    """ Returns a match score between *stretch1* and *stretch2*.
+
+    The result is the absolute value of the difference between the
+    CSS numeric values of *stretch1* and *stretch2*, normalized
+    between 0.0 and 1.0.
+    """
+    try:
+        stretchval1 = int(stretch1)
+    except ValueError:
+        stretchval1 = stretch_dict.get(stretch1, 500)
+    try:
+        stretchval2 = int(stretch2)
+    except ValueError:
+        stretchval2 = stretch_dict.get(stretch2, 500)
+    return abs(stretchval1 - stretchval2) / 1000.0
+
+
+def score_style(style1, style2):
+    """ Returns a match score between *style1* and *style2*.
+
+    * An exact match returns 0.0.
+    * A match between 'italic' and 'oblique' returns 0.1.
+    * No match returns 1.0.
+    """
+    styles = ("italic", "oblique")
+    if style1 == style2:
+        return 0.0
+    elif style1 in styles and style2 in styles:
+        return 0.1
+    return 1.0
+
+
+def score_variant(variant1, variant2):
+    """ Returns a match score between *variant1* and *variant2*.
+
+    An exact match returns 0.0, otherwise 1.0.
+    """
+    if variant1 == variant2:
+        return 0.0
+    else:
+        return 1.0
+
+
+def score_weight(weight1, weight2):
+    """ Returns a match score between *weight1* and *weight2*.
+
+    The result is the absolute value of the difference between the
+    CSS numeric values of *weight1* and *weight2*, normalized
+    between 0.0 and 1.0.
+    """
+    try:
+        weightval1 = int(weight1)
+    except ValueError:
+        weightval1 = weight_dict.get(weight1, 500)
+    try:
+        weightval2 = int(weight2)
+    except ValueError:
+        weightval2 = weight_dict.get(weight2, 500)
+    return abs(weightval1 - weightval2) / 1000.0

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -61,7 +61,10 @@ from fontTools.ttLib import TTCollection, TTFont, TTLibError
 from traits.etsconfig.api import ETSConfig
 
 from . import afm
-from ._constants import font_family_aliases, preferred_fonts
+from ._score import (
+    score_family, score_size, score_stretch, score_style, score_variant,
+    score_weight
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1105,122 +1108,6 @@ class FontManager:
         #  !!!!  Needs implementing
         raise NotImplementedError
 
-    # Each of the scoring functions below should return a value between
-    # 0.0 (perfect match) and 1.0 (terrible match)
-    def score_family(self, families, family2):
-        """
-        Returns a match score between the list of font families in
-        *families* and the font family name *family2*.
-
-        An exact match anywhere in the list returns 0.0.
-
-        A match by generic font name will return 0.1.
-
-        No match will return 1.0.
-        """
-        family2 = family2.lower()
-        for i, family1 in enumerate(families):
-            family1 = family1.lower()
-            if family1 in font_family_aliases:
-                if family1 in ("sans", "sans serif", "modern"):
-                    family1 = "sans-serif"
-                options = preferred_fonts[family1]
-                options = [x.lower() for x in options]
-                if family2 in options:
-                    idx = options.index(family2)
-                    return 0.1 * (float(idx) / len(options))
-            elif family1 == family2:
-                return 0.0
-        return 1.0
-
-    def score_style(self, style1, style2):
-        """
-        Returns a match score between *style1* and *style2*.
-
-        An exact match returns 0.0.
-
-        A match between 'italic' and 'oblique' returns 0.1.
-
-        No match returns 1.0.
-        """
-        styles = ("italic", "oblique")
-        if style1 == style2:
-            return 0.0
-        elif style1 in styles and style2 in styles:
-            return 0.1
-        return 1.0
-
-    def score_variant(self, variant1, variant2):
-        """
-        Returns a match score between *variant1* and *variant2*.
-
-        An exact match returns 0.0, otherwise 1.0.
-        """
-        if variant1 == variant2:
-            return 0.0
-        else:
-            return 1.0
-
-    def score_stretch(self, stretch1, stretch2):
-        """
-        Returns a match score between *stretch1* and *stretch2*.
-
-        The result is the absolute value of the difference between the
-        CSS numeric values of *stretch1* and *stretch2*, normalized
-        between 0.0 and 1.0.
-        """
-        try:
-            stretchval1 = int(stretch1)
-        except ValueError:
-            stretchval1 = stretch_dict.get(stretch1, 500)
-        try:
-            stretchval2 = int(stretch2)
-        except ValueError:
-            stretchval2 = stretch_dict.get(stretch2, 500)
-        return abs(stretchval1 - stretchval2) / 1000.0
-
-    def score_weight(self, weight1, weight2):
-        """
-        Returns a match score between *weight1* and *weight2*.
-
-        The result is the absolute value of the difference between the
-        CSS numeric values of *weight1* and *weight2*, normalized
-        between 0.0 and 1.0.
-        """
-        try:
-            weightval1 = int(weight1)
-        except ValueError:
-            weightval1 = weight_dict.get(weight1, 500)
-        try:
-            weightval2 = int(weight2)
-        except ValueError:
-            weightval2 = weight_dict.get(weight2, 500)
-        return abs(weightval1 - weightval2) / 1000.0
-
-    def score_size(self, size1, size2):
-        """
-        Returns a match score between *size1* and *size2*.
-
-        If *size2* (the size specified in the font file) is 'scalable', this
-        function always returns 0.0, since any font size can be generated.
-
-        Otherwise, the result is the absolute distance between *size1* and
-        *size2*, normalized so that the usual range of font sizes (6pt -
-        72pt) will lie between 0.0 and 1.0.
-        """
-        if size2 == "scalable":
-            return 0.0
-        # Size value should have already been
-        try:
-            sizeval1 = float(size1)
-        except ValueError:
-            sizeval1 = self.default_size * font_scalings(size1)
-        try:
-            sizeval2 = float(size2)
-        except ValueError:
-            return 1.0
-        return abs(sizeval1 - sizeval2) / 72.0
-
     def findfont(self, prop, fontext="ttf", directory=None,
                  fallback_to_default=True, rebuild_if_missing=True):
         """
@@ -1291,12 +1178,12 @@ class FontManager:
             # Matching family should have highest priority, so it is multiplied
             # by 10.0
             score = (
-                self.score_family(prop.get_family(), font.name) * 10.0
-                + self.score_style(prop.get_style(), font.style)
-                + self.score_variant(prop.get_variant(), font.variant)
-                + self.score_weight(prop.get_weight(), font.weight)
-                + self.score_stretch(prop.get_stretch(), font.stretch)
-                + self.score_size(prop.get_size(), font.size)
+                score_family(prop.get_family(), font.name) * 10.0
+                + score_style(prop.get_style(), font.style)
+                + score_variant(prop.get_variant(), font.variant)
+                + score_weight(prop.get_weight(), font.weight)
+                + score_stretch(prop.get_stretch(), font.stretch)
+                + score_size(prop.get_size(), font.size, self.default_size)
             )
             if score < best_score:
                 best_score = score

--- a/kiva/fonttools/tests/test_score.py
+++ b/kiva/fonttools/tests/test_score.py
@@ -1,0 +1,113 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+import unittest
+
+from kiva.fonttools._constants import preferred_fonts
+from kiva.fonttools._score import (
+    score_family, score_size, score_stretch, score_style, score_variant,
+    score_weight
+)
+
+
+class TestFontScoring(unittest.TestCase):
+    def test_score_family(self):
+        # exact matches
+        self.assertEqual(score_family(["Times"], "Times"), 0.0)
+        closest = preferred_fonts["sans-serif"][0]
+        self.assertEqual(score_family(["sans-serif"], closest), 0.0)
+        self.assertEqual(score_family(["sans"], closest), 0.0)
+        self.assertEqual(score_family(["unknown", "modern"], closest), 0.0)
+
+        # fuzzy matches
+        sans_count = len(preferred_fonts["sans-serif"])
+        worst = preferred_fonts["sans-serif"][-1]
+        expected = 0.1 * (sans_count - 1) / sans_count
+        self.assertAlmostEqual(score_family(["sans-serif"], worst), expected)
+        near_best = preferred_fonts["sans-serif"][1]
+        expected = 0.1 * 1 / sans_count
+        self.assertAlmostEqual(
+            score_family(["sans-serif"], near_best), expected
+        )
+
+        # misses
+        self.assertEqual(score_family(["Times"], "Arial"), 1.0)
+        self.assertEqual(score_family(["serif"], "Arial"), 1.0)
+
+    def test_score_size(self):
+        # exact matches
+        self.assertEqual(score_size(12.0, 12.0, default=24.0), 0.0)
+        self.assertEqual(score_size("12.0", 12.0, default=24.0), 0.0)
+        self.assertEqual(score_size(12.0, "12.0", default=24.0), 0.0)
+
+        # scaled exact matches
+        self.assertEqual(score_size(12.0, "scalable", default=24.0), 0.0)
+        self.assertEqual(score_size("medium", 24.0, default=24.0), 0.0)
+        self.assertEqual(score_size("larger", 24.0, default=20.0), 0.0)
+
+        # fuzzy matches
+        self.assertAlmostEqual(score_size(12.0, 19.2, default=12.0), 0.1)
+        self.assertAlmostEqual(score_size(12.0, 48.0, default=12.0), 0.5)
+        self.assertAlmostEqual(score_size("medium", 48.0, default=12.0), 0.5)
+        self.assertAlmostEqual(score_size("larger", 60.0, default=20.0), 0.5)
+
+        # misses
+        self.assertEqual(score_size(8.0, 80.0, default=12.0), 1.0)
+        self.assertEqual(score_size(24.0, "doesn't matter", default=12.0), 1.0)
+
+    def test_score_stretch(self):
+        # exact matches
+        self.assertEqual(score_stretch(500, 500), 0.0)
+        self.assertEqual(score_stretch("normal", 500), 0.0)
+        self.assertEqual(score_stretch(500, "normal"), 0.0)
+
+        # fuzzy matches
+        self.assertEqual(score_stretch("condensed", "semi-condensed"), 0.1)
+        self.assertEqual(
+            score_stretch("ultra-condensed", "ultra-expanded"), 0.8
+        )
+
+        # miss
+        self.assertEqual(score_stretch(0, 1000), 1.0)
+
+    def test_score_style(self):
+        # exact matches
+        self.assertEqual(score_style("italic", "italic"), 0.0)
+        self.assertEqual(score_style("oblique", "oblique"), 0.0)
+
+        # fuzzy matches
+        self.assertEqual(score_style("italic", "oblique"), 0.1)
+        self.assertEqual(score_style("oblique", "italic"), 0.1)
+
+        # miss
+        self.assertEqual(score_style("zany", "wacky"), 1.0)
+
+    def test_score_variant(self):
+        # exact matches
+        self.assertEqual(score_variant("normal", "normal"), 0.0)
+        self.assertEqual(score_variant("small-cap", "small-cap"), 0.0)
+
+        # horseshoes and hand grenades, but not this function
+
+        # miss
+        self.assertEqual(score_variant("laden", "unladen"), 1.0)
+
+    def test_score_weight(self):
+        # exact matches
+        self.assertEqual(score_weight(500, 500), 0.0)
+        self.assertEqual(score_weight("500", 500), 0.0)
+        self.assertEqual(score_weight(500, "500"), 0.0)
+        self.assertEqual(score_weight("medium", 500), 0.0)
+        self.assertEqual(score_weight(500, "medium"), 0.0)
+
+        # fuzzy match
+        self.assertEqual(score_weight(400, 500), 0.1)
+
+        # miss
+        self.assertEqual(score_weight(0, 1000), 1.0)


### PR DESCRIPTION
Ok, I'm pretty sure that along with #700, I'm really done breaking things out of `kiva.fonttools.font_manager`. The next PR is the big one.

This PR moves the font scoring methods to their own module and covers them _liberally_ with tests. A bug in `score_size` was fixed (trying to call a `dict` instance).

The font scoring methods are used by `FontManager.findfont` to compare `FontEntry` instances with `FontProperties` instances to determine their similarity.