### PR TITLE
Flip IS_RELEASED back to False

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ MAJOR = 5
 MINOR = 2
 MICRO = 0
 PRERELEASE = "rc2"
-IS_RELEASED = True
+IS_RELEASED = False
 
 # Templates for version strings.
 RELEASED_VERSION = "{major}.{minor}.{micro}{prerelease}"


### PR DESCRIPTION
This PR simply flips `IS_RELEASED` back to False following the 5.2.0 release candidate, for continued development in advance of the full 5.2.0 release