### PR TITLE
Bump version and set IS_RELEASED to False for development of 5.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ from setuptools.command.install import install as base_install
 
 MAJOR = 5
 MINOR = 1
-MICRO = 1
+MICRO = 2
 PRERELEASE = ""
-IS_RELEASED = True
+IS_RELEASED = False
 
 # Templates for version strings.
 RELEASED_VERSION = "{major}.{minor}.{micro}{prerelease}"


### PR DESCRIPTION
Targeting `maint/5.1`

This PR bumps the release version and flip the IS_RELEASE flag for the development of the next bug fix release.