### PR TITLE
Backport PR #820 to the 5.1 maintenance branch in preparation for enable 5.1.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,18 @@
 Enable CHANGELOG
 ================
 
+Enable 5.1.1
+============
+
+Thanks to:
+
+* Kit Yan Choi
+
+Fixes
+-----
+
+* Fix artefact in Qt caused by a wrong QRectF size. (#820)
+
 Enable 5.0.0
 ============
 

--- a/enable/qt4/cairo.py
+++ b/enable/qt4/cairo.py
@@ -36,6 +36,8 @@ class Window(BaseWindow):
 
         image = QtGui.QImage(data, w, h, QtGui.QImage.Format_ARGB32)
 
-        rect = QtCore.QRectF(0, 0, self.control.width(), self.control.height())
+        rect = QtCore.QRectF(
+            0, 0, w / self._gc.base_scale, h / self._gc.base_scale
+        )
         painter = QtGui.QPainter(self.control)
         painter.drawImage(rect, image)

--- a/enable/qt4/celiagg.py
+++ b/enable/qt4/celiagg.py
@@ -48,7 +48,9 @@ class Window(BaseWindow):
         image = QtGui.QImage(
             self._shuffle_buffer, w, h, QtGui.QImage.Format_RGB32
         )
-        rect = QtCore.QRectF(0, 0, self.control.width(), self.control.height())
+        rect = QtCore.QRectF(
+            0, 0, w / self._gc.base_scale, h / self._gc.base_scale
+        )
         painter = QtGui.QPainter(self.control)
         painter.drawImage(rect, image)
 

--- a/enable/qt4/image.py
+++ b/enable/qt4/image.py
@@ -38,7 +38,9 @@ class Window(BaseWindow):
         h = self._gc.height()
         data = self._gc.pixel_map.convert_to_argb32string()
         image = QtGui.QImage(data, w, h, QtGui.QImage.Format_ARGB32)
-        rect = QtCore.QRectF(0, 0, self.control.width(), self.control.height())
+        rect = QtCore.QRectF(
+            0, 0, w / self._gc.base_scale, h / self._gc.base_scale
+        )
         painter = QtGui.QPainter(self.control)
         painter.drawImage(rect, image)
 

--- a/kiva/cairo.py
+++ b/kiva/cairo.py
@@ -224,8 +224,8 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
             ctx.scale(1, -1)
 
         # For HiDPI support
-        base_scale = kw.pop("base_pixel_scale", 1)
-        ctx.scale(base_scale, base_scale)
+        self.base_scale = kw.pop("base_pixel_scale", 1)
+        ctx.scale(self.base_scale, self.base_scale)
 
         self._ctx = ctx
         self.state = GraphicsState()


### PR DESCRIPTION
This PR backports the PR #820 to the `maint/5.1` branch in preparation for the bug-fix release enable 5.1.1

Note : As you can see, it looks like the enable 5.1.0 changelog is missing from the maintenance branch - which will be addressed in a separate PR.