### PR TITLE
Handle .ttf fonts with missing `ulCodePageRange1` entries

### DIFF
--- a/kiva/fonttools/_util.py
+++ b/kiva/fonttools/_util.py
@@ -155,10 +155,14 @@ def get_ttf_prop_dict(font):
                 if bit in _ot_unicode_range_bits:
                     languages.add(_ot_unicode_range_bits[bit])
         # Check the codepage range bits
-        cp_bits = table.ulCodePageRange1
-        for lang, mask in _ot_code_page_masks.items():
-            if cp_bits & mask:
-                languages.add(lang)
+        try:
+            cp_bits = table.ulCodePageRange1
+            for lang, mask in _ot_code_page_masks.items():
+                if cp_bits & mask:
+                    languages.add(lang)
+        except AttributeError:
+            # some fonts don't have ulCodePageRange1
+            pass
         # Lock the set so that it's hashable
         propdict["languages"] = frozenset(languages)
     except KeyError:


### PR DESCRIPTION
I think this happens for either very old fonts or fonts which aren't fully compliant with the open type specification.  Not much either we or the user can do about it, so we just ignore - the information we want isn't there.

We could write a test if we can find a font which is missing this piece of data and has a suitable license (eg. OTL).  However the only fonts I could find with this are [Humor sans 1.0](http://xkcdsucks.blogspot.com/2009/03/xkcdsucks-is-proud-to-present-humor.html) which is unlicensed and MTExtra which is owned by Microsoft and which is not suitably licensed.

A reviewer can validate that this PR works by:
- having either Humor Sans or MTExtra installed in their test system
- clearing out ~/.enthought/kiva (or the corresponding directory on Windows)
- running some code which uses fonttools (eg. the kiva_explorer script should be fine).
- confirming that there is no error output to the consule

Fixes #882.