### PR TITLE
Fix warnings from the documentation build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,14 @@ copyright = '2005-2021, Enthought'
 # other places throughout the built documents.
 base_path = os.path.dirname(__file__)
 version_file = os.path.join(base_path, '..', '..', 'enable', '_version.py')
-version = release = runpy.run_path(version_file)['full_version']
+if os.path.isfile(version_file):
+    version = release = runpy.run_path(version_file)['full_version']
+else:
+    try:
+        from enable._version import full_version as version
+        release = version
+    except ImportError:
+        raise RuntimeError('Enable must be installed before building docs!')
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/source/kiva/drawing_details.rst
+++ b/docs/source/kiva/drawing_details.rst
@@ -223,14 +223,14 @@ Drawing text in kiva is accomplished via a few methods on
 measuring the size of rendered text, and drawing the text.
 
 Font Selection
-++++++++++++++
+--------------
 
 Font selection for use with the text rendering capabilities of
 :class:`GraphicsContext` can be accomplished in a few different ways depending
 on the amount of control needed by your drawing code.
 
 Simplest: ``select_font``
--------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The simplest form of font selection is the
 :py:meth:`GraphicsContext.select_font` method. The tradeoff for this simplicity
@@ -249,7 +249,7 @@ up with.
 
 
 The ``KivaFont`` trait and ``set_font``
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you're already doing your drawing within an application using traits, you can
 use the :class:`kiva.trait_defs.api.KivaFont` trait.
@@ -263,7 +263,7 @@ use the :class:`kiva.trait_defs.api.KivaFont` trait.
 
 
 ``Font`` objects
-----------------
+~~~~~~~~~~~~~~~~
 
 If you don't want to rely on the font description parsing in ``KivaFont``, you
 can also manually construct a :class:`kiva.fonttools.font.Font` instance. Once
@@ -289,7 +289,7 @@ desired font.
 
 
 Measuring Text
-++++++++++++++
+--------------
 
 Before drawing text, one often wants to know what the bounding rectangle of the
 rendered text will be so that the text can be positioned correctly. To do this,
@@ -316,7 +316,7 @@ number in the situation where glyphs hang below the baseline. In any case,
 
 
 Drawing Text
-++++++++++++
+------------
 
 Text can be drawn in a graphics context with the
 :py:meth:`GraphicsContext.show_text` and

--- a/docs/source/kiva/font_manager.rst
+++ b/docs/source/kiva/font_manager.rst
@@ -11,8 +11,9 @@ This document aims to describe the structure of the code circa version 5.1.0.
 Overview
 --------
 The basic function of :class:`FontManager` is to provide a :py:meth:`findfont`
-method which can be called by the :class:`~.Font` class to resolve a font name
-or font file location on the system where the code is running.
+method which can be called by the :class:`Font <kiva.fonttools.font.Font>`
+class to resolve a font name or font file location on the system where the code
+is running.
 
 To accomplish this, it:
 
@@ -21,9 +22,9 @@ To accomplish this, it:
 2. Examines all the font files identified in the first step and extracts their
    metadata using `fonttools <https://fonttools.readthedocs.io/en/latest/>`_.
    [:py:func:`create_font_database`]
-3. The :class:`FontManager` is then ready to be used. :class:`~.Font` instances
-   call :py:meth:`findfont` on the global :class:`FontManager` singleton as
-   needed.
+3. The :class:`FontManager` is then ready to be used.
+   :class:`Font <kiva.fonttools.font.Font>` instances call :py:meth:`findfont`
+   on the global :class:`FontManager` singleton as needed.
 
 Because scanning a system for available fonts is quite an expensive operation,
 :class:`FontManager` stores a

--- a/enable/api.py
+++ b/enable/api.py
@@ -132,7 +132,7 @@ Enable Components
 - :class:`~.BaseTool`
 - :class:`~.KeySpec`
 - :class:`~.AbstractOverlay`
-- :class:`~.Canvas`
+- :class:`Canvas <enable.canvas.Canvas>`
 - :class:`~.Component`
 - :class:`~.Container`
 - :class:`~.CoordinateBox`
@@ -154,7 +154,7 @@ Drawing Primitives
 ==================
 
 - :class:`~.Annotater`
