### PR TITLE
Test on ubuntu-18.04, not 16.04

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         toolkit: ['null', 'pyqt5', 'pyside2', 'wx']
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Qt dependencies for Linux

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         toolkit: ['null', 'pyqt5', 'pyside2', 'wx']
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install Qt dependencies for Linux

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Wx dependencies for Linux
         run: |
           sudo apt-get update
-          sudo apt-get install libsdl2-2.0-0
+          sudo apt-get install libsdl2-dev
         if: matrix.toolkit == 'wx'
       - name: Install GL dependencies for Linux
         run: sudo apt-get install libglu1-mesa-dev

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Wx dependencies for Linux
         run: |
           sudo apt-get update
-          sudo apt-get install libsdl2-dev
+          sudo apt-get install libsdl1.2-dev
         if: matrix.toolkit == 'wx'
       - name: Install GL dependencies for Linux
         run: sudo apt-get install libglu1-mesa-dev

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         toolkit: ['null', 'pyqt5', 'pyside2', 'wx']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Qt dependencies for Linux

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -188,7 +188,7 @@ def install(runtime, toolkit, environment, source):
         elif sys.platform == "linux":
             # XXX this is mainly for TravisCI workers; need a generic solution
             commands.append(
-                "edm run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04/ wxPython<4.1"  # noqa: E501
+                "edm run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04/ wxPython<4.1"  # noqa: E501
             )
         else:
             commands.append(


### PR DESCRIPTION
This PR updates the CI to use `ubuntu-18.04`, not `ubuntu-16.04` as it is no longer available on GitHub Actions CI. Accordingly, we also install the necessary `libsdl`.