### PR TITLE
Fix Qt6 mouse event code

### DIFF
--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -26,7 +26,7 @@
 import warnings
 
 # Qt imports.
-from pyface.qt import QtCore, QtGui, QtOpenGL, is_qt4, qt_api
+from pyface.qt import QtCore, QtGui, QtOpenGL, is_qt4, is_qt5, qt_api
 
 # Enthought library imports.
 from enable.abstract_window import AbstractWindow
@@ -457,8 +457,12 @@ class _Window(AbstractWindow):
         # If the event (if there is one) doesn't contain the mouse position,
         # modifiers and buttons then get sensible defaults.
         try:
-            x = event.x()
-            y = event.y()
+            if is_qt4 or is_qt5:
+                x = event.x()
+                y = event.y()
+            else:
+                x = event.position().x()
+                y = event.position().y()
             modifiers = event.modifiers()
             buttons = event.buttons()
         except AttributeError:

--- a/enable/tests/qt4/test_mouse_wheel.py
+++ b/enable/tests/qt4/test_mouse_wheel.py
@@ -50,34 +50,34 @@ class MouseWheelTestCase(TestCase):
         # create and mock a mouse wheel event
         if is_qt4:
             qt_event = QtGui.QWheelEvent(
-                QtCore.QPoint(0, 0),
-                200,
-                QtCore.Qt.NoButton,
-                QtCore.Qt.NoModifier,
-                QtCore.Qt.Vertical,
+                QtCore.QPoint(0, 0),  # pos
+                200,  # delta
+                QtCore.Qt.NoButton,  # buttons
+                QtCore.Qt.NoModifier,  # modifiers
+                QtCore.Qt.Vertical,  # orient
             )
         elif is_qt5:
             qt_event = QtGui.QWheelEvent(
-                pos=QtCore.QPointF(0, 0),
-                globalPos=self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
-                pixelDelta=QtCore.QPoint(0, 200),
-                angleDelta=QtCore.QPoint(0, 200),
-                qt4Delta=200,
-                qt4Orietation=QtCore.Qt.Vertical,
-                buttons=QtCore.Qt.NoButton,
-                modifiers=QtCore.Qt.NoModifier,
-                phase=QtCore.Qt.ScrollUpdate,
+                QtCore.QPointF(0, 0),  # pos
+                self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),  # globalPos
+                QtCore.QPoint(0, 200),  # pixelDelta
+                QtCore.QPoint(0, 200),  # angleDelta
+                200,  # qt4Delta
+                QtCore.Qt.Vertical,  # qt4Orietation
+                QtCore.Qt.NoButton,  # buttons
+                QtCore.Qt.NoModifier,  # modifiers
+                QtCore.Qt.ScrollUpdate,  # phase
             )
         else:
             qt_event = QtGui.QWheelEvent(
-                pos=QtCore.QPointF(0, 0),
-                globalPos=self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),
-                pixelDelta=QtCore.QPoint(0, 200),
-                angleDelta=QtCore.QPoint(0, 200),
-                buttons=QtCore.Qt.NoButton,
-                modifiers=QtCore.Qt.NoModifier,
-                phase=QtCore.Qt.ScrollUpdate,
-                inverted=False,
+                QtCore.QPointF(0, 0),  # pos
+                self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),  # globalPos
+                QtCore.QPoint(0, 200),  # pixelDelta
+                QtCore.QPoint(0, 200),  # angleDelta
+                QtCore.Qt.NoButton,  # buttons
+                QtCore.Qt.NoModifier,  # modifiers
+                QtCore.Qt.ScrollUpdate,  # phase
+                False,  # inverted
             )
 
         # dispatch event
