### PR TITLE
Add new on_drag_leave Enum trait to DragTool

### DIFF
--- a/enable/tests/test_drag_tool.py
+++ b/enable/tests/test_drag_tool.py
@@ -8,6 +8,7 @@
 #
 # Thanks for using Enthought open source!
 import unittest
+import warnings
 
 from traits.api import Int
 
@@ -74,7 +75,9 @@ class DragToolTestCase(EnableTestAssistant, unittest.TestCase):
         tool = self.tool
         tool.end_drag_on_leave = True
         tool._drag_state = "dragging"  # force dragging state
-        event = self.mouse_leave(interactor=tool, x=0, y=0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            event = self.mouse_leave(interactor=tool, x=0, y=0)
         self.assertEqual(tool.canceled, 1)
         self.assertEqual(tool._drag_state, "nondrag")
         self.assertTrue(event.handled)
@@ -116,7 +119,9 @@ class DragToolTestCase(EnableTestAssistant, unittest.TestCase):
         tool.end_drag_on_leave = True
         tool.on_drag_leave = 'end'
         tool._drag_state = "dragging"  # force dragging state
-        event = self.mouse_leave(interactor=tool, x=0, y=0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            event = self.mouse_leave(interactor=tool, x=0, y=0)
 
         # end_drag_on_leave should be handled like normal
         self.assertEqual(tool.canceled, 1)

--- a/enable/tests/test_drag_tool.py
+++ b/enable/tests/test_drag_tool.py
@@ -75,8 +75,7 @@ class DragToolTestCase(EnableTestAssistant, unittest.TestCase):
         tool = self.tool
         tool.end_drag_on_leave = True
         tool._drag_state = "dragging"  # force dragging state
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
+        with self.assertWarns(DeprecationWarning):
             event = self.mouse_leave(interactor=tool, x=0, y=0)
         self.assertEqual(tool.canceled, 1)
         self.assertEqual(tool._drag_state, "nondrag")
@@ -119,8 +118,7 @@ class DragToolTestCase(EnableTestAssistant, unittest.TestCase):
         tool.end_drag_on_leave = True
         tool.on_drag_leave = 'end'
         tool._drag_state = "dragging"  # force dragging state
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
+        with self.assertWarns(DeprecationWarning):
             event = self.mouse_leave(interactor=tool, x=0, y=0)
 
         # end_drag_on_leave should be handled like normal

--- a/enable/tools/drag_tool.py
+++ b/enable/tools/drag_tool.py
@@ -24,13 +24,11 @@ class DragTool(BaseTool):
     # The mouse button used for this drag operation.
     drag_button = Enum("left", "right")
 
-    # Cancel the drag operation if the mouse leaves the associated component?
-    cancel_drag_on_leave = Bool(False)
-
-    # End the drag operation if the mouse leaves the associated component?
+    # Do nothing, cancel or end the drag operation if the mouse leaves the
+    # associated component?
     # NOTE: This behavior depends on "mouse_leave" events, which in general
     # are not fired when `capture_mouse` is True (default).
-    end_drag_on_leave = Bool(False)
+    on_drag_leave = Enum(None, 'cancel', 'end')
 
     # These keys, if pressed during drag, cause the drag operation to reset.
     cancel_keys = List(Str, ["Esc"])
@@ -46,7 +44,7 @@ class DragTool(BaseTool):
     # Whether or not to capture the mouse during the drag operation. In effect,
     # this routes mouse events back to this tool for dispatching, rather than
     # allowing the event to be handled by the window. This may have effects
-    # surrounding "mouse_leave" events: see note on `end_drag_on_leave` flag.
+    # surrounding "mouse_leave" events: see note on `on_drag_leave` flag.
     capture_mouse = Bool(True)
 
     # ------------------------------------------------------------------------
@@ -101,7 +99,7 @@ class DragTool(BaseTool):
         """ Called when the drag is cancelled.
 
         A drag is usually cancelled by receiving a mouse_leave event when
-        end_drag_on_leave is True, or by the user pressing any of the
+        on_drag_leave is 'cancel', or by the user pressing any of the
         **cancel_keys**.
         """
         pass
@@ -208,9 +206,9 @@ class DragTool(BaseTool):
         return False
 
     def _drag_mouse_leave(self, event):
-        if self.cancel_drag_on_leave and self._drag_state == "dragging":
+        if self.on_drag_leave == "cancel" and self._drag_state == "dragging":
             return self._cancel_drag(event)
-        elif self.end_drag_on_leave and self._drag_state == "dragging":
+        elif self.on_drag_leave == "end" and self._drag_state == "dragging":
             return self._end_drag(event)
         return False
 

--- a/enable/tools/drag_tool.py
+++ b/enable/tools/drag_tool.py
@@ -9,7 +9,6 @@
 # Thanks for using Enthought open source!
 """ Defines the base DragTool class.
 """
-import inspect
 import warnings
 
 # Enthought library imports
@@ -116,6 +115,9 @@ class DragTool(BaseTool):
 
     def drag_end(self, event):
         """ Called when a mouse event causes the drag operation to end.
+
+        A drag is ended when a user releases the mouse, or by receiving a 
+        mouse_leave event when on_drag_leave is 'end'.
         """
         pass
 
@@ -219,9 +221,8 @@ class DragTool(BaseTool):
         if self.end_drag_on_leave:
             # raise deprecation warning
             msg = ("end_drag_on_leave is now deprecated as its name was "
-                  "misleading. It triggers a drag_cancel not drag_end on "
-                  "leave. Use new on_drag_end Enum trait instead.")
-            frame = inspect.currentframe().f_back
+                   "misleading. It triggers a drag_cancel not drag_end on "
+                   "leave. Use new on_drag_end Enum trait instead.")
             warnings.warn(
                 msg,
                 category=DeprecationWarning,

--- a/enable/tools/drag_tool.py
+++ b/enable/tools/drag_tool.py
@@ -9,6 +9,9 @@
 # Thanks for using Enthought open source!
 """ Defines the base DragTool class.
 """
+import inspect
+import warnings
+
 # Enthought library imports
 from enable.base_tool import BaseTool, KeySpec
 from traits.api import Bool, Enum, List, Property, Str, Tuple, cached_property
@@ -23,6 +26,13 @@ class DragTool(BaseTool):
 
     # The mouse button used for this drag operation.
     drag_button = Enum("left", "right")
+
+    # Deprecated; on_drag_leave is the new, more flexible / intuitive means for
+    # providing this functionality
+    # Cancel the drag operation if the mouse leaves the associated component?
+    # NOTE: This behavior depends on "mouse_leave" events, which in general
+    # are not fired when `capture_mouse` is True (default).
+    end_drag_on_leave = Bool(False)
 
     # Do nothing, cancel or end the drag operation if the mouse leaves the
     # associated component?
@@ -99,8 +109,8 @@ class DragTool(BaseTool):
         """ Called when the drag is cancelled.
 
         A drag is usually cancelled by receiving a mouse_leave event when
-        on_drag_leave is 'cancel', or by the user pressing any of the
-        **cancel_keys**.
+        end_drag_on_leave is True, or on_drag_leave is 'cancel', or by the user
+        pressing any of the **cancel_keys**.
         """
         pass
 
@@ -140,7 +150,7 @@ class DragTool(BaseTool):
         self._drag_state = "nondrag"
         outcome = self.drag_cancel(event)
         self._mouse_down_received = False
-        if event.window.mouse_owner == self:
+        if event.window.mouse_owner is self:
             event.window.set_mouse_owner(None)
         return outcome
 
@@ -148,7 +158,7 @@ class DragTool(BaseTool):
         self._drag_state = "nondrag"
         outcome = self.drag_end(event)
         self._mouse_down_received = False
-        if event.window.mouse_owner == self:
+        if event.window.mouse_owner is self:
             event.window.set_mouse_owner(None)
         return outcome
 
@@ -206,6 +216,20 @@ class DragTool(BaseTool):
         return False
 
     def _drag_mouse_leave(self, event):
+        if self.end_drag_on_leave:
+            # raise deprecation warning
+            msg = ("end_drag_on_leave is now deprecated as its name was "
+                  "misleading. It triggers a drag_cancel not drag_end on "
+                  "leave. Use new on_drag_end Enum trait instead.")
+            frame = inspect.currentframe().f_back
+            warnings.warn(
+                msg,
+                category=DeprecationWarning,
+            )
+            if self._drag_state == "dragging":
+                return self._cancel_drag(event)
+            return False
+
         if self.on_drag_leave == "cancel" and self._drag_state == "dragging":
             return self._cancel_drag(event)
         elif self.on_drag_leave == "end" and self._drag_state == "dragging":


### PR DESCRIPTION
fixes #551 

It seems like this fix is going to require a change in behavior and may potentially "break" existing code.

Currently the `end_drag_on_leave` flag does not actually lead to a drag being "ended" on a mouse leave.  Instead it is canceled.  My thoughts were to either add a `cancel_drag_on_leave` trait to do what `end_drag_on_leave` currently does (ie cancel the drag) and change `end_drag_on_leave` to actually end (see first commit). However, this requires one of these having preference over the other if both are True, and in actuality you would only ever want one behavior, so I removed `end_drag_on_leave` and made a new `on_drag_leave` enum trait.

This however is a change in the public api so we need to tread very carefully.  I am unsure what exactly we want to go with here, and thus am leaving this as a WIP for now awaiting further discussion.

I have tested manually using this example https://github.com/enthought/chaco/blob/master/examples/demo/edit_line.py.
I will write unit test(s) once the approach has been decided. CI will fail as I have not yet updated the existing tests.  Opened the PR early so other could see and discuss