### PR TITLE
Update custom marker as scale_ctm expects floats

### DIFF
--- a/enable/markers.py
+++ b/enable/markers.py
@@ -421,7 +421,7 @@ class CustomMarker(AbstractMarker):
     def _add_to_path(self, path, size):
         if self.scale_path:
             path.save_ctm()
-            path.scale_ctm(size, size)
+            path.scale_ctm(float(size), float(size))
         path.add_path(path)
         if self.scale_path:
             path.restore_ctm()
@@ -435,7 +435,7 @@ class CustomMarker(AbstractMarker):
         """
         if self.scale_path:
             newpath = CompiledPath()
-            newpath.scale_ctm(size, size)
+            newpath.scale_ctm(float(size), float(size))
             newpath.add_path(self.path)
             return newpath
         else:

--- a/enable/tests/test_markers.py
+++ b/enable/tests/test_markers.py
@@ -1,0 +1,48 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+import unittest
+
+import numpy as np
+
+from enable.compiled_path import CompiledPath
+from enable.kiva_graphics_context import GraphicsContext
+from enable.markers import CustomMarker
+
+
+class TestCustomMarker(unittest.TestCase):
+
+    def test_add_to_path(self):
+        path = CompiledPath()
+        path.begin_path()
+        path.move_to(-5, -5)
+        path.line_to(-5, 5)
+        path.line_to(5, 5)
+        path.line_to(5, -5)
+        path.line_to(-5, -5)
+
+        marker = CustomMarker(path=path)
+
+        gc = GraphicsContext((50, 50))
+        # should not fail
+        marker.add_to_path(gc.get_empty_path(), np.int64(0))
+
+    def test_get_compiled_path(self):
+        path = CompiledPath()
+        path.begin_path()
+        path.move_to(-5, -5)
+        path.line_to(-5, 5)
+        path.line_to(5, 5)
+        path.line_to(5, -5)
+        path.line_to(-5, -5)
+
+        marker = CustomMarker(path=path)
+
+        # should not fail
+        marker.get_compiled_path(np.int64(0))

--- a/enable/tests/test_markers.py
+++ b/enable/tests/test_markers.py
@@ -18,6 +18,7 @@ from enable.markers import CustomMarker
 
 class TestCustomMarker(unittest.TestCase):
 
+    # regression test for enthought/chaco#232
     def test_add_to_path(self):
         path = CompiledPath()
         path.begin_path()
@@ -33,6 +34,7 @@ class TestCustomMarker(unittest.TestCase):
         # should not fail
         marker.add_to_path(gc.get_empty_path(), np.int64(0))
 
+    # regression test for enthought/chaco#232
     def test_get_compiled_path(self):
         path = CompiledPath()
         path.begin_path()

--- a/enable/tests/test_markers.py
+++ b/enable/tests/test_markers.py
@@ -14,8 +14,10 @@ import numpy as np
 from enable.compiled_path import CompiledPath
 from enable.kiva_graphics_context import GraphicsContext
 from enable.markers import CustomMarker
+from enable.tests._testing import skip_if_not_qt
 
 
+@skip_if_not_qt
 class TestCustomMarker(unittest.TestCase):
 
     # regression test for enthought/chaco#232


### PR DESCRIPTION
Needed to close https://github.com/enthought/chaco/issues/232

Down in agg the method that gets called wants double inputs.  If an int gets passed it things break.  Changing the inputs to floats seems to resolve the problem.