### PR TITLE
Remove more code branches that supported Python 2

### DIFF
--- a/kiva/agg/src/font_type.i
+++ b/kiva/agg/src/font_type.i
@@ -73,13 +73,8 @@ def unicode_safe_init(self, _name="Arial", _size=12, _family=0, _style=0,
                       _encoding=0, _face_index=0, validate=True):
     ### HACK:  C++ stuff expects a string (not unicode) for the face_name, so fix
     ###        if needed.
-    ### Only for python < 3
-    if '' == b'':
-        if isinstance(_name, unicode):
-            _name = _name.encode("latin1")
-    else:
-        if isinstance(_name, bytes):
-            _name = _name.decode()
+    if isinstance(_name, bytes):
+        _name = _name.decode()
     obj = _agg.new_AggFontType(_name, _size, _family, _style,
                                _encoding, _face_index, validate)
     _swig_setattr(self, AggFontType, "this", obj)

--- a/kiva/agg/src/graphics_context.i
+++ b/kiva/agg/src/graphics_context.i
@@ -264,23 +264,7 @@ namespace kiva {
             CIRCLE_MARKER: (circle_marker_path, FILL_STROKE)
         }
 
-        # global freetype engine for text rendering.
-        #from enthought import freetype
-        #ft_engine = freetype.FreeType(dpi=120.0)
-
         from kiva import fonttools
-
-        def handle_unicode(text):
-            "Returns a utf8 encoded 8-bit string from 'text'"
-            # For now we just deal with unicode by converting to utf8
-            # Later we can add full-blown support with wchar_t/Py_UNICODE
-            # typemaps etc.
-            try:
-                if '' == b'' and isinstance(text, unicode):
-                    text = text.encode("utf8")
-                return text
-            except:
-                raise UnicodeError("Error encoding text to utf8.")
     %}
 
     void cleanup_font_threading_primitives();
@@ -466,7 +450,6 @@ namespace kiva {
             %feature("shadow") show_text_at_point(char *text, double dx, double dy)
             %{
             def show_text_at_point(self, text, dx, dy):
-                text = handle_unicode(text)
                 return _agg.GraphicsContextArray_show_text_at_point(self, text, dx, dy)
             %}
             bool show_text_at_point(char *text, double dx, double dy);
@@ -478,8 +461,6 @@ namespace kiva {
                    if point is None.  Returns true if text displayed properly,
                    false if there was a font issue or a glyph could not be
                    rendered.  Will handle multi-line text separated by backslash-ns"""
-
-                text = handle_unicode(text)
 
                 linelist = text.split('\n')
 
@@ -510,7 +491,6 @@ namespace kiva {
                 if not self.is_font_initialized():
                     raise RuntimeError("Font not loaded/initialized.")
                 else:
-                    text = handle_unicode(text)
                     return _agg.GraphicsContextArray_get_text_extent(self, text)
             %}
             kiva::rect_type get_text_extent(char *text);

--- a/kiva/gl/src/swig/font_type.i
+++ b/kiva/gl/src/swig/font_type.i
@@ -69,13 +69,8 @@ def unicode_safe_init(self, _name="Arial", _size=12, _family=0, _style=0,
                       _encoding=0, validate=True):
     ### HACK:  C++ stuff expects a string (not unicode) for the face_name, so fix
     ###        if needed.
-    ### Only for python < 3
-    if '' == b'':
-        if isinstance(_name, unicode):
-            _name = _name.encode("latin1")
-    else:
-        if isinstance(_name, bytes):
-            _name = _name.decode()
+    if isinstance(_name, bytes):
+        _name = _name.decode()
     obj = _gl.new_KivaGLFontType(_name, _size, _family, _style,
                                _encoding, validate)
     _swig_setattr(self, KivaGLFontType, "this", obj)


### PR DESCRIPTION
This PR removes 2 more code branches that supported Python 2. These code branches were hard to discover because they checked if a string is equal to a bytestring (`'' == b''`) - which is only true on Python 2 and not on Python 3. Note that these were discovered when looking at #839 