### PR TITLE
Remove usage of `Trait()`

### DIFF
--- a/enable/abstract_window.py
+++ b/enable/abstract_window.py
@@ -14,7 +14,7 @@ from numpy import dot
 
 # Enthought library imports
 from traits.api import (
-    Any, Bool, Event, Float, HasTraits, Instance, List, Property, Trait, Tuple,
+    Any, Bool, Event, Float, HasTraits, Instance, List, Property, Tuple, Union,
 )
 
 
@@ -54,7 +54,7 @@ class AbstractWindow(HasTraits):
 
     # When a component captures the mouse, it can optionally store a
     # dispatch order for events (until it releases the mouse).
-    mouse_owner_dispatch_history = Trait(None, None, List, transient=True)
+    mouse_owner_dispatch_history = Union(None, List, transient=True)
 
     # A scaling constant applied to any GraphicsContext used for drawing the
     # window's component.
@@ -89,7 +89,7 @@ class AbstractWindow(HasTraits):
     _prev_event_handler = Instance(Component, transient=True)
 
     # (dx, dy) integer size of the Window.
-    _size = Trait(None, Tuple, transient=True)
+    _size = Union(None, Tuple, transient=True)
 
     # The regions to update upon redraw
     _update_region = Any(transient=True)

--- a/enable/canvas.py
+++ b/enable/canvas.py
@@ -10,7 +10,7 @@
 """ Defines the enable Canvas class """
 
 # Enthought library imports
-from traits.api import Bool, List, Trait, Tuple
+from traits.api import Bool, List, Tuple, Union
 from kiva.api import FILL
 
 
@@ -39,7 +39,7 @@ class Canvas(Container):
     # of the "region of interest" that it should use when computing its
     # notional bounds for clipping and event handling purposes.  If this trait
     # is None, then the canvas really does behave as if it has no bounds.
-    view_bounds = Trait(None, None, Tuple)
+    view_bounds = Union(None, Tuple)
 
     # The (x,y) position of the lower-left corner of the rectangle
     # corresponding to the dimensions in self.bounds.  Unlike self.position,

--- a/enable/component.py
+++ b/enable/component.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 # Enthought library imports
 from traits.api import (
-    Any, Bool, Delegate, Enum, Float, Instance, Int, List, Property, Str, Trait
+    Any, Bool, Delegate, Enum, Float, Instance, Int, List, Property, Str, Union
 )
 from kiva.api import FILL, STROKE
 
@@ -93,7 +93,7 @@ class Component(CoordinateBox, Interactor):
     # The ratio of the component's width to its height.  This is used by
     # the component itself to maintain bounds when the bounds are changed
     # independently, and is also used by the layout system.
-    aspect_ratio = Trait(None, None, Float)
+    aspect_ratio = Union(None, Float)
 
     # When the component's bounds are set to a (width,height) tuple that does
     # not conform to the set aspect ratio, does the component center itself
@@ -113,7 +113,7 @@ class Component(CoordinateBox, Interactor):
     # component specifies, say, a fixed preferred width of 50 and another one
     # specifies a fixed preferred width of 100, then the latter component will
     # always be twice as wide as the former.
-    fixed_preferred_size = Trait(None, None, bounds_trait)
+    fixed_preferred_size = Union(None, bounds_trait)
 
     # ------------------------------------------------------------------------
     # Overlays and underlays

--- a/enable/drawing/drag_box.py
+++ b/enable/drawing/drag_box.py
@@ -18,7 +18,7 @@
 # Enthought library imports
 from enable.primitives.api import Box
 from enable.enable_traits import Pointer
-from traits.api import Event, Float, Trait, Tuple
+from traits.api import Event, Float, Union, Tuple
 
 # Application specific imports.
 
@@ -43,8 +43,8 @@ class DragBox(Box):
     complete = Event
 
     # Constraints on size:
