### PR TITLE
Skip markers tests if not using agg

### DIFF
--- a/enable/tests/test_markers.py
+++ b/enable/tests/test_markers.py
@@ -11,13 +11,18 @@ import unittest
 
 import numpy as np
 
+from traits.etsconfig.api import ETSConfig
+
 from enable.compiled_path import CompiledPath
 from enable.kiva_graphics_context import GraphicsContext
 from enable.markers import CustomMarker
-from enable.tests._testing import skip_if_not_qt
 
 
-@skip_if_not_qt
+# change this from 'image' to 'oldagg' when image getts switched to use celiagg
+# see enthought/enable#414 step 4
+@unittest.skipIf(
+    ETSConfig.kiva_backend != 'image', "Test is Kiva Agg specific."
+)
 class TestCustomMarker(unittest.TestCase):
 
     # regression test for enthought/chaco#232

--- a/enable/tests/test_markers.py
+++ b/enable/tests/test_markers.py
@@ -18,7 +18,7 @@ from enable.kiva_graphics_context import GraphicsContext
 from enable.markers import CustomMarker
 
 
-# change this from 'image' to 'oldagg' when image getts switched to use celiagg
+# change this from 'image' to 'oldagg' when image gets switched to use celiagg
 # see enthought/enable#414 step 4
 @unittest.skipIf(
     ETSConfig.kiva_backend != 'image', "Test is Kiva Agg specific."


### PR DESCRIPTION
Previously the test was skipped when not on qt.  This worked because it avoided the scenario of using quartz as tthe default backend on wx.  See:
https://github.com/enthought/traits/blob/249d64813b633390616af4e57ceb19a553c250ef/traits/etsconfig/etsconfig.py#L313-L320

Realistically, these tests are specific to the old agg. see comment: https://github.com/enthought/enable/pull/782#issuecomment-825074184

Note we can't yet skip if not "oldagg" because oldagg isn't actually used yet.  Doing so the test would no longer be run.  I left a comment to replace 'image' with 'oldagg' in the `skipIf` once `image` uses celiagg.