### PR TITLE
Fix svg backend issue with pyparsing version >= 3

### DIFF
--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -29,7 +29,7 @@ __extras_require__ = {
     # Dependencies for PDF backend
     "pdf": ["reportlab"],
     # Dependencies for SVG backend
-    "svg": ["pyparsing"],
+    "svg": ["packaging", "pyparsing"],
     # Dependencies purely for running tests.
     "test": [
         "hypothesis",

--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -29,7 +29,7 @@ __extras_require__ = {
     # Dependencies for PDF backend
     "pdf": ["reportlab"],
     # Dependencies for SVG backend
-    "svg": ["packaging", "pyparsing"],
+    "svg": ["pyparsing"],
     # Dependencies purely for running tests.
     "test": [
         "hypothesis",

--- a/enable/savage/svg/pathdata.py
+++ b/enable/savage/svg/pathdata.py
@@ -16,9 +16,7 @@
             pass
 """
 
-from packaging.version import parse
 from pyparsing import (
-    __version__ as pyparsing_version_str,
     CaselessLiteral, Combine, Group, Literal, OneOrMore, Optional,
     ParseException, Word, ZeroOrMore, nums, oneOf
 )
@@ -43,13 +41,12 @@ class CaselessPreservingLiteral(CaselessLiteral):
     def __init__(self, matchString):
         super().__init__(matchString.upper())
 
-        pyparsing_version = parse(pyparsing_version_str)
-        if pyparsing_version.major == 2:
-            self.name = "'%s'" % matchString
-        elif pyparsing_version.major == 3:
-            self.set_name("'%s'" % matchString)
-
-        self.errmsg = "Expected " + self.name
+        quoted_name = f"'{matchString}'"
+        if hasattr(self, "set_name"):
+            # Only available in pyparsing >= 3
+            self.set_name(quoted_name)
+        else:
+            self.setName(quoted_name)
 
     def parseImpl(self, instring, loc, doActions=True):
         test = instring[loc:loc + self.matchLen]

--- a/enable/savage/svg/pathdata.py
+++ b/enable/savage/svg/pathdata.py
@@ -16,7 +16,9 @@
             pass
 """
 
+from packaging.version import parse
 from pyparsing import (
+    __version__ as pyparsing_version_str,
     CaselessLiteral, Combine, Group, Literal, OneOrMore, Optional,
     ParseException, Word, ZeroOrMore, nums, oneOf
 )
@@ -40,7 +42,13 @@ class CaselessPreservingLiteral(CaselessLiteral):
 
     def __init__(self, matchString):
         super().__init__(matchString.upper())
-        self.set_name("'%s'" % matchString)
+
+        pyparsing_version = parse(pyparsing_version_str)
+        if pyparsing_version.major == 2:
+            self.name = "'%s'" % matchString
+        elif pyparsing_version.major == 3:
+            self.set_name("'%s'" % matchString)
+
         self.errmsg = "Expected " + self.name
 
     def parseImpl(self, instring, loc, doActions=True):

--- a/enable/savage/svg/pathdata.py
+++ b/enable/savage/svg/pathdata.py
@@ -40,7 +40,7 @@ class CaselessPreservingLiteral(CaselessLiteral):
 
     def __init__(self, matchString):
         super().__init__(matchString.upper())
-        self.name = "'%s'" % matchString
+        self.set_name("'%s'" % matchString)
         self.errmsg = "Expected " + self.name
 
     def parseImpl(self, instring, loc, doActions=True):

--- a/enable/savage/svg/tests/test_pathdata.py
+++ b/enable/savage/svg/tests/test_pathdata.py
@@ -14,8 +14,16 @@ from pyparsing import ParseException
 from enable.savage.svg.pathdata import (
     Sequence, closePath, coordinatePair, curve, ellipticalArc, horizontalLine,
     lineTo, moveTo, number, quadraticBezierCurveto,
-    smoothQuadraticBezierCurveto, svg, verticalLine
+    smoothQuadraticBezierCurveto, svg, verticalLine, CaselessLiteral,
 )
+
+
+class TestCaselessLiteral(unittest.TestCase):
+    def test_instantiation(self):
+        # regression test for https://github.com/enthought/enable/issues/887
+        # observed with pyparsing v >= 3
+        # we just test that instantiating the class doesnt raise exceptions
+        CaselessLiteral("test")
 
 
 class TestNumber(unittest.TestCase):


### PR DESCRIPTION
fixes #887 

This PR fixes an issue because of an upstream change with the `pyparsing` `CaselessLiteral` class, where the `name` attribute became a read-only property in version >= 3. We now use the new public `set_name` method instead of directly setting the attribute.

Confusingly, this isn't documented in the API changes section of the documentation - https://pyparsing-docs.readthedocs.io/en/latest/whats_new_in_3_0_0.html#api-changes but it can be found by digging into the codebase https://github.com/pyparsing/pyparsing/blob/0352555d968f9952800f0728383de8e1f9526e1e/pyparsing/core.py#L1802-L1805. Note that `CaselessLiteral` inherits from `Token` which in turn inherits from `ParserElement`, which contains the property `name` and the new `set_name` public API.

Note to reviewer : I tested this branch locally in an environment with the latest pyparsing from PyPI (3.0.5) and the testsuite passed.

Todo
- [x] add a regression test