### PR TITLE
Handle preferred size computation when container isnt resizable

### DIFF
--- a/enable/stacked_layout.py
+++ b/enable/stacked_layout.py
@@ -10,8 +10,6 @@
 """ Routines for stacked layout of components in a container
 """
 
-# TODO: stolen from Chaco PlotContainers, should change their classes to use
-
 
 def stacked_preferred_size(container, components=None):
     """ Returns the size (width,height) that is preferred for this component.

--- a/enable/stacked_layout.py
+++ b/enable/stacked_layout.py
@@ -20,6 +20,10 @@ def stacked_preferred_size(container, components=None):
         container._cached_preferred_size = container.fixed_preferred_size
         return container.fixed_preferred_size
 
+    if container.resizable == "":
+        container._cached_preferred_size = container.outer_bounds[:]
+        return container.outer_bounds
+
     if components is None:
         components = container.components
 


### PR DESCRIPTION
Ref ~https://github.com/enthought/chaco/pull/673/~. https://github.com/enthought/chaco/pull/673 got closed in favor of https://github.com/enthought/chaco/pull/674

It looks like these lines were commented out from the original commit when this code was added to enable in https://github.com/enthought/enable/commit/75fb3ac9e478751992865d98d8f27791e7a988df
and subsequently, the commented out code was removed in the PR #466