### PR TITLE
Fix the dpi related cron job failures

### DIFF
--- a/kiva/tests/drawing_tester.py
+++ b/kiva/tests/drawing_tester.py
@@ -186,7 +186,7 @@ class DrawingImageTester(DrawingTester):
         self.gc.save(filename)
         with Image.open(filename) as image:
             dpi = image.info['dpi']
-        return int(dpi[0])
+        return round(dpi[0])
 
     @contextlib.contextmanager
     def draw_and_check(self):

--- a/kiva/tests/drawing_tester.py
+++ b/kiva/tests/drawing_tester.py
@@ -186,7 +186,7 @@ class DrawingImageTester(DrawingTester):
         self.gc.save(filename)
         with Image.open(filename) as image:
             dpi = image.info['dpi']
-        return dpi[0]
+        return int(dpi[0])
 
     @contextlib.contextmanager
     def draw_and_check(self):


### PR DESCRIPTION
There was a recent `pillow` release which included this change: https://github.com/python-pillow/Pillow/pull/5476
That was causing the cron job to fail with:
```
======================================================================
FAIL: test_save_dpi (kiva.tests.test_agg_drawing.TestAggDrawing)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/kiva/tests/test_agg_drawing.py", line 24, in test_save_dpi
    self.assertEqual(self.save_and_return_dpi(), 144)
AssertionError: 143.99259999999998 != 144

======================================================================
FAIL: test_save_dpi (kiva.tests.test_celiagg_drawing.TestCeliaggDrawing)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/kiva/tests/test_celiagg_drawing.py", line 22, in test_save_dpi
    self.assertEqual(self.save_and_return_dpi(), 144)
AssertionError: 143.99259999999998 != 144

----------------------------------------------------------------------
```

This PR simply adjusts for this by adding an `int()` call when we get the dpi.  Note the above pillow PR explains why this started occurring. 

fixes #866 