### PR TITLE
Use `QOpenGLWidget`

### DIFF
--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -26,7 +26,7 @@
 import warnings
 
 # Qt imports.
-from pyface.qt import QtCore, QtGui, QtOpenGL
+from pyface.qt import QtCore, QtGui, QtOpenGL, is_qt4, qt_api
 
 # Enthought library imports.
 from enable.abstract_window import AbstractWindow
@@ -44,6 +44,14 @@ from .constants import (
 
 
 is_qt4 = QtCore.__version_info__[0] <= 4
+
+# QtOpenGLWidgets is not currently exposed in pyface.qt
+if qt_api == "pyside6":
+    from PySide6.QtOpenGLWidgets import QOpenGLWidget
+elif qt_api == "pyqt6":
+    from PyQt6.QtOpenGLWidgets import QOpenGLWidget
+else:
+    QOpenGLWidget = QtOpenGL.QGLWidget
 
 
 class _QtWindowHandler(object):
@@ -289,7 +297,7 @@ class _QtWindow(QtGui.QWidget):
         return self.handler.sizeHint(qt_size_hint)
 
 
-class _QtGLWindow(QtOpenGL.QGLWidget):
+class _QtGLWindow(QOpenGLWidget):
     def __init__(self, parent, enable_window):
         super().__init__(parent)
         self.handler = _QtWindowHandler(self, enable_window)

--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -26,7 +26,7 @@
 import warnings
 
 # Qt imports.
-from pyface.qt import QtCore, QtGui, QtOpenGL, is_qt4, qt_api
+from pyface.qt import QtCore, QtGui, QtOpenGL, is_qt4, is_qt5, qt_api
 
 # Enthought library imports.
 from enable.abstract_window import AbstractWindow
@@ -50,6 +50,10 @@ if qt_api == "pyside6":
     from PySide6.QtOpenGLWidgets import QOpenGLWidget
 elif qt_api == "pyqt6":
     from PyQt6.QtOpenGLWidgets import QOpenGLWidget
+elif qt_api == "pyside2":
+    from PySide2.QtWidgets import QOpenGLWidget
+elif qt_api == "pyqt5":
+    from PyQt5.QtWidgets import QOpenGLWidget
 else:
     QOpenGLWidget = QtOpenGL.QGLWidget
 
@@ -309,7 +313,8 @@ class _QtGLWindow(QOpenGLWidget):
     def paintEvent(self, event):
         super().paintEvent(event)
         self.handler.paintEvent(event)
-        self.swapBuffers()
+        if is_qt4:
+            self.swapBuffers()
 
     def resizeEvent(self, event):
         super().resizeEvent(event)

--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -26,7 +26,7 @@
 import warnings
 
 # Qt imports.
-from pyface.qt import QtCore, QtGui, QtOpenGL, is_qt4, is_qt5, qt_api
+from pyface.qt import QtCore, QtGui, QtOpenGL, is_qt4, qt_api
 
 # Enthought library imports.
 from enable.abstract_window import AbstractWindow

--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -490,7 +490,7 @@ class _Window(AbstractWindow):
             shift_down=bool(modifiers & QtCore.Qt.ShiftModifier),
             control_down=bool(modifiers & QtCore.Qt.ControlModifier),
             left_down=bool(buttons & QtCore.Qt.LeftButton),
-            middle_down=bool(buttons & QtCore.Qt.MidButton),
+            middle_down=bool(buttons & QtCore.Qt.MiddleButton),
             right_down=bool(buttons & QtCore.Qt.RightButton),
             window=self,
         )

--- a/enable/qt4/constants.py
+++ b/enable/qt4/constants.py
@@ -28,7 +28,7 @@ DRAG_RESULTS_MAP = {
 BUTTON_NAME_MAP = {
     QtCore.Qt.LeftButton: "left",
     QtCore.Qt.RightButton: "right",
-    QtCore.Qt.MidButton: "middle",
+    QtCore.Qt.MiddleButton: "middle",
     QtCore.Qt.XButton1: "back",
     QtCore.Qt.XButton2: "forward",
     QtCore.Qt.NoButton: "none",

--- a/kiva/gl/__init__.py
+++ b/kiva/gl/__init__.py
@@ -8,6 +8,7 @@
 #
 # Thanks for using Enthought open source!
 import ctypes
+import logging
 from math import floor
 import sys
 
@@ -18,6 +19,9 @@ from kiva.affine import affine_from_values, transform_points
 from kiva.constants import BOLD, BOLD_ITALIC, ITALIC
 from kiva.fonttools import Font
 from kiva.gl.gl import CompiledPath, GraphicsContextGL, KivaGLFontType
+
+
+logger = logging.getLogger(__name__)
 
 
 def image_as_array(img):
@@ -442,8 +446,11 @@ try:
         return label
 
 
-except ImportError:
+except ImportError as exc:
     # Pyglet is not available, so we forgo some features
+    logger.info(
+        f"Error importing Pyglet, some features not available in gl backend: {exc}",
+    )
     ArrayImage = None
     GetFont = None
     GetLabel = None

--- a/kiva/gl/__init__.py
+++ b/kiva/gl/__init__.py
@@ -448,8 +448,8 @@ try:
 
 except ImportError as exc:
     # Pyglet is not available, so we forgo some features
-    logger.info(
-        f"Error importing Pyglet, some features not available in gl backend: {exc}",
+    logger.exception(
+        "Error importing Pyglet, some features not available in gl backend"
     )
     ArrayImage = None
     GetFont = None


### PR DESCRIPTION
The `QOpenGLWidget` replaces the deprecated `QGLWidget`.  The only change is that we no longer need to actively call `swapBuffer`.

This PR relies on #897 being merged first, since this can't be tested on Qt6 without that PR.