### PR TITLE
Remove is_qt4 checks

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -15,7 +15,7 @@ jobs:
   test-edm-linux:
     strategy:
       matrix:
-        toolkit: ['null', 'pyqt', 'pyqt5', 'pyside2', 'wx']
+        toolkit: ['null', 'pyqt5', 'pyside2', 'wx']
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-        toolkit: ['pyqt', 'pyqt5', 'pyside2', 'wx']
+        toolkit: ['pyqt5', 'pyside2', 'wx']
     runs-on: ${{ matrix.os }}
     env:
       # Set root directory, mainly for Windows, so that the EDM Python

--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -43,9 +43,6 @@ from .constants import (
 )
 
 
-is_qt4 = QtCore.__version_info__[0] <= 4
-
-
 class _QtWindowHandler(object):
     def __init__(self, qt_window, enable_window):
         self._enable_window = enable_window
@@ -452,29 +449,20 @@ class _Window(AbstractWindow):
         # we treat wheel events like mouse events.
         if isinstance(event, QtGui.QWheelEvent):
             degrees_per_step = 15.0
-            if is_qt4:
-                delta = event.delta()
-                mouse_wheel = delta / float(8 * degrees_per_step)
-                mouse_wheel_axis = MOUSE_WHEEL_AXIS_MAP[event.orientation()]
-                if mouse_wheel_axis == "horizontal":
-                    mouse_wheel_delta = (delta, 0)
-                else:
-                    mouse_wheel_delta = (0, delta)
+            delta = event.pixelDelta()
+            if delta.x() == 0 and delta.y() == 0:  # pixelDelta is optional
+                delta = event.angleDelta()
+            mouse_wheel_delta = (delta.x(), delta.y())
+            if abs(mouse_wheel_delta[0]) > abs(mouse_wheel_delta[1]):
+                mouse_wheel = mouse_wheel_delta[0] / float(
+                    8 * degrees_per_step
+                )
+                mouse_wheel_axis = "horizontal"
             else:
-                delta = event.pixelDelta()
-                if delta.x() == 0 and delta.y() == 0:  # pixelDelta is optional
-                    delta = event.angleDelta()
-                mouse_wheel_delta = (delta.x(), delta.y())
-                if abs(mouse_wheel_delta[0]) > abs(mouse_wheel_delta[1]):
-                    mouse_wheel = mouse_wheel_delta[0] / float(
-                        8 * degrees_per_step
-                    )
-                    mouse_wheel_axis = "horizontal"
-                else:
-                    mouse_wheel = mouse_wheel_delta[1] / float(
-                        8 * degrees_per_step
-                    )
-                    mouse_wheel_axis = "vertical"
+                mouse_wheel = mouse_wheel_delta[1] / float(
+                    8 * degrees_per_step
+                )
+                mouse_wheel_axis = "vertical"
         else:
             mouse_wheel = 0
             mouse_wheel_delta = (0, 0)

--- a/enable/tests/qt4/test_mouse_wheel.py
+++ b/enable/tests/qt4/test_mouse_wheel.py
@@ -46,29 +46,18 @@ class MouseWheelTestCase(TestCase):
     def test_vertical_mouse_wheel(self):
         from pyface.qt import QtCore, QtGui
 
-        is_qt4 = QtCore.__version_info__[0] <= 4
-
         # create and mock a mouse wheel event
-        if is_qt4:
-            qt_event = QtGui.QWheelEvent(
-                QtCore.QPoint(0, 0),
-                200,
-                QtCore.Qt.NoButton,
-                QtCore.Qt.NoModifier,
-                QtCore.Qt.Vertical,
-            )
-        else:
-            qt_event = QtGui.QWheelEvent(
-                QtCore.QPoint(0, 0),
-                self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
-                QtCore.QPoint(0, 200),
-                QtCore.QPoint(0, 200),
-                200,
-                QtCore.Qt.Vertical,
-                QtCore.Qt.NoButton,
-                QtCore.Qt.NoModifier,
-                QtCore.Qt.ScrollUpdate,
-            )
+        qt_event = QtGui.QWheelEvent(
+            QtCore.QPoint(0, 0),
+            self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
+            QtCore.QPoint(0, 200),
+            QtCore.QPoint(0, 200),
+            200,
+            QtCore.Qt.Vertical,
+            QtCore.Qt.NoButton,
+            QtCore.Qt.NoModifier,
+            QtCore.Qt.ScrollUpdate,
+        )
 
         # dispatch event
         self.window._on_mouse_wheel(qt_event)
@@ -81,29 +70,18 @@ class MouseWheelTestCase(TestCase):
     def test_horizontal_mouse_wheel(self):
         from pyface.qt import QtCore, QtGui
 
-        is_qt4 = QtCore.__version_info__[0] <= 4
-
         # create and mock a mouse wheel event
-        if is_qt4:
-            qt_event = QtGui.QWheelEvent(
-                QtCore.QPoint(0, 0),
-                200,
-                QtCore.Qt.NoButton,
-                QtCore.Qt.NoModifier,
-                QtCore.Qt.Horizontal,
-            )
-        else:
-            qt_event = QtGui.QWheelEvent(
-                QtCore.QPoint(0, 0),
-                self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
-                QtCore.QPoint(200, 0),
-                QtCore.QPoint(200, 0),
-                200,
-                QtCore.Qt.Vertical,
-                QtCore.Qt.NoButton,
-                QtCore.Qt.NoModifier,
-                QtCore.Qt.ScrollUpdate,
-            )
+        qt_event = QtGui.QWheelEvent(
+            QtCore.QPoint(0, 0),
+            self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
+            QtCore.QPoint(200, 0),
+            QtCore.QPoint(200, 0),
+            200,
+            QtCore.Qt.Vertical,
+            QtCore.Qt.NoButton,
+            QtCore.Qt.NoModifier,
+            QtCore.Qt.ScrollUpdate,
+        )
 
         # dispatch event
         self.window._on_mouse_wheel(qt_event)
@@ -115,10 +93,6 @@ class MouseWheelTestCase(TestCase):
 
     def test_vertical_mouse_wheel_without_pixel_delta(self):
         from pyface.qt import QtCore, QtGui
-
-        is_qt4 = QtCore.__version_info__[0] <= 4
-        if is_qt4:
-            self.skipTest("Not directly applicable in Qt4")
 
         # create and mock a mouse wheel event
         qt_event = QtGui.QWheelEvent(


### PR DESCRIPTION
Targeting `stop-testing-pyqt4`.  This PR sits on top of #851 and removes `is_qt4` checks from the code base.  