-    x_bounds = Trait(None, None, Tuple(Float, Float))
-    y_bounds = Trait(None, None, Tuple(Float, Float))
+    x_bounds = Union(None, Tuple(Float, Float))
+    y_bounds = Union(None, Tuple(Float, Float))
 
     # Pointers. ####
 

--- a/enable/drawing/drag_box.py
+++ b/enable/drawing/drag_box.py
@@ -18,7 +18,7 @@
 # Enthought library imports
 from enable.primitives.api import Box
 from enable.enable_traits import Pointer
-from traits.api import Event, Float, Union, Tuple
+from traits.api import Event, Float, Tuple, Union
 
 # Application specific imports.
 

--- a/enable/enable_traits.py
+++ b/enable/enable_traits.py
@@ -17,7 +17,7 @@ from numpy import array, ndarray
 # Enthought library imports
 from kiva.trait_defs.api import KivaFont
 from traits.api import (
-    List, PrefixList, PrefixMap, Range, Trait, TraitFactory, Union,
+    List, Map, PrefixList, PrefixMap, Range, Union,
 )
 from traitsui.api import ImageEnumEditor, EnumEditor
 
@@ -102,26 +102,23 @@ border_size_editor = ImageEnumEditor(
 # -----------------------------------------------------------------------------
 
 # Privates used for specification of line style trait.
-__line_style_trait_values = {
+_line_style_trait_values = {
     "solid": None,
     "dot dash": array([3.0, 5.0, 9.0, 5.0]),
     "dash": array([6.0, 6.0]),
     "dot": array([2.0, 2.0]),
     "long dash": array([9.0, 5.0]),
 }
-__line_style_trait_map_keys = list(__line_style_trait_values.keys())
-LineStyleEditor = EnumEditor(values=__line_style_trait_map_keys)
 
-
-def __line_style_trait(value="solid", **metadata):
-    return Trait(
-        value, __line_style_trait_values, editor=LineStyleEditor, **metadata
-    )
-
+# An editor preset for line styles.
+LineStyleEditor = EnumEditor(values=list(_line_style_trait_values))
 
 # A mapped trait for use in specification of line style attributes.
-LineStyle = TraitFactory(__line_style_trait)
-
+LineStyle = Map(
+    _line_style_trait_values,
+    default_value='solid',
+    editor=LineStyleEditor,
+)
 
 # -----------------------------------------------------------------------------
 #  Trait definitions:
@@ -133,9 +130,6 @@ font_trait = KivaFont(default_font_name)
 # Bounds trait
 bounds_trait = CList([0.0, 0.0])  # (w,h)
 coordinate_trait = CList([0.0, 0.0])  # (x,y)
-
-# bounds_trait = Trait((0.0, 0.0, 20.0, 20.0), valid_bounds,
-#                      editor=bounds_editor)
 
 # Component minimum size trait
 # PZW: Make these just floats, or maybe remove them altogether.

--- a/enable/enable_traits.py
+++ b/enable/enable_traits.py
@@ -16,7 +16,9 @@ from numpy import array, ndarray
 
 # Enthought library imports
 from kiva.trait_defs.api import KivaFont
-from traits.api import List, PrefixList, PrefixMap, Range, Trait, TraitFactory
+from traits.api import (
+    List, PrefixList, PrefixMap, Range, Trait, TraitFactory, Union,
+)
 from traitsui.api import ImageEnumEditor, EnumEditor
 
 # Try to get the CList trait; for traits 2 backwards compatibility, fall back
@@ -152,7 +154,7 @@ margin_trait = Range(0, 63)
 border_size_trait = Range(0, 8, editor=border_size_editor)
 
 # Time interval trait:
-TimeInterval = Trait(None, None, Range(0.0, 3600.0))
+TimeInterval = Union(None, Range(0.0, 3600.0))
 
 # Stretch traits:
 Stretch = Range(0.0, 1.0, value=1.0)

--- a/enable/enable_traits.py
+++ b/enable/enable_traits.py
@@ -154,6 +154,7 @@ TimeInterval = Union(None, Range(0.0, 3600.0))
 Stretch = Range(0.0, 1.0, value=1.0)
 NoStretch = Stretch(0.0)
 
+
 # Scrollbar traits
 class ScrollBarRange(TraitType):
     """ Trait that holds a (low, high, page_size, line_size) range tuple.
@@ -162,22 +163,26 @@ class ScrollBarRange(TraitType):
     def validate(self, object, name, value):
         if isinstance(value, (tuple, list)) and (len(value) == 4):
             low, high, page_size, line_size = value
-            if high < low:
-                low, high = high, low
-            elif high == low:
-                high = low + 1.0
-            page_size = max(min(page_size, high - low), 0.0)
-            line_size = max(min(line_size, page_size), 0.0)
-            return (
-                float(low),
-                float(high),
-                float(page_size),
-                float(line_size),
-            )
+            try:
+                if high < low:
+                    low, high = high, low
+                elif high == low:
+                    high = low + 1.0
+                page_size = max(min(page_size, high - low), 0.0)
+                line_size = max(min(line_size, page_size), 0.0)
+                return (
+                    float(low),
+                    float(high),
+                    float(page_size),
+                    float(line_size),
+                )
+            except Exception:
+                self.error(object, name, value)
+
         self.error(object, name, value)
 
     def info(self):
-        return "a (low,high,page_size,line_size) range tuple"
+        return "a (low, high, page_size, line_size) range tuple"
 
 
 class ScrollPosition(BaseFloat):

--- a/enable/interactor.py
+++ b/enable/interactor.py
@@ -11,7 +11,7 @@
 
 # Enthought library imports
 from kiva.api import affine_identity
-from traits.api import Any, Bool, HasTraits, List, Property, Str, Trait, Union
+from traits.api import Any, Bool, HasTraits, List, Property, Str, Union
 
 # Local relative imports
 from enable.colors import ColorTrait

--- a/enable/interactor.py
+++ b/enable/interactor.py
@@ -11,7 +11,7 @@
 
 # Enthought library imports
 from kiva.api import affine_identity
-from traits.api import Any, Bool, HasTraits, List, Property, Str, Trait
+from traits.api import Any, Bool, HasTraits, List, Property, Str, Trait, Union
 
 # Local relative imports
 from enable.colors import ColorTrait
@@ -62,7 +62,7 @@ class Interactor(HasTraits):
     pointer = Pointer
 
     # The "tooltip" to display if a user mouse-overs this interactor
-    tooltip = Trait(None, None, Str)
+    tooltip = Union(None, Str)
 
     # The cursor "style" to use
     cursor_style = cursor_style_trait

--- a/enable/markers.py
+++ b/enable/markers.py
@@ -15,7 +15,7 @@ Defines markers classes, used by a variety of renderers.
 from numpy import array, pi
 
 # Enthought library imports
-from traits.api import HasTraits, Bool, Instance, Trait
+from traits.api import HasTraits, Bool, Instance, Map
 from traitsui.api import EnumEditor
 from kiva.api import (
     CIRCLE_MARKER, CROSS_MARKER, DIAMOND_MARKER, DOT_MARKER, FILL_STROKE,
@@ -470,8 +470,6 @@ MarkerNameDict = {
 }
 
 #: A mapped trait that allows string naming of marker classes.
-MarkerTrait = Trait(
-    "square", MarkerNameDict, editor=EnumEditor(values=marker_names)
-)
+MarkerTrait = Map(MarkerNameDict, default_value="square")
 
 marker_trait = MarkerTrait

--- a/enable/primitives/line.py
+++ b/enable/primitives/line.py
@@ -13,7 +13,7 @@ from numpy import array, resize
 
 # Enthought library imports.
 from kiva.api import FILL, FILL_STROKE, STROKE
-from traits.api import Any, Event, Float, List, Trait, Bool
+from traits.api import Any, Event, Float, List, Bool
 
 # Local imports.
 from enable.api import border_size_trait, Component
@@ -36,7 +36,7 @@ class Line(Component):
     line_dash = Any
 
     # The width of the line.
-    line_width = Trait(1, border_size_trait)
+    line_width = border_size_trait(1)
 
     # The points that make up this polygon.
     points = List  # List of Tuples

--- a/enable/primitives/polygon.py
+++ b/enable/primitives/polygon.py
@@ -6,7 +6,7 @@ from numpy import array
 # Enthought library imports.
 from kiva.api import EOF_FILL_STROKE, FILL, FILL_STROKE, points_in_polygon
 from traits.api import (
-    Any, Event, Float, HasTraits, Instance, List, Property, Trait, Tuple
+    Any, Event, Float, HasTraits, Instance, List, Map, Property, Tuple
 )
 from traitsui.api import Group, View
 
@@ -48,8 +48,9 @@ class Polygon(Component):
     complete = Event
 
     # The rule to use to determine the inside of the polygon.
-    inside_rule = Trait(
-        "winding", {"winding": FILL_STROKE, "oddeven": EOF_FILL_STROKE}
+    inside_rule = Map(
+        {"winding": FILL_STROKE, "oddeven": EOF_FILL_STROKE},
+        default_value="winding",
     )
 
     # The points that make up this polygon.

--- a/enable/primitives/polygon.py
+++ b/enable/primitives/polygon.py
@@ -42,7 +42,7 @@ class Polygon(Component):
     border_dash = Any
 
     # The thickness of the border of this polygon.
-    border_size = Trait(1, border_size_trait)
+    border_size = border_size_trait(1)
 
     # Event fired when the polygon is "complete".
     complete = Event

--- a/enable/qt4/scrollbar.py
+++ b/enable/qt4/scrollbar.py
@@ -13,47 +13,10 @@ the standard Qt one.
 """
 
 from pyface.qt import QtCore, QtGui
-from traits.api import Any, Bool, Enum, Float, Int, Property, Trait, TraitError
+from traits.api import Any, Bool, Enum, Float, Int, Property
 
 from enable.component import Component
-
-
-def valid_range(object, name, value):
-    """ Verify that a set of range values for a scrollbar is valid.
-    """
-    try:
-        if (type(value) in (tuple, list)) and (len(value) == 4):
-            low, high, page_size, line_size = value
-            if high < low:
-                low, high = high, low
-            elif high == low:
-                high = low + 1.0
-            page_size = max(min(page_size, high - low), 0.0)
-            line_size = max(min(line_size, page_size), 0.0)
-            return (
-                float(low),
-                float(high),
-                float(page_size),
-                float(line_size),
-            )
-    except Exception:
-        raise
-    raise TraitError
-
-
-valid_range.info = "a (low,high,page_size,line_size) range tuple"
-
-
-def valid_scroll_position(object, name, value):
-    """ Verify that a specified scroll bar position is valid.
-    """
-    try:
-        low, high, page_size, line_size = object.range
-        x = max(min(float(value), high - page_size), low)
-        return x
-    except Exception:
-        raise
-    raise TraitError
+from enable.enable_traits import ScrollBarRange, ScrollPosition
 
 
 class QResizableScrollBar(QtGui.QScrollBar):
@@ -74,11 +37,11 @@ class NativeScrollBar(Component):
 
     # The current position of the scroll bar.  This must be within the range
     # (self.low, self.high)
-    scroll_position = Trait(0.0, valid_scroll_position)
+    scroll_position = ScrollPosition()
 
     # A tuple (low, high, page_size, line_size).  Can be accessed using
     # convenience properties (see below).
-    range = Trait((0.0, 100.0, 10.0, 1.0), valid_range)
+    range = ScrollBarRange((0.0, 100.0, 10.0, 1.0))
 
     # The orientation of the scrollbar
     orientation = Enum("horizontal", "vertical")

--- a/enable/qt4/scrollbar.py
+++ b/enable/qt4/scrollbar.py
@@ -81,10 +81,10 @@ class NativeScrollBar(Component):
     range = Trait((0.0, 100.0, 10.0, 1.0), valid_range)
 
     # The orientation of the scrollbar
-    orientation = Trait("horizontal", "vertical")
+    orientation = Enum("horizontal", "vertical")
 
     # Is y=0 at the top or bottom?
-    origin = Trait("bottom", "top")
+    origin = Enum("bottom", "top")
 
     # Determines if the scroll bar should be visible and respond to events
     enabled = Bool(True)

--- a/enable/slider.py
+++ b/enable/slider.py
@@ -12,7 +12,7 @@ from numpy import linspace, zeros
 # Enthought library imports
 from kiva.api import STROKE
 from traits.api import (
-    Any, Bool, Enum, Float, Int, Property, Trait, observe,
+    Any, Bool, Enum, Float, Int, Map, Property, observe,
 )
 from traitsui.api import EnumEditor
 
@@ -21,13 +21,9 @@ from .colors import ColorTrait
 from .component import Component
 from .markers import CustomMarker, MarkerNameDict, marker_names
 
-slider_marker_names = list(marker_names) + ["rect"]
-SliderMarkerTrait = Trait(
-    "rect",
-    "rect",
-    MarkerNameDict,
-    editor=EnumEditor(values=slider_marker_names),
-)
+slider_marker_map = {'rect': None}
+slider_marker_map.update(MarkerNameDict)
+SliderMarkerTrait = Map(slider_marker_map, default_value='rect')
 
 
 class Slider(Component):

--- a/enable/tests/test_enable_traits.py
+++ b/enable/tests/test_enable_traits.py
@@ -1,0 +1,108 @@
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+import unittest
+
+from traits.api import HasStrictTraits, TraitError, Undefined
+
+from enable.enable_traits import ScrollBarRange, ScrollPosition
+
+
+class DummyScrollBar(HasStrictTraits):
+
+    range = ScrollBarRange()
+
+    position = ScrollPosition()
+
+
+class TestScrollBarTraits(unittest.TestCase):
+
+    def test_range_default(self):
+        scroll_bar = DummyScrollBar()
+        self.assertIs(scroll_bar.range, Undefined)
+
+    def test_position_default(self):
+        scroll_bar = DummyScrollBar()
+        self.assertEqual(scroll_bar.position, 0.0)
+
+    def test_range_set(self):
+        scroll_bar = DummyScrollBar()
+        values = [
+            # standard
+            ((0.0, 100.0, 10.0, 1.0), (0.0, 100.0, 10.0, 1.0)),
+            # standard, but ints
+            ((0, 100, 10, 1), (0.0, 100.0, 10.0, 1.0)),
+            # standard, but list
+            ([0.0, 100.0, 10.0, 1.0], (0.0, 100.0, 10.0, 1.0)),
+            # negative low
+            ((-100.0, 100.0, 10.0, 1.0), (-100.0, 100.0, 10.0, 1.0)),
+            # high/low reversed
+            ((100.0, 0.0, 10.0, 1.0), (0.0, 100.0, 10.0, 1.0)),
+            # high/low equal
+            ((0.0, 0.0, 0.0, 0.0), (0.0, 1.0, 0.0, 0.0)),
+            # page size greater than range
+            ((0.0, 100.0, 1000.0, 1.0), (0.0, 100.0, 100.0, 1.0)),
+            # page size negative
+            ((0.0, 100.0, -10.0, 1.0), (0.0, 100.0, 0.0, 0.0)),
+            # line size greater than page size
+            ((0.0, 100.0, 10.0, 100.0), (0.0, 100.0, 10.0, 10.0)),
+            # line size negative
+            ((0.0, 100.0, 10.0, -1.0), (0.0, 100.0, 10.0, 0.0)),
+        ]
+        for value, expected in values:
+            with self.subTest(value=value):
+                scroll_bar.range = value
+                self.assertIsInstance(scroll_bar.range, tuple)
+                self.assertTrue(
+                    all(isinstance(x, float) for x in scroll_bar.range)
+                )
+                self.assertEqual(scroll_bar.range, expected)
+
+    def test_range_set_invalid(self):
+        scroll_bar = DummyScrollBar()
+        values = [
+            # too short
+            (0.0, 100.0, 10.0),
+            # too long
+            (0.0, 100.0, 10.0, 1.0, 1.0),
+            # not floats
+            ('0.0', '100.0', '10.0', '1.0'),
+            # not comparable
+            (None, None, None, None),
+            # None not allowed
+            None,
+            # sets not OK
+            {0, 100, 10, 1},
+        ]
+        for value in values:
+            with self.subTest(value=value):
+                with self.assertRaises(TraitError):
+                    scroll_bar.range = value
+
+    def test_position_set(self):
+        scroll_bar = DummyScrollBar(range=(0.0, 100.0, 10.0, 1.0))
+        values = [
+            # typical
+            (10.0, 10.0),
+            # typical, but an int
+            (10, 10.0),
+            # at top
+            (0.0, 0.0),
+            # at bottom
+            (90.0, 90.0),
+            # above top
+            (-10.0, 0.0),
+            # below bottom
+            (100.0, 90.0),
+        ]
+        for value, expected in values:
+            with self.subTest(value=value):
+                scroll_bar.position = value
+                self.assertIsInstance(scroll_bar.position, float)
+                self.assertEqual(scroll_bar.position, expected)

--- a/enable/text_grid.py
+++ b/enable/text_grid.py
@@ -87,7 +87,7 @@ class TextGrid(Component):
     _cached_cell_coords = Array
 
     # "auto" or a tuple
-    _cell_size = Trait("auto", Any)
+    _cell_size = Any("auto")
 
     # ------------------------------------------------------------------------
     # Public methods

--- a/enable/text_grid.py
+++ b/enable/text_grid.py
@@ -16,7 +16,7 @@ from numpy import arange, array, dstack, repeat, newaxis
 
 # Enthought library imports
 from traits.api import (
-    Any, Array, Bool, Int, List, Property, Trait, Tuple, observe,
+    Any, Array, Bool, Int, List, Property, Tuple, observe,
 )
 from kiva.trait_defs.api import KivaFont
 

--- a/enable/tools/viewport_zoom_tool.py
+++ b/enable/tools/viewport_zoom_tool.py
@@ -12,7 +12,7 @@
 from numpy import inf
 
 # Enthought library imports
-from traits.api import Bool, Enum, Float, Instance, Int, List, Trait, Tuple
+from traits.api import Bool, Enum, Float, Instance, Int, List, Tuple, Union
 
 # Enable imports
 from enable.base_tool import KeySpec
@@ -108,7 +108,7 @@ class ViewportZoomTool(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
     # named colors from Enable, this attribute allows the specification of a
     # separate alpha value that replaces the alpha value of **color** at draw
     # time.
-    alpha = Trait(0.4, None, Float)
+    alpha = Union(None, Float, default_value=0.4)
 
     # The color of the outside selection rectangle.
     border_color = ColorTrait("dodgerblue")
@@ -136,14 +136,14 @@ class ViewportZoomTool(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
     _enabled = Bool(False)
 
     # the original numerical screen ranges
-    _orig_position = Trait(None, List, Float)
-    _orig_bounds = Trait(None, List, Float)
+    _orig_position = Union(None, List, Float)
+    _orig_bounds = Union(None, List, Float)
 
     # The (x,y) screen point where the mouse went down.
-    _screen_start = Trait(None, None, Tuple)
+    _screen_start = Union(None, Tuple)
 
     # The (x,,y) screen point of the last seen mouse move event.
-    _screen_end = Trait(None, None, Tuple)
+    _screen_end = Union(None, Tuple)
 
     def __init__(self, component=None, *args, **kw):
         # Support [Chaco's] AbstractController-style constructors which allow

--- a/enable/wx/scrollbar.py
+++ b/enable/wx/scrollbar.py
@@ -16,7 +16,7 @@ the standard WX one.
 import wx
 
 # Enthought Imports
-from traits.api import Property, Trait, TraitError, Any, Enum, Bool, Int
+from traits.api import Any, Bool, Enum, Int, Property, Trait, TraitError
 
 from enable.component import Component
 
@@ -79,10 +79,10 @@ class NativeScrollBar(Component):
     range = Trait((0.0, 100.0, 10.0, 1.0), valid_range)
 
     # The orientation of the scrollbar
-    orientation = Trait("horizontal", "vertical")
+    orientation = Enum("horizontal", "vertical")
 
     # The location of y=0
-    origin = Trait("bottom", "top")
+    origin = Enum("bottom", "top")
 
     # Determines if the scroll bar should be visible and respond to events
     enabled = Bool(True)

--- a/enable/wx/scrollbar.py
+++ b/enable/wx/scrollbar.py
@@ -16,48 +16,10 @@ the standard WX one.
 import wx
 
 # Enthought Imports
-from traits.api import Any, Bool, Enum, Int, Property, Trait, TraitError
+from traits.api import Any, Bool, Enum, Int, Property
 
 from enable.component import Component
-
-
-def valid_range(object, name, value):
-    "Verify that a set of range values for a scrollbar is valid"
-    try:
-        if (type(value) in (tuple, list)) and (len(value) == 4):
-            low, high, page_size, line_size = value
-            if high < low:
-                low, high = high, low
-            elif high == low:
-                high = low + 1.0
-            page_size = max(min(page_size, high - low), 0.0)
-            line_size = max(min(line_size, page_size), 0.0)
-            return (
-                float(low),
-                float(high),
-                float(page_size),
-                float(line_size),
-            )
-    except Exception:
-        raise
-    raise TraitError
-
-
-valid_range.info = "a (low,high,page_size,line_size) range tuple"
-
-
-def valid_scroll_position(object, name, value):
-    "Verify that a specified scroll bar position is valid"
-    try:
-        low, high, page_size, line_size = object.range
-        if value > high - page_size:
-            value = high - page_size
-        elif value < low:
-            value = low
-        return value
-    except Exception:
-        raise
-    raise TraitError
+from enable.enable_traits import ScrollBarRange, ScrollPosition
 
 
 class NativeScrollBar(Component):
@@ -69,14 +31,14 @@ class NativeScrollBar(Component):
 
     # The current position of the scroll bar.  This must be within the range
     # (self.low, self.high)
-    scroll_position = Trait(0.0, valid_scroll_position)
+    scroll_position = ScrollPosition()
 
     # A tuple (low, high, page_size, line_size).  Can be accessed using
     # convenience properties (see below).  Low and High refer to the conceptual
     # bounds of the region represented by the full scroll bar.  Note that
     # the maximum value of scroll_position is actually (high - page_size), and
     # not just the value of high.
-    range = Trait((0.0, 100.0, 10.0, 1.0), valid_range)
+    range = ScrollBarRange((0.0, 100.0, 10.0, 1.0))
 
     # The orientation of the scrollbar
     orientation = Enum("horizontal", "vertical")


### PR DESCRIPTION
This largely removes the usage of `Trait()` in the codebase.  The places where it is not changed are in `enable.color` (which is resolved by #924) and in the `KivaFontTrait` which is complex enough to deserve its own PR.

The PR was done in stages, each commit doing a different type of trait replacement (eg. Trait -> Union, Trait -> Map, etc.) so it may be easier to review one commit at a time.

Fixes #417.