@@ -94,34 +94,34 @@ class MouseWheelTestCase(TestCase):
         # create and mock a mouse wheel event
         if is_qt4:
             qt_event = QtGui.QWheelEvent(
-                QtCore.QPoint(0, 0),
-                200,
-                QtCore.Qt.NoButton,
-                QtCore.Qt.NoModifier,
-                QtCore.Qt.Horizontal,
+                QtCore.QPoint(0, 0),  # pos
+                200,  # delta
+                QtCore.Qt.NoButton,  # buttons
+                QtCore.Qt.NoModifier,  # modifiers
+                QtCore.Qt.Horizontal,  # orient
             )
         elif is_qt5:
             qt_event = QtGui.QWheelEvent(
-                pos=QtCore.QPointF(0, 0),
-                globalPos=self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
-                pixelDelta=QtCore.QPoint(200, 0),
-                angleDelta=QtCore.QPoint(200, 0),
-                qt4Delta=200,
-                qt4Orietation=QtCore.Qt.Horizontal,
-                buttons=QtCore.Qt.NoButton,
-                modifiers=QtCore.Qt.NoModifier,
-                phase=QtCore.Qt.ScrollUpdate,
+                QtCore.QPointF(0, 0),  # pos
+                self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),  # globalPos
+                QtCore.QPoint(200, 0),  # pixelDelta
+                QtCore.QPoint(200, 0),  # angleDelta
+                200,  # qt4Delta
+                QtCore.Qt.Horizontal,  # qt4Orietation
+                QtCore.Qt.NoButton,  # buttons
+                QtCore.Qt.NoModifier,  # modifiers
+                QtCore.Qt.ScrollUpdate,  # phase
             )
         else:
             qt_event = QtGui.QWheelEvent(
-                pos=QtCore.QPointF(0, 0),
-                globalPos=self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),
-                pixelDelta=QtCore.QPoint(200, 0),
-                angleDelta=QtCore.QPoint(200, 0),
-                buttons=QtCore.Qt.NoButton,
-                modifiers=QtCore.Qt.NoModifier,
-                phase=QtCore.Qt.ScrollUpdate,
-                inverted=False,
+                QtCore.QPointF(0, 0),  # pos
+                self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),  # globalPos
+                QtCore.QPoint(200, 0),  # pixelDelta
+                QtCore.QPoint(200, 0),  # angleDelta
+                QtCore.Qt.NoButton,  # buttons
+                QtCore.Qt.NoModifier,  # modifiers
+                QtCore.Qt.ScrollUpdate,  # phase
+                False,  # inverted
             )
 
         # dispatch event
@@ -138,34 +138,34 @@ class MouseWheelTestCase(TestCase):
         # create and mock a mouse wheel event
         if is_qt4:
             qt_event = QtGui.QWheelEvent(
-                QtCore.QPoint(0, 0),
-                200,
-                QtCore.Qt.NoButton,
-                QtCore.Qt.NoModifier,
-                QtCore.Qt.Vertical,
+                QtCore.QPoint(0, 0),  # pos
+                200,  # delta
+                QtCore.Qt.NoButton,  # buttons
+                QtCore.Qt.NoModifier,  # modifiers
+                QtCore.Qt.Vertical,  # orient
             )
         elif is_qt5:
             qt_event = QtGui.QWheelEvent(
-                pos=QtCore.QPointF(0, 0),
-                globalPos=self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
-                pixelDelta=QtCore.QPoint(0, 0),
-                angleDelta=QtCore.QPoint(0, 200),
-                qt4Delta=200,
-                qt4Orientation=QtCore.Qt.Horizontal,
-                buttons=QtCore.Qt.NoButton,
-                modifiers=QtCore.Qt.NoModifier,
-                phase=QtCore.Qt.ScrollUpdate,
+                QtCore.QPointF(0, 0),  # pos
+                self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),  # globalPos
+                QtCore.QPoint(0, 0),  # pixelDelta
+                QtCore.QPoint(0, 200),  # angleDelta
+                200,  # qt4Delta
+                QtCore.Qt.Horizontal,  # qt4Orientation
+                QtCore.Qt.NoButton,  # buttons
+                QtCore.Qt.NoModifier,  # modifiers
+                QtCore.Qt.ScrollUpdate,  # phase
             )
         else:
             qt_event = QtGui.QWheelEvent(
-                pos=QtCore.QPointF(0, 0),
-                globalPos=self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),
-                pixelDelta=QtCore.QPoint(0, 0),
-                angleDelta=QtCore.QPoint(0, 200),
-                buttos=QtCore.Qt.NoButton,
-                modifiers=QtCore.Qt.NoModifier,
-                phase=QtCore.Qt.ScrollUpdate,
-                inverted=False,
+                QtCore.QPointF(0, 0),  # pos
+                self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),  # globalPos
+                QtCore.QPoint(0, 0),  # pixelDelta
+                QtCore.QPoint(0, 200),  # angleDelta
+                QtCore.Qt.NoButton,  # buttos
+                QtCore.Qt.NoModifier,  # modifiers
+                QtCore.Qt.ScrollUpdate,  # phase
+                False,  # inverted
             )
 
         # dispatch event

