### PR TITLE
Replace use of deprecated GetItemPyData with its new replacement GetItemData

### DIFF
--- a/enable/savage/compliance/viewer.py
+++ b/enable/savage/compliance/viewer.py
@@ -271,7 +271,7 @@ class ViewFrame(wx.Frame):
 
     def OnTreeSelectionChange(self, evt):
         item = self.tree.GetSelection()
-        element = self.tree.GetItemPyData(item)
+        element = self.tree.GetItemData(item)
         if element is None:
             return
         path = self.document.paths[element]


### PR DESCRIPTION
closes #802 

As mentioned on the issue, this PR follows migration described here: https://wxpython.org/Phoenix/docs/html/MigrationGuide.html#wx-treectrl