### PR TITLE
Add pyproject.toml to specify cython and numpy as build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["cython", "numpy", "setuptools", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
 requires = ["cython", "numpy", "setuptools", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
1st part of #769 
This PR simply includes a `pyproject.toml` file specifying `cython` and `numpy` as build dependencies.  

I ran `python setup.py sdist`, created a fresh environment and ran `pip install enable-5.1.0.dev280.tar.gz`

previously I saw:
```
$ pip install enable-5.1.0.dev280.tar.gz
Processing ./enable-5.1.0.dev280.tar.gz
    ERROR: Command errored out with exit status 1:
     command: /Users/aayres/.edm/envs/dumb/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-req-build-e1pybp8n/setup.py'"'"'; __file__='"'"'/private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-req-build-e1pybp8n/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-req-build-e1pybp8n/pip-egg-info
         cwd: /private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-req-build-e1pybp8n/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-req-build-e1pybp8n/setup.py", line 19, in <module>
        from Cython.Distutils import build_ext
    ModuleNotFoundError: No module named 'Cython'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

Now I see the far more long winded:
<details>

```
$ pip install enable-5.1.0.dev280.tar.gz
Processing ./enable-5.1.0.dev280.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Collecting pillow
  Using cached Pillow-8.2.0-cp36-cp36m-macosx_10_10_x86_64.whl (2.8 MB)
Collecting traits>=6.2.0
  Using cached traits-6.2.0-cp36-cp36m-macosx_10_14_x86_64.whl (5.0 MB)
Processing /Users/aayres/Library/Caches/pip/wheels/2c/12/3a/69b89979464e90a5e5882f66c79d2908434c0c75014e91eee4/traitsui-7.1.1-py3-none-any.whl
Collecting numpy
  Using cached numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl (15.6 MB)
Processing /Users/aayres/Library/Caches/pip/wheels/c9/24/5a/1231d8847ac0ff839cc5b7810612b851318a6d2c66a891c031/pyface-7.3.0-py3-none-any.whl
Collecting fonttools
  Downloading fonttools-4.22.1-py3-none-any.whl (850 kB)
     |████████████████████████████████| 850 kB 4.3 MB/s 
Collecting importlib-metadata
  Downloading importlib_metadata-4.0.1-py3-none-any.whl (16 kB)
Collecting importlib-resources>=1.1.0
  Using cached importlib_resources-5.1.2-py3-none-any.whl (25 kB)
Collecting zipp>=0.5
  Using cached zipp-3.4.1-py3-none-any.whl (5.2 kB)
Collecting typing-extensions>=3.6.4; python_version < "3.8"
  Using cached typing_extensions-3.7.4.3-py3-none-any.whl (22 kB)
Building wheels for collected packages: enable
  Building wheel for enable (PEP 517) ... error
  ERROR: Command errored out with exit status 1:
   command: /Users/aayres/.edm/envs/dumb/bin/python3 /Users/aayres/.edm/envs/dumb/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py build_wheel /var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/tmpzpkq73cv
       cwd: /private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-req-build-2xplf939
  Complete output (343 lines):
  running bdist_wheel
  running build
  running build_ext
  skipping 'kiva/_cython_speedups.cpp' Cython extension (up-to-date)
  skipping 'kiva/_marker_renderer.cpp' Cython extension (up-to-date)
  cythoning kiva/quartz/ABCGI.pyx to kiva/quartz/ABCGI.c
  cythoning kiva/quartz/CTFont.pyx to kiva/quartz/CTFont.c
  /private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-build-env-jpy36s2d/overlay/lib/python3.6/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-req-build-2xplf939/kiva/quartz/ABCGI.pyx
    tree = Parsing.p_module(s, pxd, full_module_name)
  warning: kiva/quartz/CoreFoundation.pxi:17:4: 'CFStringEncoding' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:57:4: 'CFURLPathStyle' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:165:4: 'CFNumberType_' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:36:4: 'CGBlendMode' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:54:4: 'CGLineCap' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:59:4: 'CGLineJoin' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:64:4: 'CGPathDrawingMode' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:71:4: 'CGRectEdge' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:161:4: 'CGColorRenderingIntent' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:173:4: 'FakedEnums' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:240:4: 'CGTextDrawingMode' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:250:4: 'CGTextEncoding' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:334:4: 'CGImageAlphaInfo' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:344:4: 'CGInterpolationQuality' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:451:4: 'CGPathElementType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:12:4: 'OSStatus' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:15:8: 'noErr' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:18:8: 'kCFStringEncodingMacRoman' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:19:8: 'kCFStringEncodingWindowsLatin1' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:20:8: 'kCFStringEncodingISOLatin1' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:21:8: 'kCFStringEncodingNextStepLatin' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:22:8: 'kCFStringEncodingASCII' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:23:8: 'kCFStringEncodingUnicode' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:24:8: 'kCFStringEncodingUTF8' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:25:8: 'kCFStringEncodingNonLossyASCII' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:27:4: 'UInt8' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:28:4: 'UniChar' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:29:4: 'bool' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:30:4: 'Boolean' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:32:4: 'CFTypeRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:33:4: 'CFTypeID' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:37:4: 'CFStringRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:39:4: 'CFIndex' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:40:4: 'CFNumberType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:42:4: 'CFHashCode' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:58:8: 'kCFURLPOSIXPathStyle' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:59:8: 'kCFURLHFSPathStyle' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:60:8: 'kCFURLWindowsPathStyle' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:62:4: 'CFURLRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:76:26: 'kCFTypeArrayCallBacks' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:78:4: 'CFArrayRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:79:4: 'CFMutableArrayRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:120:4: 'CFDictionaryRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:121:4: 'CFMutableDictionaryRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:138:34: 'kCFTypeDictionaryKeyCallBacks' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:139:36: 'kCFTypeDictionaryValueCallBacks' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:151:4: 'CFAttributedStringRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:152:4: 'CFMutableAttributedStringRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:163:4: 'CFNumberRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:166:8: 'kCFNumberSInt8Type' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:167:8: 'kCFNumberSInt16Type' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:168:8: 'kCFNumberSInt32Type' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:169:8: 'kCFNumberSInt64Type' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:170:8: 'kCFNumberFloat32Type' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:171:8: 'kCFNumberFloat64Type' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:172:8: 'kCFNumberCharType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:173:8: 'kCFNumberShortType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:174:8: 'kCFNumberIntType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:175:8: 'kCFNumberLongType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:176:8: 'kCFNumberLongLongType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:177:8: 'kCFNumberFloatType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:178:8: 'kCFNumberDoubleType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:179:8: 'kCFNumberCFIndexType' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:12:4: 'CGContextRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:14:4: 'CGFloat' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:37:8: 'kCGBlendModeNormal' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:38:8: 'kCGBlendModeMultiply' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:39:8: 'kCGBlendModeScreen' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:40:8: 'kCGBlendModeOverlay' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:41:8: 'kCGBlendModeDarken' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:42:8: 'kCGBlendModeLighten' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:43:8: 'kCGBlendModeColorDodge' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:44:8: 'kCGBlendModeColorBurn' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:45:8: 'kCGBlendModeSoftLight' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:46:8: 'kCGBlendModeHardLight' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:47:8: 'kCGBlendModeDifference' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:48:8: 'kCGBlendModeExclusion' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:49:8: 'kCGBlendModeHue' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:50:8: 'kCGBlendModeSaturation' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:51:8: 'kCGBlendModeColor' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:52:8: 'kCGBlendModeLuminosity' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:55:8: 'kCGLineCapButt' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:56:8: 'kCGLineCapRound' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:57:8: 'kCGLineCapSquare' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:60:8: 'kCGLineJoinMiter' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:61:8: 'kCGLineJoinRound' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:62:8: 'kCGLineJoinBevel' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:65:8: 'kCGPathFill' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:66:8: 'kCGPathEOFill' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:67:8: 'kCGPathStroke' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:68:8: 'kCGPathFillStroke' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:69:8: 'kCGPathEOFillStroke' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:72:8: 'CGRectMinXEdge' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:73:8: 'CGRectMinYEdge' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:74:8: 'CGRectMaxXEdge' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:75:8: 'CGRectMaxYEdge' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:159:4: 'CGColorSpaceRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:162:8: 'kCGRenderingIntentDefault' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:163:8: 'kCGRenderingIntentAbsoluteColorimetric' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:164:8: 'kCGRenderingIntentRelativeColorimetric' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:165:8: 'kCGRenderingIntentPerceptual' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:166:8: 'kCGRenderingIntentSaturation' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:169:8: 'kCGColorSpaceUserGray' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:170:8: 'kCGColorSpaceUserRGB' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:171:8: 'kCGColorSpaceUserCMYK' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:174:8: 'kCGColorSpaceGenericGray' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:175:8: 'kCGColorSpaceGenericRGB' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:176:8: 'kCGColorSpaceGenericCMYK' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:186:4: 'CGColorRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:225:4: 'CGFontRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:226:4: 'CGFontIndex' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:227:4: 'CGGlyph' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:230:8: 'kCGFontIndexMax' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:231:8: 'kCGFontIndexInvalid' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:232:8: 'kCGGlyphMax' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:241:8: 'kCGTextFill' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:242:8: 'kCGTextStroke' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:243:8: 'kCGTextFillStroke' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:244:8: 'kCGTextInvisible' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:245:8: 'kCGTextFillClip' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:246:8: 'kCGTextStrokeClip' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:247:8: 'kCGTextFillStrokeClip' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:248:8: 'kCGTextClip' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:251:8: 'kCGEncodingFontSpecific' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:252:8: 'kCGEncodingMacRoman' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:273:4: 'CGDataProviderRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:314:22: 'CGAffineTransformIdentity' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:332:4: 'CGImageRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:335:8: 'kCGImageAlphaNone' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:336:8: 'kCGImageAlphaPremultipliedLast' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:337:8: 'kCGImageAlphaPremultipliedFirst' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:338:8: 'kCGImageAlphaLast' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:339:8: 'kCGImageAlphaFirst' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:340:8: 'kCGImageAlphaNoneSkipLast' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:341:8: 'kCGImageAlphaNoneSkipFirst' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:342:8: 'kCGImageAlphaOnly' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:345:8: 'kCGInterpolationDefault' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:346:8: 'kCGInterpolationNone' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:347:8: 'kCGInterpolationLow' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:348:8: 'kCGInterpolationHigh' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:382:4: 'CGPDFDocumentRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:418:4: 'CGMutablePathRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:419:4: 'CGPathRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:452:8: 'kCGPathElementMoveToPoint' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:453:8: 'kCGPathElementAddLineToPoint' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:454:8: 'kCGPathElementAddQuadCurveToPoint' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:455:8: 'kCGPathElementAddCurveToPoint' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:456:8: 'kCGPathElementCloseSubpath' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:462:4: 'CGPathApplierFunction' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:466:4: 'CGFunctionRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:468:4: 'CGFunctionEvaluateCallback' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:470:4: 'CGFunctionReleaseInfoCallback' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:483:4: 'CGShadingRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:500:4: 'CGLayerRef' redeclared
  /private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-build-env-jpy36s2d/overlay/lib/python3.6/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-req-build-2xplf939/kiva/quartz/CTFont.pyx
    tree = Parsing.p_module(s, pxd, full_module_name)
  warning: kiva/quartz/CoreFoundation.pxi:17:4: 'CFStringEncoding' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:57:4: 'CFURLPathStyle' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:165:4: 'CFNumberType_' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:36:4: 'CGBlendMode' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:54:4: 'CGLineCap' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:59:4: 'CGLineJoin' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:64:4: 'CGPathDrawingMode' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:71:4: 'CGRectEdge' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:161:4: 'CGColorRenderingIntent' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:173:4: 'FakedEnums' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:240:4: 'CGTextDrawingMode' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:250:4: 'CGTextEncoding' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:334:4: 'CGImageAlphaInfo' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:344:4: 'CGInterpolationQuality' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:451:4: 'CGPathElementType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:12:4: 'OSStatus' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:15:8: 'noErr' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:18:8: 'kCFStringEncodingMacRoman' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:19:8: 'kCFStringEncodingWindowsLatin1' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:20:8: 'kCFStringEncodingISOLatin1' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:21:8: 'kCFStringEncodingNextStepLatin' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:22:8: 'kCFStringEncodingASCII' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:23:8: 'kCFStringEncodingUnicode' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:24:8: 'kCFStringEncodingUTF8' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:25:8: 'kCFStringEncodingNonLossyASCII' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:27:4: 'UInt8' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:28:4: 'UniChar' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:29:4: 'bool' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:30:4: 'Boolean' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:32:4: 'CFTypeRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:33:4: 'CFTypeID' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:37:4: 'CFStringRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:39:4: 'CFIndex' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:40:4: 'CFNumberType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:42:4: 'CFHashCode' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:58:8: 'kCFURLPOSIXPathStyle' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:59:8: 'kCFURLHFSPathStyle' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:60:8: 'kCFURLWindowsPathStyle' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:62:4: 'CFURLRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:76:26: 'kCFTypeArrayCallBacks' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:78:4: 'CFArrayRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:79:4: 'CFMutableArrayRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:120:4: 'CFDictionaryRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:121:4: 'CFMutableDictionaryRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:138:34: 'kCFTypeDictionaryKeyCallBacks' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:139:36: 'kCFTypeDictionaryValueCallBacks' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:151:4: 'CFAttributedStringRef' redeclared
  building 'kiva._cython_speedups' extension
  creating build
  creating build/temp.macosx-10.9-x86_64-3.6
  creating build/temp.macosx-10.9-x86_64-3.6/kiva
  gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -g -arch x86_64 -arch x86_64 -Ikiva -I/private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-build-env-jpy36s2d/overlay/lib/python3.6/site-packages/numpy/core/include -I/Users/aayres/.edm/envs/dumb/include/python3.6m -c kiva/_cython_speedups.cpp -o build/temp.macosx-10.9-x86_64-3.6/kiva/_cython_speedups.o
  In file included from kiva/_cython_speedups.cpp:612:
  In file included from /private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-build-env-jpy36s2d/overlay/lib/python3.6/site-packages/numpy/core/include/numpy/arrayobject.h:4:
  In file included from /private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-build-env-jpy36s2d/overlay/lib/python3.6/site-packages/numpy/core/include/numpy/ndarrayobject.h:12:
  In file included from /private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-build-env-jpy36s2d/overlay/lib/python3.6/site-packages/numpy/core/include/numpy/ndarraytypes.h:1822:
  /private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-build-env-jpy36s2d/overlay/lib/python3.6/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: "Using deprecated NumPy API, disable it with "          "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-W#warnings]
  #warning "Using deprecated NumPy API, disable it with " \
   ^
  1 warning generated.
  gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -g -arch x86_64 -arch x86_64 -Ikiva -I/private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-build-env-jpy36s2d/overlay/lib/python3.6/site-packages/numpy/core/include -I/Users/aayres/.edm/envs/dumb/include/python3.6m -c kiva/_hit_test.cpp -o build/temp.macosx-10.9-x86_64-3.6/kiva/_hit_test.o
  creating build/lib.macosx-10.9-x86_64-3.6
  creating build/lib.macosx-10.9-x86_64-3.6/kiva
  g++ -bundle -undefined dynamic_lookup -g -arch x86_64 -headerpad_max_install_names build/temp.macosx-10.9-x86_64-3.6/kiva/_cython_speedups.o build/temp.macosx-10.9-x86_64-3.6/kiva/_hit_test.o -o build/lib.macosx-10.9-x86_64-3.6/kiva/_cython_speedups.cpython-36m-darwin.so
  building 'kiva._marker_renderer' extension
  gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -g -arch x86_64 -arch x86_64 -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -Ikiva/markers/agg -Ikiva/markers -I/private/var/folders/j9/ps8s26f91_1_lgf7mtd4smyr0000gn/T/pip-build-env-jpy36s2d/overlay/lib/python3.6/site-packages/numpy/core/include -I/Users/aayres/.edm/envs/dumb/include/python3.6m -c kiva/_marker_renderer.cpp -o build/temp.macosx-10.9-x86_64-3.6/kiva/_marker_renderer.o
  g++ -bundle -undefined dynamic_lookup -g -arch x86_64 -headerpad_max_install_names build/temp.macosx-10.9-x86_64-3.6/kiva/_marker_renderer.o -o build/lib.macosx-10.9-x86_64-3.6/kiva/_marker_renderer.cpython-36m-darwin.so
  building 'kiva.agg._agg' extension
  swigging kiva/agg/agg.i to kiva/agg/agg_wrap.cpp
  swig -python -Ikiva/agg/src -Ikiva/agg/agg-24/include -c++ -o kiva/agg/agg_wrap.cpp kiva/agg/agg.i
  warning: kiva/quartz/CoreFoundation.pxi:152:4: 'CFMutableAttributedStringRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:163:4: 'CFNumberRef' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:166:8: 'kCFNumberSInt8Type' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:167:8: 'kCFNumberSInt16Type' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:168:8: 'kCFNumberSInt32Type' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:169:8: 'kCFNumberSInt64Type' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:170:8: 'kCFNumberFloat32Type' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:171:8: 'kCFNumberFloat64Type' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:172:8: 'kCFNumberCharType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:173:8: 'kCFNumberShortType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:174:8: 'kCFNumberIntType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:175:8: 'kCFNumberLongType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:176:8: 'kCFNumberLongLongType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:177:8: 'kCFNumberFloatType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:178:8: 'kCFNumberDoubleType' redeclared
  warning: kiva/quartz/CoreFoundation.pxi:179:8: 'kCFNumberCFIndexType' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:12:4: 'CGContextRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:14:4: 'CGFloat' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:37:8: 'kCGBlendModeNormal' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:38:8: 'kCGBlendModeMultiply' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:39:8: 'kCGBlendModeScreen' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:40:8: 'kCGBlendModeOverlay' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:41:8: 'kCGBlendModeDarken' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:42:8: 'kCGBlendModeLighten' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:43:8: 'kCGBlendModeColorDodge' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:44:8: 'kCGBlendModeColorBurn' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:45:8: 'kCGBlendModeSoftLight' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:46:8: 'kCGBlendModeHardLight' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:47:8: 'kCGBlendModeDifference' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:48:8: 'kCGBlendModeExclusion' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:49:8: 'kCGBlendModeHue' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:50:8: 'kCGBlendModeSaturation' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:51:8: 'kCGBlendModeColor' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:52:8: 'kCGBlendModeLuminosity' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:55:8: 'kCGLineCapButt' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:56:8: 'kCGLineCapRound' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:57:8: 'kCGLineCapSquare' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:60:8: 'kCGLineJoinMiter' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:61:8: 'kCGLineJoinRound' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:62:8: 'kCGLineJoinBevel' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:65:8: 'kCGPathFill' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:66:8: 'kCGPathEOFill' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:67:8: 'kCGPathStroke' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:68:8: 'kCGPathFillStroke' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:69:8: 'kCGPathEOFillStroke' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:72:8: 'CGRectMinXEdge' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:73:8: 'CGRectMinYEdge' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:74:8: 'CGRectMaxXEdge' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:75:8: 'CGRectMaxYEdge' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:159:4: 'CGColorSpaceRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:162:8: 'kCGRenderingIntentDefault' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:163:8: 'kCGRenderingIntentAbsoluteColorimetric' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:164:8: 'kCGRenderingIntentRelativeColorimetric' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:165:8: 'kCGRenderingIntentPerceptual' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:166:8: 'kCGRenderingIntentSaturation' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:169:8: 'kCGColorSpaceUserGray' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:170:8: 'kCGColorSpaceUserRGB' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:171:8: 'kCGColorSpaceUserCMYK' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:174:8: 'kCGColorSpaceGenericGray' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:175:8: 'kCGColorSpaceGenericRGB' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:176:8: 'kCGColorSpaceGenericCMYK' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:186:4: 'CGColorRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:225:4: 'CGFontRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:226:4: 'CGFontIndex' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:227:4: 'CGGlyph' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:230:8: 'kCGFontIndexMax' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:231:8: 'kCGFontIndexInvalid' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:232:8: 'kCGGlyphMax' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:241:8: 'kCGTextFill' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:242:8: 'kCGTextStroke' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:243:8: 'kCGTextFillStroke' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:244:8: 'kCGTextInvisible' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:245:8: 'kCGTextFillClip' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:246:8: 'kCGTextStrokeClip' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:247:8: 'kCGTextFillStrokeClip' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:248:8: 'kCGTextClip' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:251:8: 'kCGEncodingFontSpecific' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:252:8: 'kCGEncodingMacRoman' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:273:4: 'CGDataProviderRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:314:22: 'CGAffineTransformIdentity' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:332:4: 'CGImageRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:335:8: 'kCGImageAlphaNone' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:336:8: 'kCGImageAlphaPremultipliedLast' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:337:8: 'kCGImageAlphaPremultipliedFirst' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:338:8: 'kCGImageAlphaLast' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:339:8: 'kCGImageAlphaFirst' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:340:8: 'kCGImageAlphaNoneSkipLast' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:341:8: 'kCGImageAlphaNoneSkipFirst' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:342:8: 'kCGImageAlphaOnly' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:345:8: 'kCGInterpolationDefault' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:346:8: 'kCGInterpolationNone' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:347:8: 'kCGInterpolationLow' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:348:8: 'kCGInterpolationHigh' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:382:4: 'CGPDFDocumentRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:418:4: 'CGMutablePathRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:419:4: 'CGPathRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:452:8: 'kCGPathElementMoveToPoint' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:453:8: 'kCGPathElementAddLineToPoint' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:454:8: 'kCGPathElementAddQuadCurveToPoint' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:455:8: 'kCGPathElementAddCurveToPoint' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:456:8: 'kCGPathElementCloseSubpath' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:462:4: 'CGPathApplierFunction' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:466:4: 'CGFunctionRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:468:4: 'CGFunctionEvaluateCallback' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:470:4: 'CGFunctionReleaseInfoCallback' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:483:4: 'CGShadingRef' redeclared
  warning: kiva/quartz/CoreGraphics.pxi:500:4: 'CGLayerRef' redeclared
  error: command 'swig' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for enable
Failed to build enable
ERROR: Could not build wheels for enable which use PEP 517 and cannot be installed directly
```

</details>

I then ran `brew install swig` and re-ran `pip install enable-5.1.0.dev280.tar.gz` and I see:
<details>

```
 $ pip install enable-5.1.0.dev280.tar.gz
Processing ./enable-5.1.0.dev280.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Collecting pillow
  Using cached Pillow-8.2.0-cp36-cp36m-macosx_10_10_x86_64.whl (2.8 MB)
Collecting numpy
  Using cached numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl (15.6 MB)
Collecting traits>=6.2.0
  Using cached traits-6.2.0-cp36-cp36m-macosx_10_14_x86_64.whl (5.0 MB)
Collecting fonttools
  Using cached fonttools-4.22.1-py3-none-any.whl (850 kB)
Processing /Users/aayres/Library/Caches/pip/wheels/2c/12/3a/69b89979464e90a5e5882f66c79d2908434c0c75014e91eee4/traitsui-7.1.1-py3-none-any.whl
Processing /Users/aayres/Library/Caches/pip/wheels/c9/24/5a/1231d8847ac0ff839cc5b7810612b851318a6d2c66a891c031/pyface-7.3.0-py3-none-any.whl
Collecting importlib-resources>=1.1.0
  Using cached importlib_resources-5.1.2-py3-none-any.whl (25 kB)
Collecting importlib-metadata
  Using cached importlib_metadata-4.0.1-py3-none-any.whl (16 kB)
Collecting zipp>=0.4; python_version < "3.8"
  Using cached zipp-3.4.1-py3-none-any.whl (5.2 kB)
Collecting typing-extensions>=3.6.4; python_version < "3.8"
  Using cached typing_extensions-3.7.4.3-py3-none-any.whl (22 kB)
Building wheels for collected packages: enable
  Building wheel for enable (PEP 517) ... done
  Created wheel for enable: filename=enable-5.1.0.dev280-cp36-cp36m-macosx_10_9_x86_64.whl size=2503251 sha256=c62964e18e3159c4442bf9cea35d710d65c6be40e63025363957b74831f2f170
  Stored in directory: /Users/aayres/Library/Caches/pip/wheels/c6/f1/52/5dd3cc3b4c10a4fe7a9b699b17d9cbad8cfb40b79c8eb3f180
Successfully built enable
Installing collected packages: pillow, numpy, traits, fonttools, zipp, importlib-resources, typing-extensions, importlib-metadata, pyface, traitsui, enable
Successfully installed enable-5.1.0.dev280 fonttools-4.22.1 importlib-metadata-4.0.1 importlib-resources-5.1.2 numpy-1.19.5 pillow-8.2.0 pyface-7.3.0 traits-6.2.0 traitsui-7.1.1 typing-extensions-3.7.4.3 zipp-3.4.1
```

</details>

A follow up PR will be needed to raise an exception in `setup.py` if we have the wrong swig version.