--- a/enable/tests/qt4/test_mouse_wheel.py
+++ b/enable/tests/qt4/test_mouse_wheel.py
@@ -58,26 +58,26 @@ class MouseWheelTestCase(TestCase):
             )
         elif is_qt5:
             qt_event = QtGui.QWheelEvent(
-                QtCore.QPoint(0, 0),
-                self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
-                QtCore.QPoint(0, 200),
-                QtCore.QPoint(0, 200),
-                200,
-                QtCore.Qt.Vertical,
-                QtCore.Qt.NoButton,
-                QtCore.Qt.NoModifier,
-                QtCore.Qt.ScrollUpdate,
+                pos=QtCore.QPointF(0, 0),
+                globalPos=self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
+                pixelDelta=QtCore.QPoint(0, 200),
+                angleDelta=QtCore.QPoint(0, 200),
+                qt4Delta=200,
+                qt4Orietation=QtCore.Qt.Vertical,
+                buttons=QtCore.Qt.NoButton,
+                modifiers=QtCore.Qt.NoModifier,
+                phase=QtCore.Qt.ScrollUpdate,
             )
         else:
             qt_event = QtGui.QWheelEvent(
-                QtCore.QPointF(0, 0),
-                self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),
-                QtCore.QPoint(0, 200),
-                QtCore.QPoint(0, 200),
-                QtCore.Qt.NoButton,
-                QtCore.Qt.NoModifier,
-                QtCore.Qt.ScrollUpdate,
-                False,
+                pos=QtCore.QPointF(0, 0),
+                globalPos=self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),
+                pixelDelta=QtCore.QPoint(0, 200),
+                angleDelta=QtCore.QPoint(0, 200),
+                buttons=QtCore.Qt.NoButton,
+                modifiers=QtCore.Qt.NoModifier,
+                phase=QtCore.Qt.ScrollUpdate,
+                inverted=False,
             )
 
         # dispatch event
@@ -102,26 +102,26 @@ class MouseWheelTestCase(TestCase):
             )
         elif is_qt5:
             qt_event = QtGui.QWheelEvent(
-                QtCore.QPoint(0, 0),
-                self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
-                QtCore.QPoint(200, 0),
-                QtCore.QPoint(200, 0),
-                200,
-                QtCore.Qt.Horizontal,
-                QtCore.Qt.NoButton,
-                QtCore.Qt.NoModifier,
-                QtCore.Qt.ScrollUpdate,
+                pos=QtCore.QPointF(0, 0),
+                globalPos=self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
+                pixelDelta=QtCore.QPoint(200, 0),
+                angleDelta=QtCore.QPoint(200, 0),
+                qt4Delta=200,
+                qt4Orietation=QtCore.Qt.Horizontal,
+                buttons=QtCore.Qt.NoButton,
+                modifiers=QtCore.Qt.NoModifier,
+                phase=QtCore.Qt.ScrollUpdate,
             )
         else:
             qt_event = QtGui.QWheelEvent(
-                QtCore.QPointF(0, 0),  #pos
-                self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),  # global pos
-                QtCore.QPoint(200, 0),  # pixel delta
-                QtCore.QPoint(200, 0),  # angle delta
-                QtCore.Qt.NoButton,  # mouse buttons
-                QtCore.Qt.NoModifier,  # keyboard modifiers
-                QtCore.Qt.ScrollUpdate,  # phase
-                False,  #inverted
+                pos=QtCore.QPointF(0, 0),
+                globalPos=self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),
+                pixelDelta=QtCore.QPoint(200, 0),
+                angleDelta=QtCore.QPoint(200, 0),
+                buttons=QtCore.Qt.NoButton,
+                modifiers=QtCore.Qt.NoModifier,
+                phase=QtCore.Qt.ScrollUpdate,
+                inverted=False,
             )
 
         # dispatch event
@@ -136,28 +136,36 @@ class MouseWheelTestCase(TestCase):
         from pyface.qt import QtCore, QtGui, is_qt4, is_qt5
 
         # create and mock a mouse wheel event
