### PR TITLE
remove __getstate__ methods and use transient metadata

### DIFF
--- a/enable/abstract_window.py
+++ b/enable/abstract_window.py
@@ -102,8 +102,6 @@ class AbstractWindow(HasTraits):
     # When exceeding this, the entire window is marked damaged to save memory
     MAX_DAMAGED_REGIONS = 100
 
-    _scroll_origin = Tuple()
-
     # -------------------------------------------------------------------------
     #  Abstract methods that must be implemented by concrete subclasses
     # -------------------------------------------------------------------------
@@ -207,7 +205,6 @@ class AbstractWindow(HasTraits):
     # ------------------------------------------------------------------------
 
     def __init__(self, **traits):
-        self._scroll_origin = (0.0, 0.0)
         self._update_region = None
         self._gc = None
         self._pointer_owner = None

--- a/enable/abstract_window.py
+++ b/enable/abstract_window.py
@@ -42,27 +42,27 @@ class AbstractWindow(HasTraits):
 
     # A reference to the nested component that has focus.  This is part of the
     # manual mechanism for determining keyboard focus.
-    focus_owner = Instance(Interactor)
+    focus_owner = Instance(Interactor, transient=True)
 
     # If set, this is the component to which all mouse events are passed,
     # bypassing the normal event propagation mechanism.
-    mouse_owner = Instance(Interactor)
+    mouse_owner = Instance(Interactor, transient=True)
 
     # The transform to apply to mouse event positions to put them into the
     # relative coordinates of the mouse_owner component.
-    mouse_owner_transform = Any()
+    mouse_owner_transform = Any(transient=True)
 
     # When a component captures the mouse, it can optionally store a
     # dispatch order for events (until it releases the mouse).
-    mouse_owner_dispatch_history = Trait(None, None, List)
+    mouse_owner_dispatch_history = Trait(None, None, List, transient=True)
 
     # A scaling constant applied to any GraphicsContext used for drawing the
     # window's component.
-    base_pixel_scale = Float(1.0)
+    base_pixel_scale = Float(1.0, transient=True)
 
     # When True, allow `base_pixel_scale` to be greater than 1 if the
     # underlying toolkit supports it.
-    high_resolution = Bool(True)
+    high_resolution = Bool(True, transient=True)
 
     # The background window of the window.  The entire window first gets
     # painted with this color before the component gets to draw.
@@ -73,9 +73,9 @@ class AbstractWindow(HasTraits):
     # backwards compatibility but should not be used in new code.
     bg_color = Alias("bgcolor")
 
-    alt_pressed = Bool(False)
-    ctrl_pressed = Bool(False)
-    shift_pressed = Bool(False)
+    alt_pressed = Bool(False, transient=True)
+    ctrl_pressed = Bool(False, transient=True)
+    shift_pressed = Bool(False, transient=True)
 
     # A container that gets drawn after & on top of the main component, and
     # which receives events first.
@@ -86,21 +86,23 @@ class AbstractWindow(HasTraits):
     resized = Event
 
     # Whether to enable damaged region handling
-    use_damaged_region = Bool(False)
+    use_damaged_region = Bool(False, transient=True)
 
     # The previous component that handled an event.  Used to generate
     # mouse_enter and mouse_leave events.  Right now this can only be
     # None, self.component, or self.overlay.
-    _prev_event_handler = Instance(Component)
+    _prev_event_handler = Instance(Component, transient=True)
 
     # (dx, dy) integer size of the Window.
-    _size = Trait(None, Tuple)
+    _size = Trait(None, Tuple, transient=True)
 
     # The regions to update upon redraw
     _update_region = Any
 
     # When exceeding this, the entire window is marked damaged to save memory
     MAX_DAMAGED_REGIONS = 100
+
+    _scroll_origin = Tuple()
 
     # -------------------------------------------------------------------------
     #  Abstract methods that must be implemented by concrete subclasses
@@ -551,13 +553,6 @@ class AbstractWindow(HasTraits):
         self._window_paint(event)
 
         self._update_region = []
-
-    def __getstate__(self):
-        attribs = ("component", "bgcolor", "overlay", "_scroll_origin")
-        state = {}
-        for attrib in attribs:
-            state[attrib] = getattr(self, attrib)
-        return state
 
     # -------------------------------------------------------------------------
     # Wire up the mouse event handlers

--- a/enable/abstract_window.py
+++ b/enable/abstract_window.py
@@ -92,7 +92,7 @@ class AbstractWindow(HasTraits):
     _size = Trait(None, Tuple, transient=True)
 
     # The regions to update upon redraw
-    _update_region = Any
+    _update_region = Any(transient=True)
 
     # When exceeding this, the entire window is marked damaged to save memory
     MAX_DAMAGED_REGIONS = 100

--- a/enable/scrolled.py
+++ b/enable/scrolled.py
@@ -79,7 +79,7 @@ class Scrolled(Container):
 
     # An alternate vertical scroll bar to control this Scrolled, instead of the
     # default one that lives outside the scrolled region.
-    alternate_vsb = Instance(Component)
+    alternate_vsb = Instance(Component, transient=True)
 
     # The size of the left border space
     leftborder = Float(0)
@@ -92,8 +92,8 @@ class Scrolled(Container):
     # Private traits
     # -------------------------------------------------------------------------
 
-    _vsb = Instance(NativeScrollBar)
-    _hsb = Instance(NativeScrollBar)
+    _vsb = Instance(NativeScrollBar, transient=True)
+    _hsb = Instance(NativeScrollBar, transient=True)
 
     # Stores the last horizontal and vertical scroll positions to avoid
     # multiple updates in update_from_viewport()
@@ -606,14 +606,3 @@ class Scrolled(Container):
             elif self._vsb:
                 self._vsb._mouse_wheel_changed(event)
             event.handled = True
-
-    # -------------------------------------------------------------------------
-    # Persistence
-    # -------------------------------------------------------------------------
-
-    def __getstate__(self):
-        state = super().__getstate__()
-        for key in ["alternate_vsb", "_vsb", "_hsb"]:
-            if key in state:
-                del state[key]
-        return state


### PR DESCRIPTION
closes #795 

This PR simply replaces the use of `__getstate__` methods by setting `transient` metadata on relevant traits.  `HasTraits` handles this with its own `__getstate__` method appropriately.

EDIT: It also removes the unused `_scroll_origin` attribute on `AbstractWindow`.