### PR TITLE
Flip IS_RELEASED back to False

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ MAJOR = 5
 MINOR = 2
 MICRO = 0
 PRERELEASE = "rc1"
-IS_RELEASED = True
+IS_RELEASED = False
 
 # Templates for version strings.
 RELEASED_VERSION = "{major}.{minor}.{micro}{prerelease}"


### PR DESCRIPTION
This branch name is poorly named - this PR does not bump the version, it simply sets `IS_RELEASED` back to false for continued development of 5.2.0 in prep for the full release.