### PR TITLE
Backport changelog updates from 5.2.1 release

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ Fixes
 -----
 
 * Fix FontManager bug when no fonts are available (#871)
+* Fix the dpi rounding issues with newer versions of pillow (#875)
 
 Enable 5.2.0
 ============

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,14 @@
 Enable CHANGELOG
 ================
 
+Enable 5.2.1
+============
+
+Fixes
+-----
+
+* Fix FontManager bug when no fonts are available (#871)
+
 Enable 5.2.0
 ============
 


### PR DESCRIPTION
This PR cherrypicks the commits made to the `maint/5.2` branch updating the changelog for the 5.2.1 bugfix release back to master.