### PR TITLE
verify swig version in setup.py

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -106,7 +106,6 @@ dependencies = {
     "traitsui",
     "pyface",
     "pypdf2",
-    "swig",
     "unittest2",
 }
 

--- a/setup.py
+++ b/setup.py
@@ -429,6 +429,18 @@ def macos_extensions():
 
 
 if __name__ == "__main__":
+
+    msg = ("SWIG is a required build dependency of Enable. Furthermore, there "
+          "is currently a known issue with SWIG 4.0, see enthought/enable#360."
+          " Please download SWIG 3.0.x (see http://www.swig.org/).")
+    try:
+        with subprocess.Popen(["swig", "-version"], stdout=subprocess.PIPE, encoding='utf-8') as proc:
+            swig_version_line = proc.stdout.read().split('\n')[1]
+            swig_version = swig_version_line.split(' ')[2]
+            if  not swig_version.startswith('3'):
+                raise Exception(msg)
+    except FileNotFoundError:
+        raise Exception(msg)
     # Write version modules as needed
     enable_version_path = os.path.join('enable', '_version.py')
     write_version_py(filename=enable_version_path)


### PR DESCRIPTION
This is a follow up to #808 which closes #769 

This PR checks the version of swig via a subprocess call (a little ugly but seems to get the job done) in setutp.py.
If swig is not around or we have a bad version (not version 3.x) we raise an exception.  This follows the second point at the end of the 769 issue description