### PR TITLE
Add a way to profile calls to GraphicsContext

### DIFF
--- a/kiva/_profiler.py
+++ b/kiva/_profiler.py
@@ -14,9 +14,15 @@ import time
 def instrument_graphics_context(klass):
     """ Add profiling wrappers to all public methods of a class.
 
-    This is intended to be used on implementers of AbstractGraphicsContext, but
-    it could just as easily wrap other classes (although the "draw time" text
-    in the profile log will look odd)
+    This is intended to be used on implementers of `AbstractGraphicsContext`,
+    but it could just as easily wrap other classes (although the "draw time"
+    text in the profile log will look odd)
+
+    To use, call this function on a `GraphicsContext` class object once at the
+    module level. Then in a method which wraps a whole draw cycle (like
+    `paintEvent` in Qt), add a call to the `dump_profile_and_reset` method
+    after the drawing is done. Each paint will append profiling results to the
+    output file.
     """
     # Wrap all the public methods
     for name in dir(klass):

--- a/kiva/profiler.py
+++ b/kiva/profiler.py
@@ -1,0 +1,61 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+import functools
+import time
+
+
+def instrument_graphics_context(klass):
+    """ Add profiling wrappers to all public methods of a class.
+
+    This is intended to be used on implementers of AbstractGraphicsContext, but
+    it could just as easily wrap other classes (although the "draw time" text
+    in the profile log will look odd)
+    """
+    # Wrap all the public methods
+    for name in dir(klass):
+        if name.startswith('_'):
+            continue
+
+        func = getattr(klass, name)
+        if callable(func):
+            setattr(klass, name, _get_wrapped(func))
+
+    # Add the dumper method and the counter storage
+    klass.dump_profile_and_reset = _dump_profile_and_reset
+    klass._perf_counters = {}
+
+
+def _dump_profile_and_reset(self, filename):
+    """ Dump collected profiling results from an instrumented GC
+    """
+    data = [(k, v[0], v[1]) for k, v in self._perf_counters.items()]
+    self._perf_counters = {}
+    data.sort(key=lambda x: x[2], reverse=True)
+    total = functools.reduce(lambda x, y: x + y[2], data, 0.0) * 1000
+    fns = '\n'.join([f'{d[0]} {d[1]} {d[2]*1000:0.5f}' for d in data])
+
+    text = f'\n*********\nTotal draw time: {total:0.5f}\n{fns}\n'
+    # NOTE: We open the file in append mode
+    with open(filename, "a+") as fp:
+        fp.write(text)
+
+
+def _get_wrapped(func):
+    """ Wrap a single GC method
+    """
+    def wrapped_method(self, *args, **kwargs):
+        key = func.__name__
+        calls, duration = self._perf_counters.setdefault(key, (0, 0.0))
+        start = time.perf_counter()
+        retval = func(self, *args, **kwargs)
+        delta = time.perf_counter() - start
+        self._perf_counters[key] = (calls+1, duration+delta)
+        return retval
+    return wrapped_method


### PR DESCRIPTION
This has been sitting around in my local repository for a bit, so I decided to clean it up and push it.

With this function `instrument_graphics_context`, it's possible to add a little bit of code to the `Window` implementation of a backend so that it outputs profiler results for every paint of a `ComponentEditor`. So far I've used it to get a feel for drawing speed in a complex application and also to help speed up text rendering changes in celiagg.

Here's an example of the changes needed to profile the `qt.celiagg` toolkit+backend. 
```diff
index 73fc9057..acc654a3 100644
--- a/enable/qt4/celiagg.py
+++ b/enable/qt4/celiagg.py
@@ -10,12 +10,15 @@
 
 import numpy as np
 from kiva.celiagg import CompiledPath, GraphicsContext  # noqa
+from kiva.profiler import instrument_graphics_context
 from pyface.qt import QtCore, QtGui
 from traits.api import Array
 
 from .base_window import BaseWindow
 from .scrollbar import NativeScrollBar  # noqa
 
+instrument_graphics_context(GraphicsContext)
+
 
 class Window(BaseWindow):
     # Keep a buffer around for converting RGBA -> BGRA
@@ -52,6 +55,9 @@ class Window(BaseWindow):
         painter = QtGui.QPainter(self.control)
         painter.drawImage(rect, image)
 
+        # Write a profile for the paint
+        self._gc.dump_profile_and_reset('gc_profile.txt')
+
     def _shuffle_copy(self):
         """ Convert from RGBA -> BGRA.
         Supported source formats are: rgb24, rgba32, & bgra32
```