### PR TITLE
Clarify __init__s which allow `component` as a pos. arg.

### DIFF
--- a/enable/abstract_overlay.py
+++ b/enable/abstract_overlay.py
@@ -58,10 +58,11 @@ class AbstractOverlay(Component):
     # Concrete methods / reimplementations of Component methods
     # ----------------------------------------------------------------------
 
-    def __init__(self, component=None, *args, **kw):
+    # Implement __init__ so `component` trait can be passed as a positional arg
+    def __init__(self, component=None, **kw):
         if component is not None:
-            self.component = component
-        super(AbstractOverlay, self).__init__(*args, **kw)
+            kw["component"] = component
+        super(AbstractOverlay, self).__init__(**kw)
 
     def do_layout(self, size=None, force=False, component=None):
         """ Tells this component to do a layout at a given size.  This differs

--- a/enable/base_tool.py
+++ b/enable/base_tool.py
@@ -170,5 +170,5 @@ class BaseTool(Interactor):
     def deactivate(self, component=None):
         """ Handles this component no longer being the active tool.
         """
-        # Compatibility with new AbstractController interface
+        # Compatibility with [Chaco's] AbstractController interface
         self._deactivate()

--- a/enable/base_tool.py
+++ b/enable/base_tool.py
@@ -123,11 +123,11 @@ class BaseTool(Interactor):
     # Concrete methods
     # ------------------------------------------------------------------------
 
-    def __init__(self, component=None, **kwtraits):
-        if "component" in kwtraits:
-            component = kwtraits["component"]
-        super(BaseTool, self).__init__(**kwtraits)
-        self.component = component
+    # Implement __init__ so `component` trait can be passed as a positional arg
+    def __init__(self, component=None, **traits):
+        if component is not None:
+            traits["component"] = component
+        super(BaseTool, self).__init__(**traits)
 
     def dispatch(self, event, suffix):
         """ Dispatches a mouse event based on the current event state.

--- a/enable/tools/toolbars/viewport_toolbar.py
+++ b/enable/tools/toolbars/viewport_toolbar.py
@@ -44,10 +44,12 @@ class ViewportToolbar(Container, AbstractOverlay):
 
     def __init__(self, component=None, *args, **kw):
         # self.component should be a CanvasViewport
-        self.component = component
+        if component is not None:
+            kw["component"] = component
+        super(ViewportToolbar, self).__init__(**kw)
+
         for buttontype in self.buttons:
             self.add_button(buttontype())
-        super(ViewportToolbar, self).__init__(*args, **kw)
 
     def _do_layout(self, component=None):
         if component is None:

--- a/enable/tools/viewport_zoom_tool.py
+++ b/enable/tools/viewport_zoom_tool.py
@@ -146,11 +146,11 @@ class ViewportZoomTool(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
     _screen_end = Trait(None, None, Tuple)
 
     def __init__(self, component=None, *args, **kw):
-        # Support AbstractController-style constructors so that this can be
-        # handed in the component it will be overlaying in the constructor
-        # without using kwargs.
-        self.component = component
-        super(ViewportZoomTool, self).__init__(*args, **kw)
+        # Support [Chaco's] AbstractController-style constructors which allow
+        # the component as the first positional argument.
+        if component is not None:
+            kw["component"] = component
+        super(ViewportZoomTool, self).__init__(**kw)
         self._reset_state_to_current()
 
         if self.tool_mode == "range":


### PR DESCRIPTION
Fixes #736
Fixes #737
Fixes #739

@corranwebster I see that `ViewportToolbar` and `ViewportZoomTool` also have `component=None` in their `__init__` method signatures.