### PR TITLE
Use "ubuntu-latest" for GitHub Actions CI

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -10,9 +10,7 @@ jobs:
   test-ets:
     strategy:
       matrix:
-        # Note that Ubuntu 20 cannot be used because its SWIG version is 4.0
-        # (enthought/enable#360)
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
         toolkit: ['pyside2', 'wx']
         python-version: [3.8]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         toolkit: ['null', 'pyqt5', 'pyside2', 'wx']
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install Qt dependencies for Linux


### PR DESCRIPTION
This PR updates GitHub Actions CI to use `ubuntu-latest` instead of older `ubuntu-*` versions. This is possible now as #360 has been resolved and we no longer need to pin ubuntu to older versions.