### PR TITLE
Fix artefact in Qt caused by QRectF having a slightly wrong size

### DIFF
--- a/enable/qt4/cairo.py
+++ b/enable/qt4/cairo.py
@@ -36,6 +36,8 @@ class Window(BaseWindow):
 
         image = QtGui.QImage(data, w, h, QtGui.QImage.Format_ARGB32)
 
-        rect = QtCore.QRectF(0, 0, self.control.width(), self.control.height())
+        rect = QtCore.QRectF(
+            0, 0, w / self._gc.base_scale, h / self._gc.base_scale
+        )
         painter = QtGui.QPainter(self.control)
         painter.drawImage(rect, image)

--- a/enable/qt4/celiagg.py
+++ b/enable/qt4/celiagg.py
@@ -48,7 +48,9 @@ class Window(BaseWindow):
         image = QtGui.QImage(
             self._shuffle_buffer, w, h, QtGui.QImage.Format_RGB32
         )
-        rect = QtCore.QRectF(0, 0, self.control.width(), self.control.height())
+        rect = QtCore.QRectF(
+            0, 0, w / self._gc.base_scale, h / self._gc.base_scale
+        )
         painter = QtGui.QPainter(self.control)
         painter.drawImage(rect, image)
 

--- a/enable/qt4/image.py
+++ b/enable/qt4/image.py
@@ -38,7 +38,9 @@ class Window(BaseWindow):
         h = self._gc.height()
         data = self._gc.pixel_map.convert_to_argb32string()
         image = QtGui.QImage(data, w, h, QtGui.QImage.Format_ARGB32)
-        rect = QtCore.QRectF(0, 0, self.control.width(), self.control.height())
+        rect = QtCore.QRectF(
+            0, 0, w / self._gc.base_scale, h / self._gc.base_scale
+        )
         painter = QtGui.QPainter(self.control)
         painter.drawImage(rect, image)
 

--- a/kiva/cairo.py
+++ b/kiva/cairo.py
@@ -224,8 +224,8 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
             ctx.scale(1, -1)
 
         # For HiDPI support
-        base_scale = kw.pop("base_pixel_scale", 1)
-        ctx.scale(base_scale, base_scale)
+        self.base_scale = kw.pop("base_pixel_scale", 1)
+        ctx.scale(self.base_scale, self.base_scale)
 
         self._ctx = ctx
         self.state = GraphicsState()


### PR DESCRIPTION
Closes #819

The issue is tested (manually) to affect these backends: `qt4.image`, `qt4.celiagg` and `qt4.cairo`.
For these backends, the `GraphicsContext` is defined to be slightly larger than the requested size:
https://github.com/enthought/enable/blob/1c3805cdf8e47085a2ae91cdcdc2ed0d12ba33e6/enable/qt4/cairo.py#L20-L23

There is another `QRectF` defined for `qt4.quartz`, but I could not reproduce the issue there. For this backend, the GraphicsContext was defined without the plus-one:
https://github.com/enthought/enable/blob/685038503500ecf8ffc30f3da68c7e848ae02e6f/enable/qt4/quartz.py#L35

Note that `base_scale` was not defined on the `GraphicsContext` for the cairo backend, and so it has to be added.

Apparently `base_scale` is not defined on the `qpainter`'s `GraphicsContext` either, but that would be an orthogonal issue as #819 does not affect the `qpainter` backend.