-        if is_qt5:
+        if is_qt4:
             qt_event = QtGui.QWheelEvent(
                 QtCore.QPoint(0, 0),
-                self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
-                QtCore.QPoint(0, 0),
-                QtCore.QPoint(0, 200),
                 200,
-                QtCore.Qt.Vertical,
                 QtCore.Qt.NoButton,
                 QtCore.Qt.NoModifier,
-                QtCore.Qt.ScrollUpdate,
+                QtCore.Qt.Vertical,
+            )
+        elif is_qt5:
+            qt_event = QtGui.QWheelEvent(
+                pos=QtCore.QPointF(0, 0),
+                globalPos=self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
+                pixelDelta=QtCore.QPoint(0, 0),
+                angleDelta=QtCore.QPoint(0, 200),
+                qt4Delta=200,
+                qt4Orientation=QtCore.Qt.Horizontal,
+                buttons=QtCore.Qt.NoButton,
+                modifiers=QtCore.Qt.NoModifier,
+                phase=QtCore.Qt.ScrollUpdate,
             )
         else:
             qt_event = QtGui.QWheelEvent(
-                QtCore.QPointF(0, 0),
-                self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),
-                QtCore.QPoint(0, 0),
-                QtCore.QPoint(0, 200),
-                QtCore.Qt.NoButton,
-                QtCore.Qt.NoModifier,
-                QtCore.Qt.ScrollUpdate,
-                False,
+                pos=QtCore.QPointF(0, 0),
+                globalPos=self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),
+                pixelDelta=QtCore.QPoint(0, 0),
+                angleDelta=QtCore.QPoint(0, 200),
+                buttos=QtCore.Qt.NoButton,
+                modifiers=QtCore.Qt.NoModifier,
+                phase=QtCore.Qt.ScrollUpdate,
+                inverted=False,
             )
 
         # dispatch event

--- a/enable/tests/qt4/test_mouse_wheel.py
+++ b/enable/tests/qt4/test_mouse_wheel.py
@@ -58,7 +58,7 @@ class MouseWheelTestCase(TestCase):
             )
         elif is_qt5:
             qt_event = QtGui.QWheelEvent(
-                QtCore.QPointF(0, 0),  # pos
+                QtCore.QPoint(0, 0),  # pos
                 self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),  # globalPos
                 QtCore.QPoint(0, 200),  # pixelDelta
                 QtCore.QPoint(0, 200),  # angleDelta
@@ -102,7 +102,7 @@ class MouseWheelTestCase(TestCase):
             )
         elif is_qt5:
             qt_event = QtGui.QWheelEvent(
-                QtCore.QPointF(0, 0),  # pos
+                QtCore.QPoint(0, 0),  # pos
                 self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),  # globalPos
                 QtCore.QPoint(200, 0),  # pixelDelta
                 QtCore.QPoint(200, 0),  # angleDelta
@@ -146,7 +146,7 @@ class MouseWheelTestCase(TestCase):
             )
         elif is_qt5:
             qt_event = QtGui.QWheelEvent(
-                QtCore.QPointF(0, 0),  # pos
+                QtCore.QPoint(0, 0),  # pos
                 self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),  # globalPos
                 QtCore.QPoint(0, 0),  # pixelDelta
                 QtCore.QPoint(0, 200),  # angleDelta

--- a/enable/tests/qt4/test_mouse_wheel.py
+++ b/enable/tests/qt4/test_mouse_wheel.py
@@ -44,9 +44,8 @@ class MouseWheelTestCase(TestCase):
         self.window._size = (600, 600)
 
     def test_vertical_mouse_wheel(self):
-        from pyface.qt import QtCore, QtGui
+        from pyface.qt import QtCore, QtGui, is_qt4, is_qt5
 
-        is_qt4 = QtCore.__version_info__[0] <= 4
 
         # create and mock a mouse wheel event
         if is_qt4:
@@ -57,7 +56,7 @@ class MouseWheelTestCase(TestCase):
                 QtCore.Qt.NoModifier,
                 QtCore.Qt.Vertical,
             )
-        else:
+        elif is_qt5:
             qt_event = QtGui.QWheelEvent(
                 QtCore.QPoint(0, 0),
                 self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
@@ -68,6 +67,17 @@ class MouseWheelTestCase(TestCase):
                 QtCore.Qt.NoButton,
                 QtCore.Qt.NoModifier,
                 QtCore.Qt.ScrollUpdate,
+            )
+        else:
+            qt_event = QtGui.QWheelEvent(
+                QtCore.QPointF(0, 0),
+                self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),
+                QtCore.QPoint(0, 200),
+                QtCore.QPoint(0, 200),
+                QtCore.Qt.NoButton,
+                QtCore.Qt.NoModifier,
+                QtCore.Qt.ScrollUpdate,
+                False,
             )
 
         # dispatch event
