### PR TITLE
Fix swig check setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -428,30 +428,7 @@ def macos_extensions():
     ]
 
 
-def verify_swig_version():
-    """ Verify we are using swiig version 3.0.x.
-    """
-    msg = ("SWIG is a required build dependency of Enable. Furthermore, there "
-           "is currently a known issue with SWIG 4.0, "
-           "see enthought/enable#360. Please install SWIG 3.0.x "
-           "(see http://www.swig.org/).")
-    try:
-        cmd = ["swig", "-version"]
-        opts = {"stdout": subprocess.PIPE, "encoding": "utf-8"}
-        with subprocess.Popen(cmd, **opts) as proc:
-            # We expect text along the lines of "SWIG Version 3.X.Y"
-            swig_version_match = re.search(
-                r"(SWIG Version 3)\.\d{1,2}\.\d{1,2}",
-                proc.stdout.read()
-            )
-            if swig_version_match is None:
-                raise Exception(msg)
-    except FileNotFoundError:
-        raise Exception(msg)
-
-
 if __name__ == "__main__":
-    verify_swig_version()
 
     # Write version modules as needed
     enable_version_path = os.path.join('enable', '_version.py')


### PR DESCRIPTION
Follow-up from #839 

Removes the check for Swig (thus undoing the changes from #811). I originally wanted to remove just the version check and leave the check for Swig being found in the path, but I figured that Swig not being installed would be flagged pretty soon anyway when the extension modules are compared.