### PR TITLE
Bump version and set IS_RELEASED to False for development on 5.2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,9 @@ from setuptools.command.install import install as base_install
 
 MAJOR = 5
 MINOR = 2
-MICRO = 1
+MICRO = 2
 PRERELEASE = ""
-IS_RELEASED = True
+IS_RELEASED = False
 
 # Templates for version strings.
 RELEASED_VERSION = "{major}.{minor}.{micro}{prerelease}"


### PR DESCRIPTION
This PR simply bumps the version after the 5.2.1 bug fix release for continued development.