### PR TITLE
Ensure toolkit is initialized before use

### DIFF
--- a/enable/colors.py
+++ b/enable/colors.py
@@ -9,8 +9,11 @@
 # Thanks for using Enthought open source!
 # This is a redirection file that determines what constitutes a color trait
 # in Chaco, and what constitutes the standard colors.
+
 from traits.etsconfig.api import ETSConfig
 from traits.api import List, Str, Trait, Tuple, TraitError
+from traitsui.api import toolkit as traits_toolkit
+
 
 # Color definitions
 transparent_color = (0.0, 0.0, 0.0, 0.0)
@@ -174,13 +177,8 @@ color_table = {
     "sys_window": (0.83137, 0.81569, 0.78431, 1.0),
 }
 
-if not ETSConfig.toolkit:
-    # Force Traits to decide on its toolkit if it hasn't already
-    from traitsui.api import toolkit as traits_toolkit
 
-    traits_toolkit()
-
-if ETSConfig.toolkit == "wx":
+if traits_toolkit().toolkit == "wx":
     import wx
     from traitsui.wx.color_editor import (
         ToolkitEditorFactory as StandardColorEditorFactory,
@@ -282,7 +280,7 @@ if ETSConfig.toolkit == "wx":
         editor=ColorEditorFactory,
     )
 
