### PR TITLE
Remove an "PY_MAJOR_VERSION" conditional in quartz backend

### DIFF
--- a/kiva/quartz/mac_context.c
+++ b/kiva/quartz/mac_context.c
@@ -41,8 +41,6 @@ static PyMethodDef mac_context_methods[] = {
     {NULL, NULL}
 };
 
-#if PY_MAJOR_VERSION >= 3
-
 static struct PyModuleDef mac_context_module = {
     PyModuleDef_HEAD_INIT,
     "mac_context",        /* m_name */
@@ -60,12 +58,3 @@ PyInit_mac_context(void)
 {
     return PyModule_Create(&mac_context_module);
 }
-
-#else
-
-void initmac_context(void)
-{
-    Py_InitModule("mac_context", mac_context_methods);
-}
-
-#endif


### PR DESCRIPTION
This PR removes a use of `PY_MAJOR_VERSION` conditional in the quartz backend c extension code. The Python 2 branch has been removed while preserving the Python 3 branch.