### PR TITLE
Document EnableTestAssistant

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -219,4 +219,5 @@ latex_documents = [
 intersphinx_mapping = {
     'traits': ('http://docs.enthought.com/traits', None),
     'pyface': ('http://docs.enthought.com/pyface', None),
+    "python": ("https://docs.python.org/3", None),
 }

--- a/docs/source/enable/testing.rst
+++ b/docs/source/enable/testing.rst
@@ -1,0 +1,24 @@
+=========================
+Testing Enable Components
+=========================
+
+In order to assist in the testing of enable :class:`~.Component` and
+:class:`~.Interactor` objects, Enable provides the
+:class:`~.EnableTestAssistant` class. This is a mixin class intended to work
+along side :class:`python:unittest.TestCase`. Often times in order to
+effectively test an enable component and its supported interactivity, one needs
+to simulate user interactions such as moving/clicking/dragging the mouse, using
+keys, etc. This involves manually creating the corresponding events with
+appropriate state and dispatching them appropriately. This can be rather
+tedious and :class:`~.EnableTestAssistant` provides a number of helper methods
+to greatly simplify the process, making tests both faster/cleaner to write and
+easier to read. Furthermore, in test scenarios it is ofen unnecessary to launch
+the full application window and as such :class:`~.EnableTestAssistant` provides
+a :meth:`~.create_mock_window` method for simply
+mocking out the window itself. This allows for specifically testing the
+component of interest alone, as is the goal in a unit test. Please see the api
+docs (by clicking :class:`~.EnableTestAssistant`) for the full list of methods
+available.
+
+.. Todo: Add example test. I was going to refer to an existing test, but none
+   of the exissting tests seem very helpful for documentation purposes

--- a/docs/source/enable/testing.rst
+++ b/docs/source/enable/testing.rst
@@ -17,11 +17,8 @@ the full application window and as such :class:`~.EnableTestAssistant` provides
 a :meth:`~.create_mock_window` method for simply
 mocking out the window itself. This allows for specifically testing the
 component of interest alone, as is the goal in a unit test. Please see the api
-docs (by clicking :class:`~.EnableTestAssistant`) for the full list of methods
+docs (:class:`~.EnableTestAssistant`) for the full list of methods
 available.
-
-.. Todo: Add example test. I was going to refer to an existing test, but none
-   of the exissting tests seem very helpful for documentation purposes
 
 The following is a Dummy TestCase to showcase some basics of the
 :class:`~.EnableTestAssistant` functionality.  It is not testing things

--- a/docs/source/enable/testing.rst
+++ b/docs/source/enable/testing.rst
@@ -22,3 +22,40 @@ available.
 
 .. Todo: Add example test. I was going to refer to an existing test, but none
    of the exissting tests seem very helpful for documentation purposes
+
+The following is a Dummy TestCase to showcase some basics of the
+:class:`~.EnableTestAssistant` functionality.  It is not testing things
+users would likely want to test, but it showcases the capabilities / usefulness
+of the test assistant.
+
+::
+
+    import unittest
+    from unittest import mock
+
+    from enable.component import Component
+    from enable.testing import EnableTestAssistant, _MockWindow
+
+    class TestExample(unittest.TestCase):
+        def test_example(self):
+            test_assistant = EnableTestAssistant()
+            component = Component(bounds=[100, 200])
+
+            event = test_assistant.mouse_move(component, 10, 20)
+            self.assertEqual(event.x, 10)
+            self.assertEqual(event.y, 20)
+            self.assertIsInstance(event.window, _MockWindow)
+            self.assertFalse(event.alt_down)
+            self.assertFalse(event.control_down)
+            self.assertFalse(event.shift_down)
+            self.assertFalse(sevent.left_down)
+            self.assertEqual(event.window.get_pointer_position(), (10, 20))
+
+            component.normal_left_down = mock.Mock()
+            test_assistant.mouse_down(component, x=0, y=0)
+            component.normal_left_down.assert_called_once()
+
+            event = test_assistant.mouse_move(component, 20, 30, left_down=True)
+            self.assertEqual(event.x, 20)
+            self.assertEqual(event.y, 30)
+            self.assertIs(event.left_down, True)

--- a/docs/source/enable/testing.rst
+++ b/docs/source/enable/testing.rst
@@ -20,18 +20,15 @@ component of interest alone, as is the goal in a unit test. Please see the api
 docs (:class:`~.EnableTestAssistant`) for the full list of methods
 available.
 
-The following is a Dummy TestCase to showcase some basics of the
-:class:`~.EnableTestAssistant` functionality.  It is not testing things
-users would likely want to test, but it showcases the capabilities / usefulness
-of the test assistant.
+Here is an example
 
 ::
 
     import unittest
     from unittest import mock
 
-    from enable.component import Component
-    from enable.testing import EnableTestAssistant, _MockWindow
+    from enable.api import Component
+    from enable.testing import EnableTestAssistant
 
     class TestExample(unittest.TestCase):
         def test_example(self):
@@ -41,7 +38,6 @@ of the test assistant.
             event = test_assistant.mouse_move(component, 10, 20)
             self.assertEqual(event.x, 10)
             self.assertEqual(event.y, 20)
-            self.assertIsInstance(event.window, _MockWindow)
             self.assertFalse(event.alt_down)
             self.assertFalse(event.control_down)
             self.assertFalse(event.shift_down)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,6 +31,7 @@ Enable
   enable/constraints_layout
   enable/traits
   enable/toolkit_selection
+  enable/testing
 
   credits
 


### PR DESCRIPTION
closes #774 

This PR adds a brief section to the documentation describing the `EnableTestAssistant`.  This is effectively meant as a starting point, and we will likely want to expand this documentation going forward.  In any case, just mentioning its existence in the docs is a significant improvement over it being missing entirely.

A next step (in a future PR) would be to add an example test using the test assistant to showcase how to use it and some of the useful features.  I was going to simply link to an existing test, but none of them felt really suited to be a good example for the documentation IMO.  I think it will be useful to write a test specifically for the docs, possibly writing a test for on of the existing examples.