### PR TITLE
use oldest-supported-numpy in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["cython", "numpy", "setuptools", "wheel"]
+requires = ["cython", "oldest-supported-numpy", "setuptools", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
fixes #846 using the same approach as https://github.com/enthought/chaco/pull/779

We will want to backport this to `maint/5.2` prior to the 5.2.0 release.