### PR TITLE
Catch the exception thrown by AGG

### DIFF
--- a/kiva/agg/src/graphics_context.i
+++ b/kiva/agg/src/graphics_context.i
@@ -722,10 +722,26 @@ namespace kiva {
 
             void clear_clip_path();
             void clear(agg24::rgba& value=_clear_color);
+
+            // Exception handler for cell block overflow
+            %exception {
+                try
+                {
+                    $action
+                }
+                catch (const std::overflow_error& exn)
+                {
+                    PyErr_SetString(PyExc_OverflowError, exn.what());
+                    return NULL;
+                }
+            }
+
             void stroke_path();
             void fill_path();
             void eof_fill_path();
             void draw_path(draw_mode_e mode=FILL_STROKE);
+
+            %exception;  // clear exception handlers
 
             void draw_rect(double rect[4],
                            draw_mode_e mode=FILL_STROKE);

--- a/kiva/agg/src/graphics_context.i
+++ b/kiva/agg/src/graphics_context.i
@@ -732,6 +732,13 @@ namespace kiva {
                 catch (const std::overflow_error& exn)
                 {
                     PyErr_SetString(PyExc_OverflowError, exn.what());
+
+                    // XXX: This is a hacky, but `arg1` is the graphics context
+                    // object in the SWIG-generated code.
+                    // The path needs to be cleared by drawing calls and this
+                    // guarantees that it is even if an exception is thrown.
+                    (arg1)->begin_path();
+
                     return NULL;
                 }
             }

--- a/kiva/tests/drawing_tester.py
+++ b/kiva/tests/drawing_tester.py
@@ -184,8 +184,8 @@ class DrawingImageTester(DrawingTester):
 
         filename = "{0}.png".format(self.filename)
         self.gc.save(filename)
-        image = Image.open(filename)
-        dpi = image.info['dpi']
+        with Image.open(filename) as image:
+            dpi = image.info['dpi']
         return dpi[0]
 
     @contextlib.contextmanager

--- a/kiva/tests/test_agg_drawing.py
+++ b/kiva/tests/test_agg_drawing.py
@@ -46,3 +46,27 @@ class TestAggDrawing(DrawingImageTester, unittest.TestCase):
         with open(filename, 'wb') as fp:
             fp.write(stream)
         self.assertImageSavedWithContent(filename)
+
+    def test_rasterizer_cell_overflow(self):
+        def genpoints(num):
+            arr = np.empty((num, 2))
+            arr[::2, 0] = np.linspace(0, 99, num=arr[::2, 0].shape[0])
+            arr[::2, 1] = 0.0
+            arr[1::2, 0] = np.linspace(1, 100, num=arr[1::2, 0].shape[0])
+            arr[1::2, 1] = 100.0
+            return arr
+
+        # This many points definitely generates more than 2^22 cells
+        count = 10000
+        points = genpoints(count)
+        self.gc.lines(points)
+        with self.assertRaises(OverflowError):
+            self.gc.stroke_path()
+
+        self.gc.begin_path()
+
+        # This many points is OK
+        count = 9000
+        points = genpoints(count)
+        self.gc.lines(points)
+        self.gc.stroke_path()

--- a/kiva/tests/test_agg_drawing.py
+++ b/kiva/tests/test_agg_drawing.py
@@ -63,8 +63,6 @@ class TestAggDrawing(DrawingImageTester, unittest.TestCase):
         with self.assertRaises(OverflowError):
             self.gc.stroke_path()
 
-        self.gc.begin_path()
-
         # This many points is OK
         count = 9000
         points = genpoints(count)


### PR DESCRIPTION
Resolves #750

This is basically the same change as celiagg/celiagg#97, but with SWIG exception handling instead of Cython. A test has also been added to show that the error is now recoverable.

(Celiagg keeps its rasterizer instance around between draw calls, so it needed an additional change to the AGG code which is not needed here)