### PR TITLE
Use EDM 3.2.3 instead of 3.2.1

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -7,7 +7,7 @@ name: Test with EDM
 on: pull_request
 
 env:
-  INSTALL_EDM_VERSION: 3.2.1
+  INSTALL_EDM_VERSION: 3.2.3
 
 jobs:
 


### PR DESCRIPTION
This PR updates EDM from version 3.2.1 to 3.2.3 (the latest).