### PR TITLE
Remove an unnecessary print call from the testsuite

### DIFF
--- a/enable/tests/test_viewport.py
+++ b/enable/tests/test_viewport.py
@@ -26,7 +26,6 @@ class ViewportTestCase(unittest.TestCase):
         )
 
         self.assertEqual(view.view_position, [10, 10])
-        print(view.components_at(0.0, 0.0), view.view_position)
         self.assertTrue(view.components_at(0.0, 0.0)[0] == component)
         self.assertTrue(view.components_at(44.9, 0.0)[0] == component)
         self.assertTrue(view.components_at(0.0, 44.9)[0] == component)


### PR DESCRIPTION
This PR removes an unnecessary use of `print(...)` that adds a bit of noise to the testsuite.