-- :class:`~.Box`
+- :class:`Box <enable.primitives.box.Box>`
 - :class:`~.Line`
 - :class:`~.Polygon`
 
@@ -162,11 +162,11 @@ Brushes
 =======
 
 - :class:`~.Brush`
-- :class:`~.ColorBrush`
+- :class:`ColorBrush <enable.brush.ColorBrush>`
 - :class:`~.ColorStop`
 - :class:`~.Gradient`
-- :class:`~.LinearGradientBrush`
-- :class:`~.RadialGradientBrush`
+- :class:`LinearGradientBrush <enable.brush.LinearGradientBrush>`
+- :class:`RadialGradientBrush <enable.brush.RadialGradientBrush>`
 
 """
 

--- a/enable/drawing/api.py
+++ b/enable/drawing/api.py
@@ -16,7 +16,7 @@
 - :class:`~.DragSegment`
 - :class:`~.DragBox`
 - :class:`~.DrawingTool`
-- :class:`~.Button`
+- :class:`Button <enable.drawing.drawing_canvas.Button>`
 - :class:`~.ToolbarButton`
 - :class:`~.DrawingCanvasToolbar`
 - :class:`~.DrawingCanvas`

--- a/enable/layout/layout_helpers.py
+++ b/enable/layout/layout_helpers.py
@@ -52,8 +52,8 @@ def expand_constraints(component, constraints):
     list. This is a generator function which yields the flattened stream
     of constraints.
 
-    Paramters
-    ---------
+    Parameters
+    ----------
     component : Constrainable
         The constrainable component with which the constraints are
         associated. This will be passed to the .get_constraints()

--- a/enable/primitives/api.py
+++ b/enable/primitives/api.py
@@ -10,7 +10,7 @@
 """ API for enable.primitives subpackage.
 
 - :class:`~.Annotater`
-- :class:`~.Box`
+- :class:`Box <enable.primitives.box.Box>`
 - :class:`~.Line`
 - :class:`~.Polygon`
 - :class:`~.Shape`

--- a/enable/trait_defs/rgba_color_trait.py
+++ b/enable/trait_defs/rgba_color_trait.py
@@ -105,8 +105,7 @@ def RGBAColorFunc(*args, **metadata):
     """ Returns a trait whose value must be a GUI toolkit-specific RGBA-based
     color.
 
-    Description
-    -----------
+    Description:
     For wxPython, the returned trait accepts any of the following values:
 
     * A tuple of the form (*r*, *g*, *b*, *a*), in which *r*, *g*, *b*, and *a*
@@ -116,8 +115,7 @@ def RGBAColorFunc(*args, **metadata):
       alpha (transparency) value, *RR* is the red value, *GG* is the green
       value, and *BB* is the blue value
 
-    Default Value
-    -------------
+    Default Value:
     For wxPython, (1.0, 1.0, 1.0, 1.0) (that is, opaque white)
     """
     tmp_trait = Trait(

--- a/kiva/api.py
+++ b/kiva/api.py
@@ -102,8 +102,8 @@ This can be used by Kiva backends to implement :py:meth:`draw_marker_at_points`
 Fonts
 =====
 
-- :class:`~.Font`
-- :func:`~.add_application_fonts`
+- :class:`Font <kiva.fonttools.font.Font>`
+- :func:`add_application_fonts <kiva.fonttools.app_font.add_application_fonts>`
 
 Font Constants
 --------------

--- a/kiva/trait_defs/kiva_font_trait.py
+++ b/kiva/trait_defs/kiva_font_trait.py
@@ -167,16 +167,14 @@ else:
 def KivaFontFunc(*args, **metadata):
     """ Returns a trait whose value must be a GUI toolkit-specific font.
 
-    Description
-    -----------
+    Description:
     For wxPython, the returned trait accepts any of the following:
 
     * an kiva.fonttools.Font instance
     * a string describing the font, including one or more of the font family,
       size, weight, style, and typeface name.
 
-    Default Value
-    -------------
+    Default Value:
     For wxPython, 'Arial 10'
     """
     return KivaFontTrait(*args, **metadata)


### PR DESCRIPTION
Doing a full build of the documentation with autodoc generation was spitting out some warnings, so I squashed them.