### PR TITLE
Make Kiva compileable with Swig 4

### DIFF
--- a/kiva/agg/src/font_type.i
+++ b/kiva/agg/src/font_type.i
@@ -84,7 +84,7 @@ def unicode_safe_init(self, _name="Arial", _size=12, _family=0, _style=0,
                                _encoding, _face_index, validate)
 
     self.this = obj
-    self.thisown = 1                
+    self.thisown = 1
 
 # This is a crappy way of overriding the constructor
 AggFontType.__init__ = unicode_safe_init

--- a/kiva/agg/src/font_type.i
+++ b/kiva/agg/src/font_type.i
@@ -82,8 +82,9 @@ def unicode_safe_init(self, _name="Arial", _size=12, _family=0, _style=0,
             _name = _name.decode()
     obj = _agg.new_AggFontType(_name, _size, _family, _style,
                                _encoding, _face_index, validate)
-    _swig_setattr(self, AggFontType, "this", obj)
-    _swig_setattr(self, AggFontType, "thisown", 1)
+
+    self.this = obj
+    self.thisown = 1                
 
 # This is a crappy way of overriding the constructor
 AggFontType.__init__ = unicode_safe_init

--- a/kiva/agg/src/graphics_context.i
+++ b/kiva/agg/src/graphics_context.i
@@ -362,12 +362,8 @@ namespace kiva {
                 # Apply base scale for a HiDPI context
                 _agg.GraphicsContextArray_scale_ctm(obj, base_pixel_scale, base_pixel_scale)
 
-                _swig_setattr(self, GraphicsContextArray, 'this', obj)
-                # swig 1.3.28 does not have real thisown, thisown is mapped
-                # to this.own() but with previous 'self.this=obj' an
-                # attribute 'own' error is raised. Does this workaround
-                # work with pre-1.3.28 swig?
-                _swig_setattr(self, GraphicsContextArray, 'thisown2', 1)
+                self.this = obj
+                self.thisown2 = 1
 
                 self.bmp_array = ary
                 self.base_scale = base_pixel_scale

--- a/kiva/agg/src/graphics_context.i
+++ b/kiva/agg/src/graphics_context.i
@@ -363,6 +363,10 @@ namespace kiva {
                 _agg.GraphicsContextArray_scale_ctm(obj, base_pixel_scale, base_pixel_scale)
 
                 self.this = obj
+                # swig 1.3.28 does not have real thisown, thisown is mapped
+                # to this.own() but with previous 'self.this=obj' an
+                # attribute 'own' error is raised. Does this workaround
+                # work with pre-1.3.28 swig?				
                 self.thisown2 = 1
 
                 self.bmp_array = ary

--- a/kiva/agg/tests/test_affine_matrix.py
+++ b/kiva/agg/tests/test_affine_matrix.py
@@ -31,7 +31,7 @@ class AffineMatrixTestCase(unittest.TestCase):
         try:
             agg.AffineMatrix(a)
         except (NotImplementedError, TypeError):
-            # NotImplementedError in Swig 3, TypeError in Swig 4
+            # NotImplementedError in Swig 3, TypeError in Swig 4 (see swig #1261)
             pass  # can't init from complex value.
 
     def test_init_from_array2(self):

--- a/kiva/agg/tests/test_affine_matrix.py
+++ b/kiva/agg/tests/test_affine_matrix.py
@@ -30,7 +30,8 @@ class AffineMatrixTestCase(unittest.TestCase):
         a = ones(6, "D")
         try:
             agg.AffineMatrix(a)
-        except NotImplementedError:
+        except (NotImplementedError, TypeError):
+            # NotImplementedError in Swig 3, TypeError in Swig 4
             pass  # can't init from complex value.
 
     def test_init_from_array2(self):

--- a/kiva/gl/src/swig/font_type.i
+++ b/kiva/gl/src/swig/font_type.i
@@ -78,10 +78,9 @@ def unicode_safe_init(self, _name="Arial", _size=12, _family=0, _style=0,
             _name = _name.decode()
     obj = _gl.new_KivaGLFontType(_name, _size, _family, _style,
                                _encoding, validate)
-    _swig_setattr(self, KivaGLFontType, "this", obj)
-    _swig_setattr(self, KivaGLFontType, "thisown", 1)
+    self.this = obj
+    self.thisown = 1
 
 # This is a crappy way of overriding the constructor
 KivaGLFontType.__init__ = unicode_safe_init
 %}
-


### PR DESCRIPTION
Fixes #360.

The Swig wrappers used a historic construct (using `_swig_setattr` instead of direct attribute assignment) that broke with the relase of Swig 4 (which removed `_swig_setattr`). 

There are a lot of historical oddities with the Swig wrappers (as is well-known); I didn't touch anything beyond the strictly necessary, expecting the Swig layer to go away with #414.