### PR TITLE
Set encoding when saving image from SVG backend.

### DIFF
--- a/kiva/svg.py
+++ b/kiva/svg.py
@@ -161,7 +161,7 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
         return self.size[1]
 
     def save(self, filename, file_format=None, pil_options=None):
-        with open(filename, "w") as f:
+        with open(filename, "w", encoding="utf-8") as f:
             ext = os.path.splitext(filename)[1]
             if ext == ".svg":
                 template = xmltemplate


### PR DESCRIPTION
fixes #734 

This PR fixes an issue with the SVG backend where saving to an image when running the enable benchmark was failing with an encoding issue. This was fixed by simply setting the encoding when saving the image.