### PR TITLE
Allow sending "mouse move" with left/right down with EnableTestAssistant

### DIFF
--- a/enable/testing.py
+++ b/enable/testing.py
@@ -336,11 +336,15 @@ class EnableTestAssistant(KivaTestAssistant):
 
         left_down : boolean, optional
             The mouse is moved while `left` is down. Default value is
-            False.
+            Undefined.
+
+        middle_down : boolean, optional
+            The mouse is moved while `middle` is down. Default value is
+            Undefined.
 
         right_down : boolean, optional
             The mouse is moved while `right` is down. Default value is
-            False.
+            Undefined.
 
         Returns
         -------

--- a/enable/testing.py
+++ b/enable/testing.py
@@ -89,6 +89,7 @@ class EnableTestAssistant(KivaTestAssistant):
                 alt_down=alt_down,
                 control_down=control_down,
                 shift_down=shift_down,
+                left_down=True,
             )
         x, y = points[-1]
         self.mouse_up(

--- a/enable/testing.py
+++ b/enable/testing.py
@@ -302,7 +302,7 @@ class EnableTestAssistant(KivaTestAssistant):
 
     def mouse_move(self, interactor, x, y, window=None, alt_down=False,
                    control_down=False, shift_down=False, left_down=Undefined,
-                   right_down=Undefined):
+                   middle_down=Undefined, right_down=Undefined):
         """ Send a mouse move event to the interactor.
 
         Parameters
@@ -356,6 +356,7 @@ class EnableTestAssistant(KivaTestAssistant):
             control_down=control_down,
             shift_down=shift_down,
             left_down=left_down,
+            middle_down=middle_down,
             right_down=right_down,
         )
         if hasattr(window.get_pointer_position, "return_value"):

--- a/enable/testing.py
+++ b/enable/testing.py
@@ -298,7 +298,8 @@ class EnableTestAssistant(KivaTestAssistant):
         return event
 
     def mouse_move(self, interactor, x, y, window=None, alt_down=False,
-                   control_down=False, shift_down=False):
+                   control_down=False, shift_down=False, left_down=False,
+                   right_down=False):
         """ Send a mouse move event to the interactor.
 
         Parameters
@@ -320,14 +321,22 @@ class EnableTestAssistant(KivaTestAssistant):
             get_pointer_position() or should use a mock for the method.
 
         alt_down : boolean, optional
-            The button is pressed while `alt` is down. Default value is False.
+            The mouse is moved while `alt` is down. Default value is False.
 
         control_down : boolean, optional
-            The button is pressed while `control` is down. Default value is
+            The mouse is moved while `control` is down. Default value is
             False.
 
         shift_down : boolean, optional
-            The button is pressed while `shift` is down. Default value is
+            The mouse is moved while `shift` is down. Default value is
+            False.
+
+        left_down : boolean, optional
+            The mouse is moved while `left` is down. Default value is
+            False.
+
+        right_down : boolean, optional
+            The mouse is moved while `right` is down. Default value is
             False.
 
         Returns
@@ -343,6 +352,8 @@ class EnableTestAssistant(KivaTestAssistant):
             alt_down=alt_down,
             control_down=control_down,
             shift_down=shift_down,
+            left_down=left_down,
+            right_down=right_down,
         )
         if hasattr(window.get_pointer_position, "return_value"):
             # Note: Non-mock windows shouldn't try to get pointer position

--- a/enable/testing.py
+++ b/enable/testing.py
@@ -9,6 +9,8 @@
 # Thanks for using Enthought open source!
 from unittest.mock import Mock
 
+from traits.api import Undefined
+
 from enable.abstract_window import AbstractWindow
 from enable.events import DragEvent, KeyEvent, MouseEvent
 from kiva.testing import KivaTestAssistant
