### PR TITLE
pyproject.toml fix backport and changelog updates

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -45,12 +45,13 @@ Maintenance
 * Remove old deprecated drawing methods (#814)
 * Remove AbstractWindow.bg_color trait (#816)
 * Remove unused enable/trait_defs/ui/wx/enable_rgba_color_editor.py module (#817)
+* Deal with __getstate__ methods (#804, #841)
 
 Build and Continuous Integration
 --------------------------------
 
 * Skip markers tests if not using agg (#799)
-* Add pyproject.toml to specify cython and numpy as build deps (#808)
+* Add pyproject.toml to specify cython and numpy as build deps (#808, #836, #847)
 * Verify swig version in setup.py (#811)
 
 Enable 5.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["cython", "numpy", "setuptools", "wheel"]
+requires = ["cython", "oldest-supported-numpy", "setuptools", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR backports the recent `pyproject.toml` fix to the `maint/5.2` branch, and also updates the changelog with that PR, PR #836 which was recently merged into the `maint/5.2` branch directly, and the PRs #804 and #841 which were backported to the maint branch in #845