### PR TITLE
Make celiagg a little bit more like kiva.agg

### DIFF
--- a/enable/qt4/celiagg.py
+++ b/enable/qt4/celiagg.py
@@ -21,7 +21,7 @@ class Window(BaseWindow):
     # Keep a buffer around for converting RGBA -> BGRA
     _shuffle_buffer = Array(shape=(None, None, 4), dtype=np.uint8)
 
-    def _create_gc(self, size, pix_format="rgba32"):
+    def _create_gc(self, size, pix_format="bgra32"):
         gc = GraphicsContext(
             (size[0] + 1, size[1] + 1),
             pix_format=pix_format,
@@ -58,7 +58,7 @@ class Window(BaseWindow):
 
         Qt's Format_RGB32 is actually BGR. So, Yeah...
         """
-        src = self._gc.gc.array
+        src = self._gc.bmp_array
         dst = self._shuffle_buffer
         src_fmt = self._gc.pix_format
 


### PR DESCRIPTION
This makes some small changes to the celiagg backend so that a celiagg `GraphicsContext` looks a bit more like a `kiva.agg` `GraphicsContext`. This covers [this comment](https://github.com/enthought/enable/issues/414#issuecomment-737519739)  on #414 by adding a `bmp_array` attribute to celiagg's `GraphicsContext`. Additionally, "bgra32" is now the default pixel format.