### PR TITLE
Fix alignment trait on "HStackedContainer"

### DIFF
--- a/enable/stacked_container.py
+++ b/enable/stacked_container.py
@@ -52,10 +52,10 @@ class HStackedContainer(StackedContainer):
     # Overrides StackedPlotContainer.
     stack_index = 0
 
-    # VPlotContainer attributes
+    # HPlotContainer attributes
 
-    # The horizontal alignment of objects that don't span the full width.
-    halign = Enum("bottom", "top", "center")
+    # The vertical alignment of objects that don't span the full height.
+    valign = Enum("bottom", "top", "center")
 
     # The order in which components in the plot container are laid out.
     stack_order = Enum("left_to_right", "right_to_left")
@@ -67,9 +67,9 @@ class HStackedContainer(StackedContainer):
             components = self.components
         else:
             components = self.components[::-1]
-        if self.halign == "bottom":
+        if self.valign == "bottom":
             align = "min"
-        elif self.halign == "center":
+        elif self.valign == "center":
             align = "center"
         else:
             align = "max"


### PR DESCRIPTION
This PR fixes the alignment trait and `_do_layout` method on the `HStackedContainer`. This might have been a simple copy-paste mistake. This was discovered when working on https://github.com/enthought/chaco/pull/674.

This PR simply renames the `halign` triat with `valign` and updates its usage in the `_do_layout` method. See related https://github.com/enthought/chaco/blob/a88b7b96a981dc96ad9f0d615c21d699f93851d1/chaco/plot_containers.py#L289-L324, which is possibly where the `HStackedContainer` class originated.