@@ -79,9 +89,7 @@ class MouseWheelTestCase(TestCase):
         self.assertEqual(self.tool.event.mouse_wheel_delta, (0, 200))
 
     def test_horizontal_mouse_wheel(self):
-        from pyface.qt import QtCore, QtGui
-
-        is_qt4 = QtCore.__version_info__[0] <= 4
+        from pyface.qt import QtCore, QtGui, is_qt4, is_qt5
 
         # create and mock a mouse wheel event
         if is_qt4:
@@ -92,17 +100,28 @@ class MouseWheelTestCase(TestCase):
                 QtCore.Qt.NoModifier,
                 QtCore.Qt.Horizontal,
             )
-        else:
+        elif is_qt5:
             qt_event = QtGui.QWheelEvent(
                 QtCore.QPoint(0, 0),
                 self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
                 QtCore.QPoint(200, 0),
                 QtCore.QPoint(200, 0),
                 200,
-                QtCore.Qt.Vertical,
+                QtCore.Qt.Horizontal,
                 QtCore.Qt.NoButton,
                 QtCore.Qt.NoModifier,
                 QtCore.Qt.ScrollUpdate,
+            )
+        else:
+            qt_event = QtGui.QWheelEvent(
+                QtCore.QPointF(0, 0),  #pos
+                self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),  # global pos
+                QtCore.QPoint(200, 0),  # pixel delta
+                QtCore.QPoint(200, 0),  # angle delta
+                QtCore.Qt.NoButton,  # mouse buttons
+                QtCore.Qt.NoModifier,  # keyboard modifiers
+                QtCore.Qt.ScrollUpdate,  # phase
+                False,  #inverted
             )
 
         # dispatch event
@@ -114,24 +133,32 @@ class MouseWheelTestCase(TestCase):
         self.assertEqual(self.tool.event.mouse_wheel_delta, (200, 0))
 
     def test_vertical_mouse_wheel_without_pixel_delta(self):
-        from pyface.qt import QtCore, QtGui
-
-        is_qt4 = QtCore.__version_info__[0] <= 4
-        if is_qt4:
-            self.skipTest("Not directly applicable in Qt4")
+        from pyface.qt import QtCore, QtGui, is_qt4, is_qt5
 
         # create and mock a mouse wheel event
-        qt_event = QtGui.QWheelEvent(
-            QtCore.QPoint(0, 0),
-            self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
-            QtCore.QPoint(0, 0),
-            QtCore.QPoint(0, 200),
-            200,
-            QtCore.Qt.Vertical,
-            QtCore.Qt.NoButton,
-            QtCore.Qt.NoModifier,
-            QtCore.Qt.ScrollUpdate,
-        )
+        if is_qt5:
+            qt_event = QtGui.QWheelEvent(
+                QtCore.QPoint(0, 0),
+                self.window.control.mapToGlobal(QtCore.QPoint(0, 0)),
+                QtCore.QPoint(0, 0),
+                QtCore.QPoint(0, 200),
+                200,
+                QtCore.Qt.Vertical,
+                QtCore.Qt.NoButton,
+                QtCore.Qt.NoModifier,
+                QtCore.Qt.ScrollUpdate,
+            )
+        else:
+            qt_event = QtGui.QWheelEvent(
+                QtCore.QPointF(0, 0),
+                self.window.control.mapToGlobal(QtCore.QPointF(0, 0)),
+                QtCore.QPoint(0, 0),
+                QtCore.QPoint(0, 200),
+                QtCore.Qt.NoButton,
+                QtCore.Qt.NoModifier,
+                QtCore.Qt.ScrollUpdate,
+                False,
+            )
 
         # dispatch event
         self.window._on_mouse_wheel(qt_event)


### PR DESCRIPTION
This fixes #915 but additionally will fix code from other Qt mouse events, since the position API has changed - there are no longer `x` and `y` position getters available in Qt6.

This:
- uses the new API for position for Qt6 mouse events
- fixes the test code that generates synthetic mouse events for Qt6