### PR TITLE
Update super usage in potentially buggy cases

### DIFF
--- a/enable/canvas.py
+++ b/enable/canvas.py
@@ -159,7 +159,7 @@ class Canvas(Container):
                     gc.move_to(x, 0)
                     gc.line_to(x2, 0)
                     gc.stroke_path()
-        super(Container, self)._draw_underlay(gc, view_bounds, mode)
+        super(Canvas, self)._draw_underlay(gc, view_bounds, mode)
 
     def _transform_view_bounds(self, view_bounds):
         # Overload the parent class's implementation to skip visibility test

--- a/enable/canvas.py
+++ b/enable/canvas.py
@@ -159,7 +159,7 @@ class Canvas(Container):
                     gc.move_to(x, 0)
                     gc.line_to(x2, 0)
                     gc.stroke_path()
-        super(Canvas, self)._draw_underlay(gc, view_bounds, mode)
+        super()._draw_underlay(gc, view_bounds, mode)
 
     def _transform_view_bounds(self, view_bounds):
         # Overload the parent class's implementation to skip visibility test

--- a/enable/tests/tools/test_hover_tool.py
+++ b/enable/tests/tools/test_hover_tool.py
@@ -53,7 +53,7 @@ LOCATIONS = [
 class HoverToolTestCase(EnableTestAssistant, GuiTestAssistant,
                         unittest.TestCase):
     def setUp(self):
-        super(HoverToolTestCase, self).setUp()
+        GuiTestAssistant.setUp(self)
         self.component = Component(
             position=[LOWER_BOUND, LOWER_BOUND], bounds=[SIZE, SIZE]
         )

--- a/enable/text_grid.py
+++ b/enable/text_grid.py
@@ -94,7 +94,7 @@ class TextGrid(Component):
     # ------------------------------------------------------------------------
 
     def __init__(self, **kwtraits):
-        super(Component, self).__init__(**kwtraits)
+        super(TextGrid, self).__init__(**kwtraits)
         self.selected_cells = []
 
     # ------------------------------------------------------------------------

--- a/enable/text_grid.py
+++ b/enable/text_grid.py
@@ -94,7 +94,7 @@ class TextGrid(Component):
     # ------------------------------------------------------------------------
 
     def __init__(self, **kwtraits):
-        super(TextGrid, self).__init__(**kwtraits)
+        super().__init__(**kwtraits)
         self.selected_cells = []
 
     # ------------------------------------------------------------------------


### PR DESCRIPTION
See related #789 

This PR updates a few calls to `super` that were potentially buggy. In these two cases for example, we were calling `super(A, self)` from class `B` where `B` inherits from `A`. We first update the `super` calls to use the correct class argument - and then update the `super` call to remove the arguments altogether.