### PR TITLE
Fix text locale test issue on Windows

### DIFF
--- a/kiva/tests/agg/test_text.py
+++ b/kiva/tests/agg/test_text.py
@@ -50,7 +50,7 @@ class TestText(unittest.TestCase):
                 gc.show_text(text)
                 x0, _ = gc.get_text_position()
 
-        with locale_context(locale.LC_CTYPE, ("en", "ASCII")):
+        with locale_context(locale.LC_CTYPE, ("C", "ASCII")):
             gc = agg.GraphicsContextArray((200, 200))
             f = Font("modern")
             with gc:

--- a/kiva/tests/agg/test_text.py
+++ b/kiva/tests/agg/test_text.py
@@ -9,6 +9,7 @@
 # Thanks for using Enthought open source!
 from contextlib import contextmanager
 import locale
+import sys
 import unittest
 
 from kiva import agg
@@ -21,9 +22,7 @@ def locale_context(category, new=None):
     """
     old = locale.getlocale(category)
     try:
-        # check that we can set the current locale to ensure finally will work
         # see Enable #899
-        locale.setlocale(category, old)
         locale.setlocale(category, new)
     except locale.Error as e:
         raise unittest.SkipTest(str(e))
@@ -34,6 +33,12 @@ def locale_context(category, new=None):
 
 
 class TestText(unittest.TestCase):
+
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "Skipping on windows due to issues with setlocale. "
+        "See https://bugs.python.org/issue38324",
+    )
     def test_locale_independence(self):
         # Ensure that >ASCII Unicode text is decoded correctly regardless of
         # the locale.

--- a/kiva/tests/agg/test_text.py
+++ b/kiva/tests/agg/test_text.py
@@ -21,7 +21,10 @@ def locale_context(category, new=None):
     """ Temporarily set the locale.
     """
     old = locale.getlocale(category)
-    locale.setlocale(category, new)
+    try:
+        locale.setlocale(category, new)
+    except locale.Error as e:
+        raise unittest.SkipTest(str(e))
     try:
         yield
     finally:

--- a/kiva/tests/agg/test_text.py
+++ b/kiva/tests/agg/test_text.py
@@ -30,6 +30,11 @@ def locale_context(category, new=None):
 
 class TestText(unittest.TestCase):
 
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "Skipping on windows due to issues with setlocale. "
+        "See issue #899 and https://bugs.python.org/issue38324",
+    )
     def test_locale_independence(self):
         # Ensure that >ASCII Unicode text is decoded correctly regardless of
         # the locale.

--- a/kiva/tests/agg/test_text.py
+++ b/kiva/tests/agg/test_text.py
@@ -35,7 +35,7 @@ class TestText(unittest.TestCase):
         # the locale.
         text = "\N{GREEK SMALL LETTER MU}"
 
-        with locale_context(locale.LC_CTYPE, ("en", "UTF-8")):
+        with locale_context(locale.LC_CTYPE, ("en", "utf8")):
             gc = agg.GraphicsContextArray((200, 200))
             f = Font("modern")
             with gc:

--- a/kiva/tests/agg/test_text.py
+++ b/kiva/tests/agg/test_text.py
@@ -21,6 +21,9 @@ def locale_context(category, new=None):
     """
     old = locale.getlocale(category)
     try:
+        # check that we can set the current locale to ensure finally will work
+        # see Enable #899
+        locale.setlocale(category, old)
         locale.setlocale(category, new)
     except locale.Error as e:
         raise unittest.SkipTest(str(e))

--- a/kiva/tests/agg/test_text.py
+++ b/kiva/tests/agg/test_text.py
@@ -30,11 +30,6 @@ def locale_context(category, new=None):
 
 class TestText(unittest.TestCase):
 
-    @unittest.skipIf(
-        sys.platform == "win32",
-        "Skipping on windows due to issues with setlocale. "
-        "See issue #899 and https://bugs.python.org/issue38324",
-    )
     def test_locale_independence(self):
         # Ensure that >ASCII Unicode text is decoded correctly regardless of
         # the locale.

--- a/kiva/tests/agg/test_text.py
+++ b/kiva/tests/agg/test_text.py
@@ -21,11 +21,7 @@ def locale_context(category, new=None):
     """ Temporarily set the locale.
     """
     old = locale.getlocale(category)
-    try:
-        # see Enable #899
-        locale.setlocale(category, new)
-    except locale.Error as e:
-        raise unittest.SkipTest(str(e))
+    locale.setlocale(category, new)
     try:
         yield
     finally:
@@ -37,7 +33,7 @@ class TestText(unittest.TestCase):
     @unittest.skipIf(
         sys.platform == "win32",
         "Skipping on windows due to issues with setlocale. "
-        "See https://bugs.python.org/issue38324",
+        "See issue #899 and https://bugs.python.org/issue38324",
     )
     def test_locale_independence(self):
         # Ensure that >ASCII Unicode text is decoded correctly regardless of


### PR DESCRIPTION
This attempts to set the locale to the current value before changing to the testing locale to ensure that a reset will work.  On failure, it skips which matches previous behaviour.

Fixes #899