### PR TITLE
Modify PR workflow for better cache utilization

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -53,6 +53,8 @@ jobs:
         run: edm --config ci/.edm.yaml install -y wheel click coverage
       - name: Install test environment
         if: github.event_name == 'pull_request' || steps.cacheStep.outputs.cache-hit != 'true'
+        env:
+          PIP_CACHE_DIR: ~/.cache/pip
         run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }}
       - name: Run tests
         if: github.event_name == 'pull_request' || steps.cacheStep.outputs.cache-hit != 'true'
@@ -93,6 +95,8 @@ jobs:
         run: edm --config ci/.edm.yaml install -y wheel click coverage
       - name: Install test environment
         if: github.event_name == 'pull_request' || steps.cacheStep.outputs.cache-hit != 'true'
+        env:
+          PIP_CACHE_DIR: ~/.cache/pip
         run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }}
       - name: Run tests
         if: github.event_name == 'pull_request' || steps.cacheStep.outputs.cache-hit != 'true'

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -5,6 +5,7 @@
 name: Test with EDM
 
 # Runs for all Pull Requests and merges to the master branch
+# Jobs run on the master branch will skip steps if the cache is already warm.
 on:
   pull_request:
   push:
@@ -39,11 +40,9 @@ jobs:
       - name: Cache EDM packages
         id: cacheStep
         uses: actions/cache@v2
-        env:
-          cache-name: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
         with:
           path: ~/.cache
-          key: ${{ env.cache-name }}
+          key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
       - name: Setup EDM
         uses: enthought/setup-edm-action@v1
         if: github.event_name == 'pull_request' || steps.cacheStep.outputs.cache-hit != 'true'
@@ -81,11 +80,9 @@ jobs:
       - name: Cache EDM packages
         id: cacheStep
         uses: actions/cache@v2
-        env:
-          cache-name: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
         with:
           path: ~/.cache
-          key: ${{ env.cache-name }}
+          key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
       - name: Setup EDM
         if: github.event_name == 'pull_request' || steps.cacheStep.outputs.cache-hit != 'true'
         uses: enthought/setup-edm-action@v1

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -4,7 +4,12 @@
 
 name: Test with EDM
 
-on: pull_request
+# Runs for all Pull Requests and merges to the master branch
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 env:
   INSTALL_EDM_VERSION: 3.2.1
@@ -32,19 +37,26 @@ jobs:
       - name: Install GL dependencies for Linux
         run: sudo apt-get install libglu1-mesa-dev
       - name: Cache EDM packages
+        id: cacheStep
         uses: actions/cache@v2
+        env:
+          cache-name: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
         with:
           path: ~/.cache
-          key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
+          key: ${{ env.cache-name }}
       - name: Setup EDM
         uses: enthought/setup-edm-action@v1
+        if: github.event_name == 'pull_request' || steps.cacheStep.outputs.cache-hit != 'true'
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install click to the default EDM environment
+        if: github.event_name == 'pull_request' || steps.cacheStep.outputs.cache-hit != 'true'
         run: edm --config ci/.edm.yaml install -y wheel click coverage
       - name: Install test environment
+        if: github.event_name == 'pull_request' || steps.cacheStep.outputs.cache-hit != 'true'
         run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }}
       - name: Run tests
+        if: github.event_name == 'pull_request' || steps.cacheStep.outputs.cache-hit != 'true'
         uses: GabrielBB/xvfb-action@v1
         with:
           # kiva agg requires at least 15-bit color depth.
@@ -67,17 +79,24 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache EDM packages
+        id: cacheStep
         uses: actions/cache@v2
+        env:
+          cache-name: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
         with:
           path: ~/.cache
-          key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
+          key: ${{ env.cache-name }}
       - name: Setup EDM
+        if: github.event_name == 'pull_request' || steps.cacheStep.outputs.cache-hit != 'true'
         uses: enthought/setup-edm-action@v1
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install click to the default EDM environment
+        if: github.event_name == 'pull_request' || steps.cacheStep.outputs.cache-hit != 'true'
         run: edm --config ci/.edm.yaml install -y wheel click coverage
       - name: Install test environment
+        if: github.event_name == 'pull_request' || steps.cacheStep.outputs.cache-hit != 'true'
         run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }}
       - name: Run tests
+        if: github.event_name == 'pull_request' || steps.cacheStep.outputs.cache-hit != 'true'
         run: edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }}


### PR DESCRIPTION
Resolves #601

This is actually pretty ugly... See [this discussion](https://github.community/t/how-to-perform-an-early-clean-exit-of-a-job/17531) to understand why we have an `if:` added to everything after the `actions/cache` runs.

Basically, we need to run CI jobs on the master branch each time the hash key changes. Otherwise PRs will always build a cache on their first run of the workflow, because no cache was found for the feature branch or the master branch. The Actions documentation explains it [here](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)