### PR TITLE
Backport cron job fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ Fixes
 -----
 
 * Fix FontManager bug when no fonts are available (#871)
+* Fix the dpi related cron job failures (#875)
 
 Enable 5.2.0
 ============

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,7 +8,7 @@ Fixes
 -----
 
 * Fix FontManager bug when no fonts are available (#871)
-* Fix the dpi related cron job failures (#875)
+* Fix the dpi rounding issues with newer versions of pillow (#875)
 
 Enable 5.2.0
 ============

--- a/kiva/tests/drawing_tester.py
+++ b/kiva/tests/drawing_tester.py
@@ -186,7 +186,7 @@ class DrawingImageTester(DrawingTester):
         self.gc.save(filename)
         with Image.open(filename) as image:
             dpi = image.info['dpi']
-        return dpi[0]
+        return round(dpi[0])
 
     @contextlib.contextmanager
     def draw_and_check(self):


### PR DESCRIPTION
targeting `maint/5.2`
This PR backports the recent fix of the cron job failures to the maintenance branch so it can be included in the 5.2.1 bugfix release.  It also updates the changelog