### PR TITLE
Add support for font fallback lookups

### DIFF
--- a/kiva/fonttools/_database.py
+++ b/kiva/fonttools/_database.py
@@ -59,6 +59,7 @@ class FontDatabase:
         self._entries = {ent for ent in entries if isinstance(ent, FontEntry)}
         self._family_map = self._build_family_map(self._entries)
         self._file_map = self._build_file_map(self._entries)
+        self._language_map = self._build_language_map(self._entries)
 
     def add_fonts(self, entries):
         """ Add more :class`FontEntry` instances to the database.
@@ -71,6 +72,8 @@ class FontDatabase:
             self._entries.add(entry)
             self._family_map.setdefault(entry.family, []).append(entry)
             self._file_map.setdefault(entry.fname, []).append(entry)
+            for lang in entry.languages:
+                self._language_map.setdefault(lang, []).append(entry)
 
     def fonts_for_directory(self, directory):
         """ Returns all fonts whose file is in a directory.
@@ -101,6 +104,11 @@ class FontDatabase:
         # Yes, self._entries is a set. Consumers should only expect an iterable
         return self._entries
 
+    def fonts_for_language(self, language):
+        """ Returns all fonts which support a particular language.
+        """
+        return self._language_map.get(language, [])
+
     def __len__(self):
         return len(self._entries)
 
@@ -117,5 +125,14 @@ class FontDatabase:
         ret = {}
         for entry in entries:
             ret.setdefault(entry.fname, []).append(entry)
+
+        return ret
+
+    @staticmethod
+    def _build_language_map(entries):
+        ret = {}
+        for entry in entries:
+            for lang in entry.languages:
+                ret.setdefault(lang, []).append(entry)
 
         return ret

--- a/kiva/fonttools/font.py
+++ b/kiva/fonttools/font.py
@@ -112,18 +112,38 @@ class Font(object):
         self.underline = underline
         self.encoding = encoding
 
-    def findfont(self):
+    def findfont(self, language=None):
         """ Returns the file name and face index of the font that most closely
         matches our font properties.
+
+        Parameters
+        ----------
+        language : str [optional]
+            If provided, attempt to find a font which supports ``language``.
         """
         query = self._make_font_query()
+        if language is not None:
+            spec = default_font_manager().find_fallback(query, language)
+            if spec is not None:
+                return spec
+
         return default_font_manager().findfont(query)
 
-    def findfontname(self):
+    def findfontname(self, language=None):
         """ Returns the name of the font that most closely matches our font
-        properties
+        properties.
+
+        Parameters
+        ----------
+        language : str [optional]
+            If provided, attempt to find a font which supports ``language``.
         """
         query = self._make_font_query()
+        if language is not None:
+            spec = default_font_manager().find_fallback(query, language)
+            if spec is not None:
+                return spec.family
+
         return query.get_name()
 
     def _make_font_query(self):

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -118,10 +118,10 @@ class FontManager:
         self.afm_db = create_font_database(afmfiles, fontext="afm")
         self.default_font["afm"] = None
 
-        self.ttf_lookup_cache = {}
-        self.afm_lookup_cache = {}
-        self.ttf_fallback_cache = {}
-        self.afm_fallback_cache = {}
+        self._ttf_lookup_cache = {}
+        self._afm_lookup_cache = {}
+        self._ttf_fallback_cache = {}
+        self._afm_fallback_cache = {}
 
     def update_fonts(self, paths):
         """ Update the font lists with new font files.
@@ -146,10 +146,10 @@ class FontManager:
         the :class:`FontQuery` *query*, and has support for ``language``.
         """
         if fontext == "afm":
-            font_cache = self.afm_fallback_cache
+            font_cache = self._afm_fallback_cache
             font_db = self.afm_db
         else:
-            font_cache = self.ttf_fallback_cache
+            font_cache = self._ttf_fallback_cache
             font_db = self.ttf_db
 
         key = hash(language + str(query))
@@ -182,7 +182,7 @@ class FontManager:
             warnings.warn(msg.format(query, language))
             return None
 
-        result = FontSpec(
+        result = _FontSpec(
             best_font.fname,
             best_font.family,
             best_font.face_index,
@@ -225,13 +225,13 @@ class FontManager:
             logger.debug("findfont returning %s", fname)
             # It's not at all clear where a `FontQuery` instance with
             # `fname` already set would come from. Assume face_index == 0.
-            return FontSpec(fname, query.family[0])
+            return _FontSpec(fname, query.family[0])
 
         if fontext == "afm":
-            font_cache = self.afm_lookup_cache
+            font_cache = self._afm_lookup_cache
             font_db = self.afm_db
         else:
-            font_cache = self.ttf_lookup_cache
+            font_cache = self._ttf_lookup_cache
             font_db = self.ttf_db
 
         if directory is None:
@@ -294,7 +294,7 @@ class FontManager:
                     UserWarning,
                 )
                 # Assume this is never a .ttc font, so 0 is ok for face index.
-                result = FontSpec(self.default_font[fontext], "Default")
+                result = _FontSpec(self.default_font[fontext], "Default")
         else:
             logger.debug(
                 "findfont: Matching %s to %s (%s[%d]) with score of %f",
@@ -304,7 +304,7 @@ class FontManager:
                 best_font.face_index,
                 best_score,
             )
-            result = FontSpec(
+            result = _FontSpec(
                 best_font.fname,
                 best_font.family,
                 best_font.face_index,
@@ -329,7 +329,7 @@ class FontManager:
         return result
 
 
-class FontSpec(object):
+class _FontSpec(object):
     """ An object to represent the return value of findfont() and
     find_fallback().
     """
@@ -345,7 +345,7 @@ class FontSpec(object):
 
     def __repr__(self):
         args = f"{self.filename}, {self.family}, face_index={self.face_index}"
-        return f"FontSpec({args})"
+        return f"_FontSpec({args})"
 
 
 # ---------------------------------------------------------------------------

--- a/kiva/fonttools/tests/test_font.py
+++ b/kiva/fonttools/tests/test_font.py
@@ -54,6 +54,18 @@ class TestFont(unittest.TestCase):
         # Name should be nonempty.
         self.assertGreater(len(name), 0)
 
+    def test_find_font_for_language(self):
+        font = Font(face_name="")
+
+        # Nearly every font supports Latin script, so this shouldn't fail
+        spec = font.findfont(language="Latin")
+        self.assertTrue(os.path.exists(spec.filename))
+
+        # There will be warnings for an unknown language
+        with self.assertWarns(UserWarning):
+            spec = font.findfont(language="FancyTalk")
+        self.assertTrue(os.path.exists(spec.filename))
+
     def test_str_to_font(self):
         # Simple
         from_str = str_to_font("modern 10")


### PR DESCRIPTION
This is a big part of #762: Give a way to lookup a font which "matches" a query and supports a particular language. Builds on top of the work done in #763