### PR TITLE
Remove deprecated "str_to_font" and "points_in_polygon" functions.

### DIFF
--- a/enable/api.py
+++ b/enable/api.py
@@ -187,7 +187,6 @@ from .base import (
     TOP_RIGHT,
     BOTTOM_LEFT,
     BOTTOM_RIGHT,
-    str_to_font,
     empty_rectangle,
     intersect_bounds,
 )

--- a/enable/base.py
+++ b/enable/base.py
@@ -76,53 +76,6 @@ font_styles = {"italic": ITALIC}
 font_weights = {"bold": BOLD}
 font_noise = ["pt", "point", "family"]
 
-
-def str_to_font(object, name, value):
-    """ Converts a (somewhat) free-form string into a valid Font object.
-    """
-    import warnings
-
-    warnings.warn(
-        ("str_to_font should not be imported from enable.api. Use the version "
-         "from kiva.fonttools instead."),
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    try:
-        point_size = 10
-        family = SWISS
-        style = NORMAL
-        weight = NORMAL
-        underline = 0
-        face_name = []
-        for word in value.split():
-            lword = word.lower()
-            if lword in font_families:
-                family = font_families[lword]
-            elif lword in font_styles:
-                style = font_styles[lword]
-            elif lword in font_weights:
-                weight = font_weights[lword]
-            elif lword == "underline":
-                underline = 1
-            elif lword not in font_noise:
-                try:
-                    point_size = int(lword)
-                except Exception:
-                    face_name.append(word)
-        return Font(
-            face_name=" ".join(face_name),
-            size=point_size,
-            family=family,
-            weight=weight,
-            style=style,
-            underline=underline,
-        )
-    except Exception:
-        pass
-    raise TraitError(object, name, "a font descriptor string", repr(value))
-
-
 # Pick a default font that should work on all platforms.
 default_font_name = "modern 10"
 default_font = Font(family=MODERN, size=10)

--- a/kiva/agg/__init__.py
+++ b/kiva/agg/__init__.py
@@ -57,22 +57,3 @@ except ImportError as ex:
     warnings.warn("Error initializing Agg: %s" % ex, Warning, 2)
 
     GraphicsContextSystem = None
-
-
-def points_in_polygon(pts, poly_pts, use_winding=False):
-    """Keep this function around for old code, but warn anyone who calls it.
-    """
-    import inspect
-    import warnings
-    from kiva.api import points_in_polygon as new_points_in_polygon
-
-    msg = "points_in_polygon() has moved to kiva.api"
-    frame = inspect.currentframe().f_back
-    warnings.warn_explicit(
-        msg,
-        category=DeprecationWarning,
-        filename=inspect.getfile(frame.f_code),
-        lineno=frame.f_lineno,
-    )
-
-    new_points_in_polygon(pts, poly_pts, use_winding=use_winding)

--- a/kiva/tests/test_points_in_polygon.py
+++ b/kiva/tests/test_points_in_polygon.py
@@ -8,27 +8,13 @@
 #
 # Thanks for using Enthought open source!
 import unittest
-import warnings
 
 from numpy import allclose, array, zeros
 
-from kiva.agg import points_in_polygon as points_in_polygon_deprecated
 from kiva.api import points_in_polygon
 
 
 class TestPointsInPolygon(unittest.TestCase):
-    def test_deprecated_import(self):
-        polygon = array(((0.0, 0.0), (10.0, 0.0), (0.0, 10.0)))
-        points = array(((5.0, 5.0),))
-
-        with warnings.catch_warnings(record=True) as collector:
-            warnings.simplefilter("always")
-            points_in_polygon_deprecated(points, polygon)
-
-            assert len(collector) == 1
-            warn = collector[0]
-            assert issubclass(warn.category, DeprecationWarning)
-
     def test_empty_points_in_polygon(self):
         polygon = array(((0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)))
         points = zeros((0, 2))


### PR DESCRIPTION
This PR removes the deprecated `str_to_font` from `enable.api` and `points_in_polygon` from `kiva.agg`.