### PR TITLE
Remove unused tk related drawing methods

### DIFF
--- a/kiva/agg/src/gtk1/plat_support.i
+++ b/kiva/agg/src/gtk1/plat_support.i
@@ -98,11 +98,6 @@ namespace agg24
          self.bmp_array = pixel_map_as_unowned_array(self)
          return self
 
-    def draw_to_tkwindow(self, window, x, y):
-        window_id = window._tk_widget.winfo_id()
-        self.draw(window_id, x, y)
-        return
-
     def draw_to_wxwindow(self, window, x, y):
         window_id = window.GetHandle()
         self.draw(window_id, x, y)

--- a/kiva/agg/src/win32/plat_support.i
+++ b/kiva/agg/src/win32/plat_support.i
@@ -116,13 +116,6 @@ namespace agg24
          self.bmp_array = pixel_map_as_unowned_array(self)
          return self
 
-    def draw_to_tkwindow(self, window, x, y):
-        window_id = window._tk_widget.winfo_id()
-        hdc = GetDC(window_id)
-        self.draw(hdc, x, y)
-        ReleaseDC(window_id, hdc)
-        return
-
     def draw_to_wxwindow(self, window, x, y, width=-1, height=-1):
         window_dc = getattr(window,'_dc',None)
         if window_dc is None:

--- a/kiva/agg/src/x11/plat_support.i
+++ b/kiva/agg/src/x11/plat_support.i
@@ -99,11 +99,6 @@ namespace agg24
          self.bmp_array = pixel_map_as_unowned_array(self)
          return self
 
-    def draw_to_tkwindow(self, window, x, y):
-        window_id = window._tk_widget.winfo_id()
-        self.draw(window_id, x, y)
-        return
-
     def draw_to_wxwindow(self, window, x, y):
         import wx
         window_dc = getattr(window,'_dc',None)


### PR DESCRIPTION
This PR removes the old/outdated/unnecessary `draw_to_tkwindow` drawing code in the platform support for the agg backend.