### PR TITLE
Make it possible to manually trigger cron job

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -5,6 +5,8 @@ name: ETS from source
 on:
   schedule:
     - cron:  '0 0 * * 5'
+  # Make it possible to manually trigger the workflow
+  workflow_dispatch:
 
 jobs:
   test-ets:


### PR DESCRIPTION
This PR makes it possible to manually trigger the cron job - using `workflow_dispatch`. Ref https://github.com/enthought/ets/issues/68