### PR TITLE
Fix listeners hooked up using observe but unhooked using on_trait_change

### DIFF
--- a/enable/scrolled.py
+++ b/enable/scrolled.py
@@ -487,13 +487,13 @@ class Scrolled(Container):
     def _release_sb(self, sb):
         if sb is not None:
             if sb == self._vsb:
-                sb.on_trait_change(
+                sb.observe(
                     self._handle_vertical_scroll,
                     "scroll_position",
                     remove=True,
                 )
             if sb == self._hsb:
-                sb.on_trait_change(
+                sb.observe(
                     self._handle_horizontal_scroll,
                     "scroll_position",
                     remove=True,


### PR DESCRIPTION
This PR fixes two listeners that are hooked up using `observe` but are then unhooked using `on_trait_change`.