### PR TITLE
[Do not merge] Re-export layout helpers via enable.api

### DIFF
--- a/enable/api.py
+++ b/enable/api.py
@@ -145,6 +145,12 @@ Enable Components
 - :class:`~.GraphicsContextEnable`
 - :class:`~.ImageGraphicsContextEnable`
 
+Layout Helpers
+--------------
+
+- :func:`~.stack_layout`
+- :func:`~.stacked_preferred_size`
+
 Enable Widgets
 ==============
 
@@ -279,6 +285,7 @@ from .coordinate_box import CoordinateBox
 from .component_editor import ComponentEditor
 from .overlay_container import OverlayContainer
 from .stacked_container import HStackedContainer, VStackedContainer
+from .stacked_layout import stack_layout, stacked_preferred_size
 
 try:
     import kiwisolver

--- a/enable/api.py
+++ b/enable/api.py
@@ -148,6 +148,8 @@ Enable Components
 Layout Helpers
 --------------
 
+- :func:`~.simple_container_do_layout`
+- :func:`~.simple_container_get_preferred_size`
 - :func:`~.stack_layout`
 - :func:`~.stacked_preferred_size`
 
@@ -284,6 +286,9 @@ from .container import Container
 from .coordinate_box import CoordinateBox
 from .component_editor import ComponentEditor
 from .overlay_container import OverlayContainer
+from .simple_layout import (
+    simple_container_do_layout, simple_container_get_preferred_size,
+)
 from .stacked_container import HStackedContainer, VStackedContainer
 from .stacked_layout import stack_layout, stacked_preferred_size
 

--- a/enable/stacked_layout.py
+++ b/enable/stacked_layout.py
@@ -12,9 +12,8 @@
 
 
 def stacked_preferred_size(container, components=None):
-    """ Returns the size (width,height) that is preferred for this component.
-
-    Overrides Component.
+    """ Returns the preferred size (width, height) for the given container
+    and components.
     """
     if container.fixed_preferred_size is not None:
         container._cached_preferred_size = container.fixed_preferred_size


### PR DESCRIPTION
This PR re-exports the layout helpers `simple_container_do_layout`, `simple_container_get_preferred_size`, `stack_layout` and `stacked_preferred_size` via `enable.api` because they are now used by chaco. See PR https://github.com/enthought/chaco/pull/757. This PR also slightly improves the docstring of `stacked_preferred_size`.