@@ -299,8 +301,8 @@ class EnableTestAssistant(KivaTestAssistant):
         return event
 
     def mouse_move(self, interactor, x, y, window=None, alt_down=False,
-                   control_down=False, shift_down=False, left_down=False,
-                   right_down=False):
+                   control_down=False, shift_down=False, left_down=Undefined,
+                   right_down=Undefined):
         """ Send a mouse move event to the interactor.
 
         Parameters

--- a/enable/tests/test_test_assistant.py
+++ b/enable/tests/test_test_assistant.py
@@ -43,7 +43,6 @@ class TestTestAssistant(unittest.TestCase):
 
         self.assertEqual(event.x, 10)
         self.assertEqual(event.y, 20)
-        # left_down from calling mouse_dwn is carried into mouse move event
         self.assertIs(event.left_down, True)
 
     def test_mouse_dclick(self):

--- a/enable/tests/test_test_assistant.py
+++ b/enable/tests/test_test_assistant.py
@@ -36,6 +36,16 @@ class TestTestAssistant(unittest.TestCase):
         test_assistant.mouse_down(component, x=0, y=0)
         component.normal_left_down.assert_called_once()
 
+    def test_mouse_move_while_down(self):
+        test_assistant = EnableTestAssistant()
+        component = Component(bounds=[100, 200])
+        event = test_assistant.mouse_move(component, 10, 20, left_down=True)
+
+        self.assertEqual(event.x, 10)
+        self.assertEqual(event.y, 20)
+        # left_down from calling mouse_dwn is carried into mouse move event
+        self.assertIs(event.left_down, True)
+
     def test_mouse_dclick(self):
         test_assistant = EnableTestAssistant()
         component = Component(bounds=[100, 200])

--- a/enable/tests/tools/pyface/test_move_command_tool.py
+++ b/enable/tests/tools/pyface/test_move_command_tool.py
@@ -47,13 +47,13 @@ class MoveCommandToolTestCase(unittest.TestCase, EnableTestAssistant,
 
         # start moving the mouse
         mouse_move_event = self.mouse_move(
-            self.component, 145, 145, window=window
+            self.component, 145, 145, window=window, left_down=True
         )
         self.assertTrue(mouse_move_event.handled)
 
         # move the mouse to the final location
         mouse_move_event = self.mouse_move(
-            self.component, 195, 95, window=window
+            self.component, 195, 95, window=window, left_down=True
         )
         self.assertTrue(mouse_move_event.handled)
 
@@ -87,13 +87,13 @@ class MoveCommandToolTestCase(unittest.TestCase, EnableTestAssistant,
 
         # start moving the mouse
         mouse_move_event = self.mouse_move(
-            self.component, 145, 145, window=window
+            self.component, 145, 145, window=window, left_down=True
         )
         self.assertTrue(mouse_move_event.handled)
 
         # move the mouse to the final location
         mouse_move_event = self.mouse_move(
-            self.component, 195, 95, window=window
+            self.component, 195, 95, window=window, left_down=True
         )
         self.assertTrue(mouse_move_event.handled)
 
@@ -121,13 +121,13 @@ class MoveCommandToolTestCase(unittest.TestCase, EnableTestAssistant,
 
         # start moving the mouse
         mouse_move_event = self.mouse_move(
-            self.component, 145, 145, window=window
+            self.component, 145, 145, window=window, left_down=True
         )
         self.assertTrue(mouse_move_event.handled)
 
         # move the mouse to the final location
         mouse_move_event = self.mouse_move(
-            self.component, 195, 95, window=window
+            self.component, 195, 95, window=window, left_down=True
         )
         self.assertTrue(mouse_move_event.handled)
 

--- a/enable/tests/tools/pyface/test_resize_command_tool.py
+++ b/enable/tests/tools/pyface/test_resize_command_tool.py
@@ -48,13 +48,13 @@ class ResizeCommandToolTestCase(unittest.TestCase, EnableTestAssistant,
 
         # start moving the mouse
         mouse_move_event = self.mouse_move(
-            self.component, 145, 145, window=window
+            self.component, 145, 145, window=window, left_down=True
         )
         self.assertTrue(mouse_move_event.handled)
 
         # move the mouse to the final location
         mouse_move_event = self.mouse_move(
-            self.component, 195, 95, window=window
+            self.component, 195, 95, window=window, left_down=True
         )
         self.assertTrue(mouse_move_event.handled)
 
@@ -87,13 +87,13 @@ class ResizeCommandToolTestCase(unittest.TestCase, EnableTestAssistant,
 
         # start moving the mouse
         mouse_move_event = self.mouse_move(
-            self.component, 145, 145, window=window
+            self.component, 145, 145, window=window, left_down=True
         )
         self.assertTrue(mouse_move_event.handled)
 
         # move the mouse to the final location
         mouse_move_event = self.mouse_move(
-            self.component, 195, 95, window=window
+            self.component, 195, 95, window=window, left_down=True
         )
         self.assertTrue(mouse_move_event.handled)
 


### PR DESCRIPTION
fixes #460 

This PR adds `left_down` and `right_down` kwargs to `mouse_move` so that the test assistant can simulate moving the mouse with either the left or right button down.  As mentioned on the issue, there are cases where we expect mouse_move events to have {left/right}_down set to True.  This PR also adds a simple test to check that the traits are set if we call mousee_move with the new kwargs.  Additionally, the `press_move_release` method is updated so that `left_down` is True for the mouse_move generated event itself.