### PR TITLE
Bump version and set IS_RELEASED to False for development of 5.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,9 @@ from setuptools.command.install import install as base_install
 
 MAJOR = 5
 MINOR = 2
-MICRO = 0
+MICRO = 1
 PRERELEASE = ""
-IS_RELEASED = True
+IS_RELEASED = False
 
 # Templates for version strings.
 RELEASED_VERSION = "{major}.{minor}.{micro}{prerelease}"


### PR DESCRIPTION
This PR simply bumps the version number in setup.py for continued development.