-elif ETSConfig.toolkit.startswith("qt"):
+elif traits_toolkit().toolkit.startswith("qt"):
     from pyface.qt import QtGui
     from traitsui.qt4.color_editor import (
         ToolkitEditorFactory as StandardColorEditorFactory,

--- a/enable/colors.py
+++ b/enable/colors.py
@@ -10,7 +10,6 @@
 # This is a redirection file that determines what constitutes a color trait
 # in Chaco, and what constitutes the standard colors.
 
-from traits.etsconfig.api import ETSConfig
 from traits.api import List, Str, Trait, Tuple, TraitError
 from traitsui.api import toolkit as traits_toolkit
 

--- a/enable/component_editor.py
+++ b/enable/component_editor.py
@@ -19,7 +19,7 @@ from traitsui.api import BasicEditorFactory, toolkit_object
 
 Editor = toolkit_object("editor:Editor")
 try:
-    Editor()
+    Editor(None)
 except NotImplementedError:
     Editor = object
 

--- a/enable/component_editor.py
+++ b/enable/component_editor.py
@@ -13,24 +13,18 @@
 from enable.colors import ColorTrait
 from enable.window import Window
 
-from traits.etsconfig.api import ETSConfig
-
 from traits.api import Bool, Property, Tuple
-from traitsui.api import BasicEditorFactory
+from traitsui.api import BasicEditorFactory, toolkit_object
 
-if ETSConfig.toolkit == "wx":
-    from traitsui.wx.editor import Editor
-elif ETSConfig.toolkit.startswith("qt"):
-    from traitsui.qt4.editor import Editor
-else:
+
+Editor = toolkit_object("editor:Editor")
+try:
+    Editor()
+except NotImplementedError:
     Editor = object
 
 
 class _ComponentEditor(Editor):
-
-    # -------------------------------------------------------------------------
-    #  Trait definitions:
-    # -------------------------------------------------------------------------
 
     # The plot editor is scrollable (overrides Traits UI Editor).
     scrollable = True

--- a/enable/component_editor.py
+++ b/enable/component_editor.py
@@ -14,13 +14,10 @@ from enable.colors import ColorTrait
 from enable.window import Window
 
 from traits.api import Bool, Property, Tuple
-from traitsui.api import BasicEditorFactory, toolkit_object
-
+from traitsui.api import BasicEditorFactory, Editor as BaseEditor, toolkit_object
 
 Editor = toolkit_object("editor:Editor")
-try:
-    Editor(None)
-except NotImplementedError:
+if not issubclass(Editor, BaseEditor):
     Editor = object
 
 

--- a/enable/examples/_example_support.py
+++ b/enable/examples/_example_support.py
@@ -13,7 +13,6 @@ demo programs have to use.
 """
 
 from traits.api import HasTraits, Instance
-from traits.etsconfig.api import ETSConfig
 from traitsui.api import Item, View
 
 from enable.api import Component, ComponentEditor

--- a/enable/tools/hover_tool.py
+++ b/enable/tools/hover_tool.py
@@ -15,7 +15,7 @@ components.
 # Enthought library imports
 from enable.base_tool import BaseTool
 from traits.api import Any, Callable, Enum, Float, Int
-from pyface.api import toolkit
+from pyface.toolkit import toolkit
 from pyface.timer.api import DoLaterTimer
 
 

--- a/enable/tools/hover_tool.py
+++ b/enable/tools/hover_tool.py
@@ -15,12 +15,12 @@ components.
 # Enthought library imports
 from enable.base_tool import BaseTool
 from traits.api import Any, Callable, Enum, Float, Int
-from traits.etsconfig.api import ETSConfig
+from pyface.api import toolkit
 from pyface.timer.api import DoLaterTimer
 
 
 # Define a toolkit-specific function for determining the global mouse position
-if ETSConfig.toolkit == "wx":
+if toolkit.toolkit == "wx":
     import wx
 
     def GetGlobalMousePosition():
@@ -33,7 +33,7 @@ if ETSConfig.toolkit == "wx":
             raise RuntimeError("Unable to determine mouse position")
 
 
-elif ETSConfig.toolkit.startswith("qt"):
+elif toolkit.toolkit.startswith("qt"):
     from pyface.qt import QtGui
 
     def GetGlobalMousePosition():

--- a/enable/tools/hover_tool.py
+++ b/enable/tools/hover_tool.py
@@ -20,6 +20,7 @@ from pyface.timer.api import DoLaterTimer
 
 
 # Define a toolkit-specific function for determining the global mouse position
+# XXX this probably belongs in Pyface's SystemMetrics or something similar.
 if toolkit.toolkit == "wx":
     import wx
 
@@ -46,7 +47,7 @@ else:
     def GetGlobalMousePosition():
         raise NotImplementedError(
             "GetGlobalMousePosition is not defined for"
-            "toolkit '%s'." % ETSConfig.toolkit
+            "toolkit '%s'." % toolkit.toolkit
         )
 
 

--- a/enable/trait_defs/ui/rgba_color_editor.py
+++ b/enable/trait_defs/ui/rgba_color_editor.py
@@ -7,11 +7,11 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-from traits.etsconfig.api import ETSConfig
+from traitsui.api import toolkit
 
-if ETSConfig.toolkit == "wx":
+if toolkit().toolkit == "wx":
     from .wx.rgba_color_editor import RGBAColorEditor
-elif ETSConfig.toolkit.startswith("qt"):
+elif toolkit().toolkit.startswith("qt"):
     from .qt4.rgba_color_editor import RGBAColorEditor
 else:
     RGBAColorEditor = None

--- a/kiva/fonttools/app_font.py
+++ b/kiva/fonttools/app_font.py
@@ -9,8 +9,6 @@
 # Thanks for using Enthought open source!
 import warnings
 
-from traits.etsconfig.api import ETSConfig
-
 from kiva.fonttools.font_manager import default_font_manager
 
 
@@ -31,9 +29,11 @@ def add_application_fonts(filenames):
     fm.update_fonts(filenames)
 
     # Handle the GUI toolkit
-    if ETSConfig.toolkit.startswith("qt"):
+    from traitsui.api import toolkit
+
+    if toolkit().toolkit.startswith("qt"):
         _qt_impl(filenames)
-    elif ETSConfig.toolkit == "wx":
+    elif toolkit().toolkit == "wx":
         _wx_impl(filenames)
 
 

--- a/kiva/fonttools/app_font.py
+++ b/kiva/fonttools/app_font.py
@@ -7,9 +7,13 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+import logging
 import warnings
 
 from kiva.fonttools.font_manager import default_font_manager
+
+
+logger = logging.getLogger(__name__)
 
 
 def add_application_fonts(filenames):
@@ -23,18 +27,27 @@ def add_application_fonts(filenames):
     """
     if isinstance(filenames, str):
         filenames = [filenames]
+    logger.info(f"Installing additonal fonts: {filenames}")
 
     # Handle Kiva
     fm = default_font_manager()
     fm.update_fonts(filenames)
+    logger.debug("Additional fonts installed into Kiva backends.")
 
     # Handle the GUI toolkit
-    from traitsui.api import toolkit
+    try:
+        from pyface.toolkit import toolkit
+    except ImportError:
+        toolkit = None
+        logger.exception(
+            "Pyface not available, Kiva fonts not installed into toolkit."
+        )
 
-    if toolkit().toolkit.startswith("qt"):
-        _qt_impl(filenames)
-    elif toolkit().toolkit == "wx":
-        _wx_impl(filenames)
+    if toolkit is not None:
+        if toolkit.toolkit.startswith("qt"):
+            _qt_impl(filenames)
+        elif toolkit.toolkit == "wx":
+            _wx_impl(filenames)
 
 
 def _qt_impl(filenames):
@@ -42,6 +55,7 @@ def _qt_impl(filenames):
 
     for fname in filenames:
         QtGui.QFontDatabase.addApplicationFont(fname)
+    logger.debug("Additional fonts installed into Qt toolkit.")
 
 
 def _wx_impl(filenames):
@@ -50,5 +64,6 @@ def _wx_impl(filenames):
     if hasattr(wx.Font, "CanUsePrivateFont") and wx.Font.CanUsePrivateFont():
         for fname in filenames:
             wx.Font.AddPrivateFont(fname)
+        logger.debug("Additional fonts installed into Wx toolkit.")
     else:
         warnings.warn("Wx does not support private fonts! Failed to add.")

--- a/kiva/trait_defs/kiva_font_trait.py
+++ b/kiva/trait_defs/kiva_font_trait.py
@@ -10,22 +10,28 @@
 """ Trait definition for a wxPython-based Kiva font.
 """
 
-# -----------------------------------------------------------------------------
-#  Imports:
-# -----------------------------------------------------------------------------
+import logging
 
 from traits.api import Trait, TraitError, TraitHandler, TraitFactory
-from traitsui.api import toolkit
 
-if toolkit().toolkit == "wx":
-    from .ui.wx.kiva_font_editor import KivaFontEditor
-elif toolkit().toolkit.startswith("qt"):
-    # FIXME
-    # from .ui.qt4.kiva_font_editor import KivaFontEditor
-    KivaFontEditor = None
-else:
-    KivaFontEditor = None
+logger = logging.getLogger(__name__)
 
+try:
+    from traitsui.api import toolkit
+except ImportError:
+    toolkit = None
+    logger.exception("Could not import TraitsUI, KivaFontTrait has no editor")
+
+
+KivaFontEditor = None
+
+if toolkit is not None:
+    if toolkit().toolkit == "wx":
+        from .ui.wx.kiva_font_editor import KivaFontEditor
+    elif toolkit().toolkit.startswith("qt"):
+        # FIXME
+        # from .ui.qt4.kiva_font_editor import KivaFontEditor
+        pass
 
 
 # -----------------------------------------------------------------------------

--- a/kiva/trait_defs/kiva_font_trait.py
+++ b/kiva/trait_defs/kiva_font_trait.py
@@ -14,18 +14,18 @@
 #  Imports:
 # -----------------------------------------------------------------------------
 
-from traits.etsconfig.api import ETSConfig
+from traits.api import Trait, TraitError, TraitHandler, TraitFactory
+from traitsui.api import toolkit
 
-if ETSConfig.toolkit == "wx":
+if toolkit().toolkit == "wx":
     from .ui.wx.kiva_font_editor import KivaFontEditor
-elif ETSConfig.toolkit.startswith("qt"):
+elif toolkit().toolkit.startswith("qt"):
     # FIXME
     # from .ui.qt4.kiva_font_editor import KivaFontEditor
     KivaFontEditor = None
 else:
     KivaFontEditor = None
 
-from traits.api import Trait, TraitError, TraitHandler, TraitFactory
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
In a number of places the code used ETSConfig.toolkit to determine the backend at import time.  However it is possible that that value was being checked before ETSConfig.toolkit was properly set.  This changes the code to get the appropriate Pyface or TraitsUI toolkit object and gets the name of the toolkit from that.

This fixes #913.

This doesn't attempt to fix #904.