### PR TITLE
Remove AbstractWindow.bg_color trait

### DIFF
--- a/enable/abstract_window.py
+++ b/enable/abstract_window.py
@@ -68,11 +68,6 @@ class AbstractWindow(HasTraits):
     # painted with this color before the component gets to draw.
     bgcolor = ColorTrait("sys_window")
 
-    # Unfortunately, for a while, there was a naming inconsistency and the
-    # background color trait named "bg_color".  This is still provided for
-    # backwards compatibility but should not be used in new code.
-    bg_color = Alias("bgcolor")
-
     alt_pressed = Bool(False)
     ctrl_pressed = Bool(False)
     shift_pressed = Bool(False)


### PR DESCRIPTION
closes #812

This PR simply removes the old deprecated trait.  Note searching the codebase for `bg_color` is what motivated issue #815. Perhaps `enable/trait_defs/ui/wx/enable_rgba_color_editor.py` should just be deleted?  given 815 I imagine it is completely broken