### PR TITLE
Explicitly require pyface>=7.2 since we use pyface.undo

### DIFF
--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -16,7 +16,7 @@ except ImportError:
     __version__ = "not-built"
 
 __requires__ = [
-    "numpy", "pillow", "traits>=6.2.0", "traitsui", "pyface", "fonttools"
+    "numpy", "pillow", "traits>=6.2.0", "traitsui", "pyface>=7.2.0", "fonttools"
 ]
 
 __extras_require__ = {


### PR DESCRIPTION
This has actually been true since PR #507 

Adding it now simply to be more explicit 