### PR TITLE
Don't try to import from enable in setup.py

### DIFF
--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -10,7 +10,10 @@
 """ A multi-platform object drawing library.
     Part of the Enable project of the Enthought Tool Suite.
 """
-from ._version import full_version as __version__
+try:
+    from enable._version import full_version as __version__
+except ImportError:
+    __version__ = "not-built"
 
 __requires__ = [
     "numpy", "pillow", "traits>=6.2.0", "traitsui", "pyface", "fonttools"


### PR DESCRIPTION
Resolves #486

I didn't do this exactly like TraitsUI (as suggested in the issue). Instead, I opted to use `runpy.run_path` everywhere.