### PR TITLE
Update copyright for 2022

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/docs/source/api/templates/module.rst_t
+++ b/docs/source/api/templates/module.rst_t
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+   (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/api/templates/package.rst_t
+++ b/docs/source/api/templates/package.rst_t
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+   (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -53,7 +53,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'enable'
-copyright = '2005-2021, Enthought'
+copyright = '2005-2022 Enthought'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/abstract_overlay.py
+++ b/enable/abstract_overlay.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/abstract_window.py
+++ b/enable/abstract_window.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/api.py
+++ b/enable/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/base.py
+++ b/enable/base.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/base_tool.py
+++ b/enable/base_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/brush.py
+++ b/enable/brush.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/canvas.py
+++ b/enable/canvas.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/colors.py
+++ b/enable/colors.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/compass.py
+++ b/enable/compass.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/compiled_path.py
+++ b/enable/compiled_path.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/component.py
+++ b/enable/component.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/component_editor.py
+++ b/enable/component_editor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/constraints_container.py
+++ b/enable/constraints_container.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/container.py
+++ b/enable/container.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/coordinate_box.py
+++ b/enable/coordinate_box.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/drawing/api.py
+++ b/enable/drawing/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/drawing/drag_box.py
+++ b/enable/drawing/drag_box.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/drawing/drag_line.py
+++ b/enable/drawing/drag_line.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/drawing/drag_polygon.py
+++ b/enable/drawing/drag_polygon.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/drawing/drag_segment.py
+++ b/enable/drawing/drag_segment.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/drawing/drawing_canvas.py
+++ b/enable/drawing/drawing_canvas.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/drawing/drawing_tool.py
+++ b/enable/drawing/drawing_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/drawing/point_line.py
+++ b/enable/drawing/point_line.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/drawing/point_polygon.py
+++ b/enable/drawing/point_polygon.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/enable_traits.py
+++ b/enable/enable_traits.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/events.py
+++ b/enable/events.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/example_application.py
+++ b/enable/example_application.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/example_canvas.py
+++ b/enable/example_canvas.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/example_support.py
+++ b/enable/example_support.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/_etsdemo_info.py
+++ b/enable/examples/_etsdemo_info.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/_example_application.py
+++ b/enable/examples/_example_application.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/_example_canvas.py
+++ b/enable/examples/_example_canvas.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/_example_support.py
+++ b/enable/examples/_example_support.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/basic_draw.py
+++ b/enable/examples/demo/enable/basic_draw.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/basic_move.py
+++ b/enable/examples/demo/enable/basic_move.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/brush_draw.py
+++ b/enable/examples/demo/enable/brush_draw.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/canvas_demo.py
+++ b/enable/examples/demo/enable/canvas_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/compass_example.py
+++ b/enable/examples/demo/enable/compass_example.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/component_demo.py
+++ b/enable/examples/demo/enable/component_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/constraints_demo.enaml
+++ b/enable/examples/demo/enable/constraints_demo.enaml
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/constraints_demo.py
+++ b/enable/examples/demo/enable/constraints_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/container_demo.py
+++ b/enable/examples/demo/enable/container_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/filled_container_demo.py
+++ b/enable/examples/demo/enable/filled_container_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/gadgets/vu_demo.py
+++ b/enable/examples/demo/enable/gadgets/vu_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/gradient_demo.py
+++ b/enable/examples/demo/enable/gradient_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/hidpi_component.py
+++ b/enable/examples/demo/enable/hidpi_component.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/image_draw.py
+++ b/enable/examples/demo/enable/image_draw.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/label_test.py
+++ b/enable/examples/demo/enable/label_test.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/latency_demo.py
+++ b/enable/examples/demo/enable/latency_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/primitives_demo.py
+++ b/enable/examples/demo/enable/primitives_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/resize_tool_demo.py
+++ b/enable/examples/demo/enable/resize_tool_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/scrollbar_demo.py
+++ b/enable/examples/demo/enable/scrollbar_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/scrolled_canvas_demo.py
+++ b/enable/examples/demo/enable/scrolled_canvas_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/scrolled_demo.py
+++ b/enable/examples/demo/enable/scrolled_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/shapes/api.py
+++ b/enable/examples/demo/enable/shapes/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/shapes/box.py
+++ b/enable/examples/demo/enable/shapes/box.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/shapes/circle.py
+++ b/enable/examples/demo/enable/shapes/circle.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/shapes/run.py
+++ b/enable/examples/demo/enable/shapes/run.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/sierpinski_zoom.py
+++ b/enable/examples/demo/enable/sierpinski_zoom.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/slider_example.py
+++ b/enable/examples/demo/enable/slider_example.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/stacked_container_demo.py
+++ b/enable/examples/demo/enable/stacked_container_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/text_field_demo.py
+++ b/enable/examples/demo/enable/text_field_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/text_grid_demo.py
+++ b/enable/examples/demo/enable/text_grid_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/tools/button_tool.py
+++ b/enable/examples/demo/enable/tools/button_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/tools/drop_tool.py
+++ b/enable/examples/demo/enable/tools/drop_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/tools/pyface/context_menu.py
+++ b/enable/examples/demo/enable/tools/pyface/context_menu.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/tools/pyface/undoable_move_tool.py
+++ b/enable/examples/demo/enable/tools/pyface/undoable_move_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/view_bounds_test.py
+++ b/enable/examples/demo/enable/view_bounds_test.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/enable/zoomed_event_demo.py
+++ b/enable/examples/demo/enable/zoomed_event_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/savage/button_demo.py
+++ b/enable/examples/demo/savage/button_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/savage/buttons_on_canvas.py
+++ b/enable/examples/demo/savage/buttons_on_canvas.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/savage/static_image.py
+++ b/enable/examples/demo/savage/static_image.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/demo/savage/toggle_demo.py
+++ b/enable/examples/demo/savage/toggle_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/examples/tests/test_etsdemo_info.py
+++ b/enable/examples/tests/test_etsdemo_info.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/font_metrics_provider.py
+++ b/enable/font_metrics_provider.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/gadgets/vu_meter.py
+++ b/enable/gadgets/vu_meter.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/gcbench/__main__.py
+++ b/enable/gcbench/__main__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/gcbench/bench.py
+++ b/enable/gcbench/bench.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/gcbench/data.py
+++ b/enable/gcbench/data.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/gcbench/opengl.py
+++ b/enable/gcbench/opengl.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/gcbench/pdf.py
+++ b/enable/gcbench/pdf.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/gcbench/publish.py
+++ b/enable/gcbench/publish.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/gcbench/suite.py
+++ b/enable/gcbench/suite.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/gl_graphics_context.py
+++ b/enable/gl_graphics_context.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/graphics_context.py
+++ b/enable/graphics_context.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/interactor.py
+++ b/enable/interactor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/kiva_graphics_context.py
+++ b/enable/kiva_graphics_context.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/label.py
+++ b/enable/label.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/layout/ab_constrainable.py
+++ b/enable/layout/ab_constrainable.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/layout/api.py
+++ b/enable/layout/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/layout/constraints_namespace.py
+++ b/enable/layout/constraints_namespace.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/layout/geometry.py
+++ b/enable/layout/geometry.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/layout/layout_helpers.py
+++ b/enable/layout/layout_helpers.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/layout/layout_manager.py
+++ b/enable/layout/layout_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/layout/linear_symbolic.py
+++ b/enable/layout/linear_symbolic.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/layout/utils.py
+++ b/enable/layout/utils.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/markers.py
+++ b/enable/markers.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/native_scrollbar.py
+++ b/enable/native_scrollbar.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/null/blend2d.py
+++ b/enable/null/blend2d.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/null/cairo.py
+++ b/enable/null/cairo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/null/celiagg.py
+++ b/enable/null/celiagg.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/null/image.py
+++ b/enable/null/image.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/null/oldagg.py
+++ b/enable/null/oldagg.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/null/pdf.py
+++ b/enable/null/pdf.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/null/ps.py
+++ b/enable/null/ps.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/null/qpainter.py
+++ b/enable/null/qpainter.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/null/quartz.py
+++ b/enable/null/quartz.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/null/svg.py
+++ b/enable/null/svg.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/null/toolkit.py
+++ b/enable/null/toolkit.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/overlay_container.py
+++ b/enable/overlay_container.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/primitives/__init__.py
+++ b/enable/primitives/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/primitives/annotater.py
+++ b/enable/primitives/annotater.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/primitives/api.py
+++ b/enable/primitives/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/primitives/box.py
+++ b/enable/primitives/box.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/primitives/image.py
+++ b/enable/primitives/image.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/primitives/line.py
+++ b/enable/primitives/line.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/primitives/shape.py
+++ b/enable/primitives/shape.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/qt4/cairo.py
+++ b/enable/qt4/cairo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/qt4/celiagg.py
+++ b/enable/qt4/celiagg.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/qt4/constants.py
+++ b/enable/qt4/constants.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/qt4/gl.py
+++ b/enable/qt4/gl.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/qt4/image.py
+++ b/enable/qt4/image.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/qt4/oldagg.py
+++ b/enable/qt4/oldagg.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/qt4/qpainter.py
+++ b/enable/qt4/qpainter.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/qt4/quartz.py
+++ b/enable/qt4/quartz.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/qt4/scrollbar.py
+++ b/enable/qt4/scrollbar.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/qt4/toolkit.py
+++ b/enable/qt4/toolkit.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/__init__.py
+++ b/enable/savage/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/compliance/comparator.py
+++ b/enable/savage/compliance/comparator.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/compliance/crosshair.py
+++ b/enable/savage/compliance/crosshair.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/compliance/drawer.py
+++ b/enable/savage/compliance/drawer.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/compliance/profile_this.py
+++ b/enable/savage/compliance/profile_this.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/compliance/sike.py
+++ b/enable/savage/compliance/sike.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/compliance/svg_component.py
+++ b/enable/savage/compliance/svg_component.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/compliance/viewer.py
+++ b/enable/savage/compliance/viewer.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/compliance/xml_view.py
+++ b/enable/savage/compliance/xml_view.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/attributes.py
+++ b/enable/savage/svg/attributes.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/backends/kiva/renderer.py
+++ b/enable/savage/svg/backends/kiva/renderer.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/backends/kiva/tests/test_renderer.py
+++ b/enable/savage/svg/backends/kiva/tests/test_renderer.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/backends/null/null_renderer.py
+++ b/enable/savage/svg/backends/null/null_renderer.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/backends/wx/__init__.py
+++ b/enable/savage/svg/backends/wx/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/backends/wx/renderer.py
+++ b/enable/savage/svg/backends/wx/renderer.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/css/__init__.py
+++ b/enable/savage/svg/css/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/css/atrule.py
+++ b/enable/savage/svg/css/atrule.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/css/block.py
+++ b/enable/savage/svg/css/block.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/css/colour.py
+++ b/enable/savage/svg/css/colour.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/css/identifier.py
+++ b/enable/savage/svg/css/identifier.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/css/inline.py
+++ b/enable/savage/svg/css/inline.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/css/transform.py
+++ b/enable/savage/svg/css/transform.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/css/values.py
+++ b/enable/savage/svg/css/values.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/document.py
+++ b/enable/savage/svg/document.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/pathdata.py
+++ b/enable/savage/svg/pathdata.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/svg_extras.py
+++ b/enable/savage/svg/svg_extras.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/svg_regex.py
+++ b/enable/savage/svg/svg_regex.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/tests/css/test_atrule.py
+++ b/enable/savage/svg/tests/css/test_atrule.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/tests/css/test_block.py
+++ b/enable/savage/svg/tests/css/test_block.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/tests/css/test_color.py
+++ b/enable/savage/svg/tests/css/test_color.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/tests/css/test_identifier.py
+++ b/enable/savage/svg/tests/css/test_identifier.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/tests/css/test_transform.py
+++ b/enable/savage/svg/tests/css/test_transform.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/tests/css/test_values.py
+++ b/enable/savage/svg/tests/css/test_values.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/tests/test_attributes.py
+++ b/enable/savage/svg/tests/test_attributes.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/tests/test_document.py
+++ b/enable/savage/svg/tests/test_document.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/svg/tests/test_pathdata.py
+++ b/enable/savage/svg/tests/test_pathdata.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/trait_defs/ui/api.py
+++ b/enable/savage/trait_defs/ui/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/trait_defs/ui/qt4/svg_button_editor.py
+++ b/enable/savage/trait_defs/ui/qt4/svg_button_editor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/trait_defs/ui/qt4/svg_editor.py
+++ b/enable/savage/trait_defs/ui/qt4/svg_editor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/trait_defs/ui/svg_button.py
+++ b/enable/savage/trait_defs/ui/svg_button.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/trait_defs/ui/svg_button_editor.py
+++ b/enable/savage/trait_defs/ui/svg_button_editor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/trait_defs/ui/svg_editor.py
+++ b/enable/savage/trait_defs/ui/svg_editor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/trait_defs/ui/toolkit.py
+++ b/enable/savage/trait_defs/ui/toolkit.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/trait_defs/ui/wx/kiva_render_panel.py
+++ b/enable/savage/trait_defs/ui/wx/kiva_render_panel.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/trait_defs/ui/wx/svg_button_editor.py
+++ b/enable/savage/trait_defs/ui/wx/svg_button_editor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/trait_defs/ui/wx/svg_editor.py
+++ b/enable/savage/trait_defs/ui/wx/svg_editor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/savage/trait_defs/ui/wx/wx_render_panel.py
+++ b/enable/savage/trait_defs/ui/wx/wx_render_panel.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/scrolled.py
+++ b/enable/scrolled.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/simple_layout.py
+++ b/enable/simple_layout.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/slider.py
+++ b/enable/slider.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/stacked_container.py
+++ b/enable/stacked_container.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/stacked_layout.py
+++ b/enable/stacked_layout.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/testing.py
+++ b/enable/testing.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/_testing.py
+++ b/enable/tests/_testing.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/drawing/test_point_line.py
+++ b/enable/tests/drawing/test_point_line.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/primitives/test_image.py
+++ b/enable/tests/primitives/test_image.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/qt4/test_mouse_wheel.py
+++ b/enable/tests/qt4/test_mouse_wheel.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/qt4/test_scrollbar.py
+++ b/enable/tests/qt4/test_scrollbar.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_abstract_window.py
+++ b/enable/tests/test_abstract_window.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_brush.py
+++ b/enable/tests/test_brush.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_component.py
+++ b/enable/tests/test_component.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_component_editor.py
+++ b/enable/tests/test_component_editor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_constraints_container.py
+++ b/enable/tests/test_constraints_container.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_container.py
+++ b/enable/tests/test_container.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_coordinate_box.py
+++ b/enable/tests/test_coordinate_box.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_drag_tool.py
+++ b/enable/tests/test_drag_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_drop_tool.py
+++ b/enable/tests/test_drop_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_event_transform.py
+++ b/enable/tests/test_event_transform.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_key_spec.py
+++ b/enable/tests/test_key_spec.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_kiva_graphics_context.py
+++ b/enable/tests/test_kiva_graphics_context.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_markers.py
+++ b/enable/tests/test_markers.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_resize_tool.py
+++ b/enable/tests/test_resize_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_test_assistant.py
+++ b/enable/tests/test_test_assistant.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/test_viewport.py
+++ b/enable/tests/test_viewport.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/tools/pyface/test_commands.py
+++ b/enable/tests/tools/pyface/test_commands.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/tools/pyface/test_move_command_tool.py
+++ b/enable/tests/tools/pyface/test_move_command_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/tools/pyface/test_resize_command_tool.py
+++ b/enable/tests/tools/pyface/test_resize_command_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/tools/pyface/test_undo_tool.py
+++ b/enable/tests/tools/pyface/test_undo_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/tools/test_button_tool.py
+++ b/enable/tests/tools/test_button_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/tools/test_hover_tool.py
+++ b/enable/tests/tools/test_hover_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tests/wx/test_mouse_wheel.py
+++ b/enable/tests/wx/test_mouse_wheel.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/text_field.py
+++ b/enable/text_field.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/text_field_grid.py
+++ b/enable/text_field_grid.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/text_field_style.py
+++ b/enable/text_field_style.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/text_grid.py
+++ b/enable/text_grid.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/toolkit.py
+++ b/enable/toolkit.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/toolkit_constants.py
+++ b/enable/toolkit_constants.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/api.py
+++ b/enable/tools/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/apptools/api.py
+++ b/enable/tools/apptools/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/base_drop_tool.py
+++ b/enable/tools/base_drop_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/base_zoom_tool.py
+++ b/enable/tools/base_zoom_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/button_tool.py
+++ b/enable/tools/button_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/drag_tool.py
+++ b/enable/tools/drag_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -116,7 +116,7 @@ class DragTool(BaseTool):
     def drag_end(self, event):
         """ Called when a mouse event causes the drag operation to end.
 
-        A drag is ended when a user releases the mouse, or by receiving a 
+        A drag is ended when a user releases the mouse, or by receiving a
         mouse_leave event when on_drag_leave is 'end'.
         """
         pass

--- a/enable/tools/hover_tool.py
+++ b/enable/tools/hover_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/move_tool.py
+++ b/enable/tools/move_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/pyface/api.py
+++ b/enable/tools/pyface/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/pyface/command_tool.py
+++ b/enable/tools/pyface/command_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/pyface/commands.py
+++ b/enable/tools/pyface/commands.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/pyface/context_menu_tool.py
+++ b/enable/tools/pyface/context_menu_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/pyface/move_command_tool.py
+++ b/enable/tools/pyface/move_command_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/pyface/resize_command_tool.py
+++ b/enable/tools/pyface/resize_command_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/pyface/undo_tool.py
+++ b/enable/tools/pyface/undo_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/resize_tool.py
+++ b/enable/tools/resize_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/tool_history_mixin.py
+++ b/enable/tools/tool_history_mixin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/toolbars/toolbar_buttons.py
+++ b/enable/tools/toolbars/toolbar_buttons.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/toolbars/viewport_toolbar.py
+++ b/enable/tools/toolbars/viewport_toolbar.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/traits_tool.py
+++ b/enable/tools/traits_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/value_drag_tool.py
+++ b/enable/tools/value_drag_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/viewport_pan_tool.py
+++ b/enable/tools/viewport_pan_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/tools/viewport_zoom_tool.py
+++ b/enable/tools/viewport_zoom_tool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/trait_defs/api.py
+++ b/enable/trait_defs/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/trait_defs/rgba_color_trait.py
+++ b/enable/trait_defs/rgba_color_trait.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/trait_defs/ui/api.py
+++ b/enable/trait_defs/ui/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/trait_defs/ui/qt4/rgba_color_editor.py
+++ b/enable/trait_defs/ui/qt4/rgba_color_editor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/trait_defs/ui/rgba_color_editor.py
+++ b/enable/trait_defs/ui/rgba_color_editor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/trait_defs/ui/wx/rgba_color_editor.py
+++ b/enable/trait_defs/ui/wx/rgba_color_editor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/viewable.py
+++ b/enable/viewable.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/viewport.py
+++ b/enable/viewport.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/window.py
+++ b/enable/window.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/wx/base_window.py
+++ b/enable/wx/base_window.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/wx/cairo.py
+++ b/enable/wx/cairo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/wx/celiagg.py
+++ b/enable/wx/celiagg.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/wx/constants.py
+++ b/enable/wx/constants.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/wx/gl.py
+++ b/enable/wx/gl.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/wx/image.py
+++ b/enable/wx/image.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/wx/oldagg.py
+++ b/enable/wx/oldagg.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/wx/quartz.py
+++ b/enable/wx/quartz.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/wx/scrollbar.py
+++ b/enable/wx/scrollbar.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/enable/wx/toolkit.py
+++ b/enable/wx/toolkit.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/__init__.py
+++ b/kiva/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/_cython_speedups.pyx
+++ b/kiva/_cython_speedups.pyx
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/_fontdata.py
+++ b/kiva/_fontdata.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/_hit_test.cpp
+++ b/kiva/_hit_test.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/_hit_test.h
+++ b/kiva/_hit_test.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -12,14 +12,14 @@
 
 namespace kiva
 {
-    bool point_in_polygon(double x, double y, 
+    bool point_in_polygon(double x, double y,
                           double* poly_pts, int Npoly_pts);
-    void points_in_polygon(double* pts, int Npts, 
+    void points_in_polygon(double* pts, int Npts,
                           double* poly_pts, int Npoly_pts,
                           unsigned char* results, int Nresults);
-    bool point_in_polygon_winding(double x, double y, 
+    bool point_in_polygon_winding(double x, double y,
                                   double* poly_pts, int Npoly_pts);
-    void points_in_polygon_winding(double* pts, int Npts, 
+    void points_in_polygon_winding(double* pts, int Npts,
                                    double* poly_pts, int Npoly_pts,
                                    unsigned char* results, int Nresults);
 

--- a/kiva/_hit_test.pxd
+++ b/kiva/_hit_test.pxd
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/_marker_renderer.pxd
+++ b/kiva/_marker_renderer.pxd
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/_marker_renderer.pyx
+++ b/kiva/_marker_renderer.pyx
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/_profiler.py
+++ b/kiva/_profiler.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/abstract_graphics_context.py
+++ b/kiva/abstract_graphics_context.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/affine.py
+++ b/kiva/affine.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/__init__.py
+++ b/kiva/agg/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/agg.i
+++ b/kiva/agg/agg.i
@@ -1,5 +1,5 @@
 /* -*- c++ -*- */
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/affine_matrix.i
+++ b/kiva/agg/src/affine_matrix.i
@@ -1,5 +1,5 @@
 /* -*- c -*- */
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/agg_std_string.i
+++ b/kiva/agg/src/agg_std_string.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/agg_typemaps.i
+++ b/kiva/agg/src/agg_typemaps.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -39,7 +39,7 @@
 // Typemaps for (double x, double y) points
 //
 //    For: *
-//    
+//
 //    This is useful for places where ints may be passed in and need to
 //    be converted. Python 2.6 requires this
 // --------------------------------------------------------------------------
@@ -333,9 +333,9 @@
     {
         goto fail;
     }
-    
+
     std::vector<kiva::gradient_stop> stops;
-    
+
     for (int i = 0; i < ary->dimensions[0]; i++)
     {
         // the stop is offset, red, green, blue, alpha
@@ -343,8 +343,8 @@
         agg24::rgba8 color(data[5*i+1]*255, data[5*i+2]*255, data[5*i+3]*255, data[5*i+4]*255);
         stops.push_back(kiva::gradient_stop(data[5*i], color));
     }
-    
-    
+
+
     $1 = stops;
 }
 

--- a/kiva/agg/src/compiled_path.i
+++ b/kiva/agg/src/compiled_path.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -20,7 +20,7 @@
 %apply (double* point_array, int point_count) {(double* pts, int Npts)};
 %apply (double* point_array, int point_count) {(double* start, int Nstart)};
 %apply (double* point_array, int point_count) {(double* end, int Nend)};
-%apply (double* rect_array, int rect_count) {(double* all_rects, 
+%apply (double* rect_array, int rect_count) {(double* all_rects,
                                               int Nrects)};
 %apply (double *vertex_x, double* vertex_y) {(double* x, double *y)};
 
@@ -29,8 +29,8 @@
 namespace kiva
 {
     %rename(CompiledPath) compiled_path;
-    
-    class compiled_path 
+
+    class compiled_path
     {
         public:
             compiled_path();
@@ -39,10 +39,10 @@ namespace kiva
             void close_path();
             void move_to(double x, double y);
             void line_to(double x, double y);
-            void quad_curve_to(double x_ctrl,  double y_ctrl, 
-                               double x_to,    double y_to);            
-            void curve_to(double x_ctrl1, double y_ctrl1, 
-                          double x_ctrl2, double y_ctrl2, 
+            void quad_curve_to(double x_ctrl,  double y_ctrl,
+                               double x_to,    double y_to);
+            void curve_to(double x_ctrl1, double y_ctrl1,
+                          double x_ctrl2, double y_ctrl2,
                           double x_to,    double y_to);
             void arc(double x, double y, double radius, double start_angle,
 
@@ -59,7 +59,7 @@ namespace kiva
             void rects(double* all_rects, int Nrects);
             void translate_ctm(double x, double y);
             void rotate_ctm(double angle);
-            void scale_ctm(double sx, double sy);            
+            void scale_ctm(double sx, double sy);
             %rename(concat_ctm_agg) concat_ctm(agg24::trans_affine&);
             void concat_ctm(agg24::trans_affine& m);
             %rename(set_ctm_agg) set_ctm(agg24::trans_affine&);
@@ -83,21 +83,21 @@ namespace kiva
                     self.set_ctm_agg(self.kivaaffine_to_aggaffine(ctm))
             %}
             agg24::trans_affine get_ctm();
-            void save_ctm();           
+            void save_ctm();
             void restore_ctm();
-            
+
             // methods from agg24::path_storage that are used in testing
             unsigned total_vertices() const;
             %rename(_rewind) rewind(unsigned);
             void rewind(unsigned start=0);
-            
+
             %rename (_vertex) vertex(unsigned, double*, double*);
-            unsigned vertex(unsigned idx, double* x, double* y) const;            
-            
+            unsigned vertex(unsigned idx, double* x, double* y) const;
+
             %rename (_vertex) vertex(double*, double*);
             unsigned vertex(double* x, double* y);
 
-    };    
+    };
 }
 
 %pythoncode {
@@ -117,10 +117,10 @@ def _vertices(self):
         while cmd_flag != 0:
             pt, cmd_flag = self._vertex()
             cmd,flag = _agg.path_cmd(cmd_flag),_agg.path_flags(cmd_flag)
-            vertices.append((pt[0],pt[1], cmd, flag))        
+            vertices.append((pt[0],pt[1], cmd, flag))
         return array(vertices)
 
-CompiledPath._vertices = _vertices    
+CompiledPath._vertices = _vertices
 
 
 def get_kiva_ctm(self):
@@ -130,7 +130,7 @@ def get_kiva_ctm(self):
                       [aff[4], aff[5], 1]], float64)
 
 CompiledPath.get_kiva_ctm = get_kiva_ctm
-       
+
 }
 
 %clear (double *x, double *y);

--- a/kiva/agg/src/constants.i
+++ b/kiva/agg/src/constants.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -15,20 +15,20 @@
 // 3) Provides python dictionaries to map back and forth between enumerated
 //    types and more descriptive strings that can be used in python.
 //
-// A number of constants (and some functions and types) are defined in 
+// A number of constants (and some functions and types) are defined in
 // agg_basics.h and kiva_constants.h.
 //
-// agg_renderer_markers.h is used for rendering simple shapes at multiple 
+// agg_renderer_markers.h is used for rendering simple shapes at multiple
 // data points.  It is useful for generating scatter plots in simple cases.
 // This wrapper is used to pick up the enumerated types for markers such
 // as marker_square, marker_circle, etc.  The only classes in the header are
 // template definitions so they are all ignored by swig.
 //
-// 
+//
 /////////////////////////////////////////////////////////////////////////////
 
 %{
-#include "agg_basics.h"    
+#include "agg_basics.h"
 #include "kiva_constants.h"
 #include "agg_renderer_markers.h"
 %}

--- a/kiva/agg/src/font_type.i
+++ b/kiva/agg/src/font_type.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -22,14 +22,14 @@ namespace kiva
     {
         public:
             %mutable;
-            int size;              
+            int size;
             std::string name;
             int family;
-            int style;     
+            int style;
             int encoding;
             int face_index;
             std::string filename;
-            
+
             // constructor
             font_type(std::string _name="Arial",
                       int _size=12,
@@ -38,18 +38,18 @@ namespace kiva
                       int _encoding=0,
                       int _face_index=0,
                       bool validate=true);
-                      
+
             int change_filename(std::string _filename);
 
             bool is_loaded();
     };
 }
 %extend kiva::font_type
-{    
+{
     char *__repr__()
     {
         static char tmp[1024];
-        // !! We should work to make output formatting conform to 
+        // !! We should work to make output formatting conform to
         // !! whatever it Numeric does (which needs to be cleaned up also).
         sprintf(tmp,"Font(%s,%d,%d,%d,%d,%d)",
                 self->name.c_str(), self->family, self->size, self->style,
@@ -64,7 +64,7 @@ namespace kiva
                 self->style == other.style &&
                 self->encoding == other.encoding &&
                 self->face_index == other.face_index);
-    }    
+    }
 }
 
 %pythoncode
@@ -84,4 +84,4 @@ def unicode_safe_init(self, _name="Arial", _size=12, _family=0, _style=0,
 # This is a crappy way of overriding the constructor
 AggFontType.__init__ = unicode_safe_init
 %}
-    
+

--- a/kiva/agg/src/graphics_context.i
+++ b/kiva/agg/src/graphics_context.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -350,7 +350,7 @@ namespace kiva {
                 # swig 1.3.28 does not have real thisown, thisown is mapped
                 # to this.own() but with previous 'self.this=obj' an
                 # attribute 'own' error is raised. Does this workaround
-                # work with pre-1.3.28 swig?				
+                # work with pre-1.3.28 swig?
                 self.thisown2 = 1
 
                 self.bmp_array = ary

--- a/kiva/agg/src/gtk1/agg_bmp.cpp
+++ b/kiva/agg/src/gtk1/agg_bmp.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/gtk1/agg_bmp.h
+++ b/kiva/agg/src/gtk1/agg_bmp.h
@@ -1,5 +1,5 @@
 // -*- c++ -*-
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/gtk1/agg_platform_specific.cpp
+++ b/kiva/agg/src/gtk1/agg_platform_specific.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -117,16 +117,16 @@ namespace agg24
 
   XImage* x11_display::create_image(const rendering_buffer* rbuf) {
     DEBUG_MTH("x11_display::create_image");
-    unsigned width = rbuf->width(); 
-    unsigned height = rbuf->height(); 
-    return XCreateImage(m_display, 
-			m_visual, //CopyFromParent, 
-			m_depth, 
-			ZPixmap, 
+    unsigned width = rbuf->width();
+    unsigned height = rbuf->height();
+    return XCreateImage(m_display,
+			m_visual, //CopyFromParent,
+			m_depth,
+			ZPixmap,
 			0,
-			(char*)(rbuf->buf()), 
+			(char*)(rbuf->buf()),
 			width,
-			height, 
+			height,
 			m_sys_bpp,
 			width * (m_sys_bpp / 8));
   }
@@ -188,7 +188,7 @@ namespace agg24
       case pix_format_gray8:
 	m_bpp = 8;
 	break;
-	
+
       case pix_format_rgb565:
       case pix_format_rgb555:
 	m_bpp = 16;
@@ -245,15 +245,15 @@ namespace agg24
 		  m_sys_format = pix_format_rgba32;
 		  m_byte_order = LSBFirst;
 		  break;
-		  
+
 		case pix_format_abgr32:
 		  m_sys_format = pix_format_abgr32;
 		  m_byte_order = MSBFirst;
 		  break;
-		  
-		default:                            
+
+		default:
 		  m_byte_order = hw_byte_order;
-		  m_sys_format = 
+		  m_sys_format =
 		    (hw_byte_order == LSBFirst) ?
 		    pix_format_rgba32 :
 		    pix_format_abgr32;
@@ -268,15 +268,15 @@ namespace agg24
 		  m_sys_format = pix_format_argb32;
 		  m_byte_order = MSBFirst;
 		  break;
-		  
+
 		case pix_format_bgra32:
 		  m_sys_format = pix_format_bgra32;
 		  m_byte_order = LSBFirst;
 		  break;
-		  
-		default:                            
+
+		default:
 		  m_byte_order = hw_byte_order;
-		  m_sys_format = 
+		  m_sys_format =
 		    (hw_byte_order == MSBFirst) ?
 		    pix_format_argb32 :
 		    pix_format_bgra32;
@@ -343,7 +343,7 @@ namespace agg24
 	    UNHANDLED_PIX_FORMATS;
 	  }
 	break;
-                    
+
       case pix_format_rgb565:
 	switch(m_format)
 	  {
@@ -358,7 +358,7 @@ namespace agg24
 	    UNHANDLED_PIX_FORMATS;
 	  }
 	break;
-	
+
       case pix_format_rgba32:
 	switch(m_format)
 	  {
@@ -373,7 +373,7 @@ namespace agg24
 	    UNHANDLED_PIX_FORMATS;
 	  }
 	break;
-	
+
       case pix_format_abgr32:
 	switch(m_format)
 	  {
@@ -388,7 +388,7 @@ namespace agg24
 	    UNHANDLED_PIX_FORMATS;
 	  }
 	break;
-	
+
       case pix_format_argb32:
 	switch(m_format)
 	  {
@@ -403,7 +403,7 @@ namespace agg24
 	    UNHANDLED_PIX_FORMATS;
 	  }
 	break;
-	
+
       case pix_format_bgra32:
 	switch(m_format)
 	  {

--- a/kiva/agg/src/gtk1/agg_platform_specific.h
+++ b/kiva/agg/src/gtk1/agg_platform_specific.h
@@ -1,5 +1,5 @@
 // -*- c++ -*-
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -20,7 +20,7 @@ namespace agg24
 
   enum pix_format_e
     {
-      pix_format_undefined = 0,  // By default. No conversions are applied 
+      pix_format_undefined = 0,  // By default. No conversions are applied
       pix_format_gray8,          // Simple 256 level grayscale
       pix_format_rgb555,         // 15 bit rgb. Depends on the byte ordering!
       pix_format_rgb565,         // 16 bit rgb. Depends on the byte ordering!
@@ -30,7 +30,7 @@ namespace agg24
       pix_format_argb32,         // A-R-G-B, native MAC format
       pix_format_abgr32,         // A-B-G-R, one byte per color component
       pix_format_bgra32,         // B-G-R-A, native win32 BMP format
-      
+
       end_of_pix_formats
     };
 
@@ -46,7 +46,7 @@ namespace agg24
     void destroy_image(XImage* ximg);
 
   public:
-    Display*             m_display;    
+    Display*             m_display;
     int                  m_screen;
     int                  m_depth;
     Visual*              m_visual;
@@ -60,7 +60,7 @@ namespace agg24
   //------------------------------------------------------------------------
   class platform_specific
   {
-    
+
     static x11_display x11;
 
   public:
@@ -84,7 +84,7 @@ namespace agg24
     int                  m_byte_order;  // init()
     unsigned             m_sys_bpp;     // init()
     pix_format_e         m_sys_format;  // init()
-    
+
   };
 
 }

--- a/kiva/agg/src/gtk1/plat_support.i
+++ b/kiva/agg/src/gtk1/plat_support.i
@@ -1,5 +1,5 @@
 // -*- c++ -*-
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -24,11 +24,11 @@ namespace agg24
         npy_intp rows = pix_map.height();
         npy_intp cols = pix_map.width();
         npy_intp depth = pix_map.bpp() / 8;
-    
+
         dims[0] = rows;
         dims[1] = cols;
         dims[2] = depth;
-        
+
         return PyArray_SimpleNewFromData(3,dims,NPY_UINT8,(void*)pix_map.buf());
     }
 
@@ -41,7 +41,7 @@ namespace agg24
     $1 = (Window) PyInt_AsLong($input);
 }
 
-// More permissive unsigned typemap that converts any numeric type to an 
+// More permissive unsigned typemap that converts any numeric type to an
 // unsigned value.  It is cleared at the end of this file.
 %typemap(in) unsigned
 {
@@ -49,13 +49,13 @@ namespace agg24
     if (PyErr_Occurred()) SWIG_fail;
     $1 = (unsigned) PyLong_AsLong(obj);
     if (PyErr_Occurred()) SWIG_fail;
-}   
+}
 
 namespace agg24
 {
     enum pix_format_e
     {
-        pix_format_undefined = 0,  // By default. No conversions are applied 
+        pix_format_undefined = 0,  // By default. No conversions are applied
         pix_format_gray8,          // Simple 256 level grayscale
         pix_format_rgb555,         // 15 bit rgb. Depends on the byte ordering!
         pix_format_rgb565,         // 16 bit rgb. Depends on the byte ordering!
@@ -65,7 +65,7 @@ namespace agg24
         pix_format_argb32,         // A-R-G-B, native MAC format
         pix_format_abgr32,         // A-B-G-R, one byte per color component
         pix_format_bgra32,         // B-G-R-A, native win32 BMP format
-  
+
         end_of_pix_formats
     };
 
@@ -81,7 +81,7 @@ namespace agg24
         %feature("shadow") draw(Window h_dc, int x, int y, double scale) const
         %{
         def draw(self, h_dc, x=0, y=0, scale=1.0):
-            # fix me: brittle becuase we are hard coding 
+            # fix me: brittle becuase we are hard coding
             # module and class name.  Done cause SWIG 1.3.24 does
             # some funky overloading stuff in it that breaks keyword
             # arguments.

--- a/kiva/agg/src/kiva_affine_helpers.cpp
+++ b/kiva/agg/src/kiva_affine_helpers.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/kiva_affine_helpers.h
+++ b/kiva/agg/src/kiva_affine_helpers.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/kiva_alpha_gamma.h
+++ b/kiva/agg/src/kiva_alpha_gamma.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/kiva_basics.h
+++ b/kiva/agg/src/kiva_basics.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -12,7 +12,7 @@
 
 #include "kiva_constants.h"
 
-namespace kiva 
+namespace kiva
 {
 
 #ifdef _MSC_VER
@@ -65,7 +65,7 @@ namespace kiva
 
     // Determines whether or not two floating point numbers are
     // essentially equal.  This uses an aspect of the IEEE floating-
-    // point spec described in 
+    // point spec described in
     // http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
     // The code for both functions are from this same page.
     //

--- a/kiva/agg/src/kiva_compiled_path.cpp
+++ b/kiva/agg/src/kiva_compiled_path.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/kiva_compiled_path.h
+++ b/kiva/agg/src/kiva_compiled_path.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -13,7 +13,7 @@
 #include <iostream>
 #include <stack>
 
-#include "agg_basics.h" 
+#include "agg_basics.h"
 #include "agg_path_storage.h"
 #include "agg_trans_affine.h"
 
@@ -22,16 +22,16 @@
 
 namespace kiva
 {
-   
+
     class compiled_path : public agg24::path_storage
     {
-        
+
         /*-------------------------------------------------------------------
          This extends the standard agg24::path_storage class to include
          matrix transforms within the path definition.  Doing so requires
 		 overriding a number of methods to apply the matrix transformation
 		 to vertices added to the path.
-         
+
          The overridden methods are:
              move_to
              line_to
@@ -39,9 +39,9 @@ namespace kiva
              curve3
              curve4
              add_path
-        
+
          There are a few others that need to be looked at also...
-         
+
          In addition, we need to add several methods:
              translate_ctm
              rotate_ctm
@@ -53,50 +53,50 @@ namespace kiva
              restore_ctm
         -------------------------------------------------------------------*/
 
-        
+
 		// hack to get VC++ 6.0 to compile correctly
         typedef agg24::path_storage base;
-        
+
 
         /*-------------------------------------------------------------------
          ptm -- path transform matrix.
-         
+
          This is used to transform each point added to the path.  It begins
-         as an identity matrix and accumulates every transform made during the 
-         path formation.  At the end of the path creation, the ptm holds 
+         as an identity matrix and accumulates every transform made during the
+         path formation.  At the end of the path creation, the ptm holds
          the total transformation seen during the path formation.  It
-         can thus be multiplied with the ctm to determine what the ctm 
+         can thus be multiplied with the ctm to determine what the ctm
          should be after the compiled_path has been drawn.
 
 		 Todo: Should this default to the identity matrix or the current ctm?
         -------------------------------------------------------------------*/
         agg24::trans_affine ptm;
-        
-        
+
+
         // ptm_stack is used for save/restore of the ptm
         std::stack<agg24::trans_affine> ptm_stack;
 
         // If the path contains curves, this value is true;
         bool _has_curves;
-                
-        public:        
-            // constructor        
-            compiled_path() : base(), ptm(agg24::trans_affine())        
+
+        public:
+            // constructor
+            compiled_path() : base(), ptm(agg24::trans_affine())
             {}
-            
+
             //---------------------------------------------------------------
             // path_storage interface
             //---------------------------------------------------------------
 			void remove_all();
-    
+
 			void begin_path();
             void close_path();
             void move_to(double x, double y);
             void line_to(double x, double y);
-            void quad_curve_to(double x_ctrl,  double y_ctrl, 
+            void quad_curve_to(double x_ctrl,  double y_ctrl,
                                double x_to,    double y_to);
-            void curve_to(double x_ctrl1, double y_ctrl1, 
-                          double x_ctrl2, double y_ctrl2, 
+            void curve_to(double x_ctrl1, double y_ctrl1,
+                          double x_ctrl2, double y_ctrl2,
                           double x_to,    double y_to);
 
             // see graphics_context_base for descriptions of these functions
@@ -131,7 +131,7 @@ namespace kiva
             //---------------------------------------------------------------
             void save_ctm();
 			void restore_ctm();
-			
+
             //---------------------------------------------------------------
             // Test whether curves exist in path.
             //---------------------------------------------------------------

--- a/kiva/agg/src/kiva_constants.h
+++ b/kiva/agg/src/kiva_constants.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/kiva_dash_type.h
+++ b/kiva/agg/src/kiva_dash_type.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -41,10 +41,10 @@ namespace kiva
                 if (n%2)
                     pattern[n] = _pattern[0];
             }
-            
+
             ~dash_type()
             {
-            }    
+            }
 
 
             bool is_solid()

--- a/kiva/agg/src/kiva_exceptions.h
+++ b/kiva/agg/src/kiva_exceptions.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/kiva_font_type.cpp
+++ b/kiva/agg/src/kiva_font_type.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -27,7 +27,7 @@ const char* font_dirs[] = { "c:/windows/fonts/", "./",
                                 "/usr/share/fonts/truetype/",
                                 "/usr/share/fonts/msttcorefonts/",
                                 "/var/lib/defoma/x-ttcidfont-conf.d/dirs/TrueType/",
-                                "/usr/share/fonts/truetype/msttcorefonts/", 
+                                "/usr/share/fonts/truetype/msttcorefonts/",
                               };
 #endif
 

--- a/kiva/agg/src/kiva_font_type.h
+++ b/kiva/agg/src/kiva_font_type.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -31,7 +31,7 @@ namespace kiva
             int face_index;
 
             // Constructors
-            
+
             // Creates a font object.  By default, searches the hardcoded
             // font paths for a file named like the face name; to override
             // this, set validate=false.
@@ -45,23 +45,23 @@ namespace kiva
 
             font_type(const font_type &font);
             font_type &operator=(const font_type& font);
-        
+
             int change_filename(std::string _filename);
-            
+
             // Is the font loaded properly?
             inline bool is_loaded() const { return _is_loaded; }
-        
+
         private:
             bool _is_loaded;
     };
 
     inline bool operator==(font_type &a, font_type &b)
     {
-        return (a.size == b.size) && (a.name == b.name) && 
+        return (a.size == b.size) && (a.name == b.name) &&
                (a.style == b.style) && (a.encoding == b.encoding) &&
                (a.family == b.family) && (a.face_index == b.face_index);
     }
-    
-    
+
+
 }
 #endif

--- a/kiva/agg/src/kiva_gradient.cpp
+++ b/kiva/agg/src/kiva_gradient.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/kiva_gradient.h
+++ b/kiva/agg/src/kiva_gradient.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -204,7 +204,7 @@ namespace kiva
             {
                 // length is the distance between the two points
                 d2 = sqrt(dx * dx + dy * dy);
-                
+
                 if (points[0].first == points[1].first)
                 {
                     // gradient_y. handle flips

--- a/kiva/agg/src/kiva_graphics_context.h
+++ b/kiva/agg/src/kiva_graphics_context.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -477,7 +477,7 @@ namespace kiva
             typedef std::pair<double, double> point_type;
             std::vector<gradient_stop> stops_list;
             std::vector<point_type> points;
-            
+
             if (strcmp(units, "objectBoundingBox") == 0)
             {
                 // Transform from relative coordinates
@@ -485,7 +485,7 @@ namespace kiva
                 x1 = clip_rect.x + x1 * clip_rect.w;
                 x2 = clip_rect.x + x2 * clip_rect.w;
                 y1 = clip_rect.y + y1 * clip_rect.h;
-                y2 = clip_rect.y + y2 * clip_rect.h;                
+                y2 = clip_rect.y + y2 * clip_rect.h;
             }
 
             points.push_back(point_type(x1, y1));

--- a/kiva/agg/src/kiva_graphics_context_base.cpp
+++ b/kiva/agg/src/kiva_graphics_context_base.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -476,24 +476,24 @@ kiva::rect_type graphics_context_base::_get_path_bounds()
 {
     double xmin = 0., ymin = 0., xmax = 0., ymax = 0.;
     double x = 0., y = 0.;
-    
+
     for (unsigned i = 0; i < this->path.total_vertices(); ++i)
     {
         this->path.vertex(i, &x, &y);
-        
+
         if (i == 0)
         {
             xmin = xmax = x;
             ymin = ymax = y;
             continue;
         }
-        
+
         if (x < xmin) xmin = x;
         else if (xmax < x) xmax = x;
         if (y < ymin) ymin = y;
         else if (ymax < y) ymax = y;
     }
-    
+
     return kiva::rect_type(xmin, ymin, xmax-xmin, ymax-ymin);
 }
 

--- a/kiva/agg/src/kiva_graphics_context_base.h
+++ b/kiva/agg/src/kiva_graphics_context_base.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/kiva_graphics_state.h
+++ b/kiva/agg/src/kiva_graphics_state.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/kiva_image_filters.h
+++ b/kiva/agg/src/kiva_image_filters.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -24,24 +24,24 @@ namespace kiva
 {
 
     typedef agg24::span_interpolator_linear<> interpolator_type;
-    
+
     template<class pixel_format>
     class image_filters
     {
     };
-    
+
     template<>
     class image_filters<agg24::pixfmt_rgba32>
     {
         public:
         typedef agg24::image_accessor_clip<agg24::pixfmt_rgba32> source_type;
-        
-        typedef agg24::span_image_filter_rgba_nn<source_type, 
+
+        typedef agg24::span_image_filter_rgba_nn<source_type,
                                            interpolator_type> nearest_type;
-        typedef agg24::span_image_filter_rgba_bilinear<source_type, 
+        typedef agg24::span_image_filter_rgba_bilinear<source_type,
                                            interpolator_type> bilinear_type;
-        typedef agg24::span_image_filter_rgba<source_type, 
-                                           interpolator_type> general_type;                   
+        typedef agg24::span_image_filter_rgba<source_type,
+                                           interpolator_type> general_type;
     };
 
     template<>
@@ -49,69 +49,69 @@ namespace kiva
     {
         public:
         typedef agg24::image_accessor_clip<agg24::pixfmt_bgra32> source_type;
-        
-        typedef agg24::span_image_filter_rgba_nn<source_type, 
+
+        typedef agg24::span_image_filter_rgba_nn<source_type,
                                            interpolator_type> nearest_type;
-        typedef agg24::span_image_filter_rgba_bilinear<source_type, 
+        typedef agg24::span_image_filter_rgba_bilinear<source_type,
                                            interpolator_type> bilinear_type;
-        typedef agg24::span_image_filter_rgba<source_type, 
-                                           interpolator_type> general_type;                   
+        typedef agg24::span_image_filter_rgba<source_type,
+                                           interpolator_type> general_type;
     };
-    
+
     template<>
     class image_filters<agg24::pixfmt_argb32>
     {
         public:
         typedef agg24::image_accessor_clip<agg24::pixfmt_argb32> source_type;
-        
-        typedef agg24::span_image_filter_rgba_nn<source_type, 
+
+        typedef agg24::span_image_filter_rgba_nn<source_type,
                                            interpolator_type> nearest_type;
-        typedef agg24::span_image_filter_rgba_bilinear<source_type, 
+        typedef agg24::span_image_filter_rgba_bilinear<source_type,
                                            interpolator_type> bilinear_type;
-        typedef agg24::span_image_filter_rgba<source_type, 
-                                           interpolator_type> general_type;                   
+        typedef agg24::span_image_filter_rgba<source_type,
+                                           interpolator_type> general_type;
     };
-    
+
     template<>
     class image_filters<agg24::pixfmt_abgr32>
     {
         public:
         typedef agg24::image_accessor_clip<agg24::pixfmt_abgr32> source_type;
-        
-        typedef agg24::span_image_filter_rgba_nn<source_type, 
+
+        typedef agg24::span_image_filter_rgba_nn<source_type,
                                            interpolator_type> nearest_type;
-        typedef agg24::span_image_filter_rgba_bilinear<source_type, 
+        typedef agg24::span_image_filter_rgba_bilinear<source_type,
                                            interpolator_type> bilinear_type;
-        typedef agg24::span_image_filter_rgba<source_type, 
-                                           interpolator_type> general_type;                   
+        typedef agg24::span_image_filter_rgba<source_type,
+                                           interpolator_type> general_type;
     };
-    
+
     template<>
     class image_filters<agg24::pixfmt_rgb24>
     {
         public:
         typedef agg24::image_accessor_clip<agg24::pixfmt_rgb24> source_type;
-        
-        typedef agg24::span_image_filter_rgb_nn<source_type, 
+
+        typedef agg24::span_image_filter_rgb_nn<source_type,
                                            interpolator_type> nearest_type;
-        typedef agg24::span_image_filter_rgb_bilinear<source_type, 
+        typedef agg24::span_image_filter_rgb_bilinear<source_type,
                                            interpolator_type> bilinear_type;
-        typedef agg24::span_image_filter_rgb<source_type, 
-                                           interpolator_type> general_type;                   
+        typedef agg24::span_image_filter_rgb<source_type,
+                                           interpolator_type> general_type;
     };
-    
+
     template<>
     class image_filters<agg24::pixfmt_bgr24>
     {
         public:
         typedef agg24::image_accessor_clip<agg24::pixfmt_bgr24> source_type;
-        
-        typedef agg24::span_image_filter_rgb_nn<source_type, 
+
+        typedef agg24::span_image_filter_rgb_nn<source_type,
                                            interpolator_type> nearest_type;
-        typedef agg24::span_image_filter_rgb_bilinear<source_type, 
+        typedef agg24::span_image_filter_rgb_bilinear<source_type,
                                            interpolator_type> bilinear_type;
-        typedef agg24::span_image_filter_rgb<source_type, 
-                                           interpolator_type> general_type;                   
+        typedef agg24::span_image_filter_rgb<source_type,
+                                           interpolator_type> general_type;
     };
 }
 

--- a/kiva/agg/src/kiva_pix_format.h
+++ b/kiva/agg/src/kiva_pix_format.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -11,7 +11,7 @@
 /////////////////////////////////////////////////////////////////////////////
 //
 // This set of templatized functions return a kiva::pix_format_e value based
-// on the agg pixel format template parameter.  The function is called from 
+// on the agg pixel format template parameter.  The function is called from
 // the graphics_context<T>.format() method.
 //
 /////////////////////////////////////////////////////////////////////////////
@@ -32,7 +32,7 @@ namespace kiva
     // The default function returns "undefined", and the template
     // is specialized for each of the actual Agg pixel formats.
     template <class AggPixFmt> kiva::pix_format_e agg_pix_to_kiva(void *dummy=NULL)
-    { 
+    {
         return kiva::pix_format_undefined;
     }
 
@@ -45,7 +45,7 @@ namespace kiva
     // and all calls to agg_pix_to_kiva<T>() end up in an arbitrary one of the
     // following specializations (usually the first).  The obvious workaround is
     // to add optional function parameters corresponding to the template parameter.
-    // 
+    //
     // Furthermore, when calling these functions, MSVC will complain about
     // ambiguous overloading, so you have to create a dummy pointer and pass it
     // in.  Normally, you would be able to do this:

--- a/kiva/agg/src/kiva_rect.cpp
+++ b/kiva/agg/src/kiva_rect.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -67,7 +67,7 @@ rect_list_type disjoint_intersect(const rect_list_type &original_list,
             result_list.push_back(result_rect);
         }
     }
-    
+
     return result_list;
 }
 
@@ -93,7 +93,7 @@ rect_list_type disjoint_union(const rect_list_type &rects)
         rlist = disjoint_union(rlist, rects[i]);
     }
     return rlist;
-    
+
 }
 
 rect_list_type disjoint_union(rect_list_type original_list,
@@ -110,7 +110,7 @@ rect_list_type disjoint_union(rect_list_type original_list,
     rect_list_type additional_rects;
     rect_list_type todo;
     todo.push_back(new_rect);
-    
+
     // Iterate over each item in the todo list:
     unsigned int todo_count = 0;
     bool use_leftover = true;
@@ -151,7 +151,7 @@ rect_list_type disjoint_union(rect_list_type original_list,
                 use_leftover = false;
                 break;
             }
-    
+
             // Test for existing rect being wholly contained in new rect
             bool x2inx1 = ((xl2 >= xl1) && (xr2 <= xr1));
             bool y2iny1 = ((yb2 >= yb1) && (yt2 <= yt1));
@@ -215,7 +215,7 @@ rect_list_type disjoint_union(rect_list_type original_list,
                 orig_count++;
                 continue;
             }
-            
+
             // Test for rect 2 being within rect 1 along the y-axis:
             if (y2iny1)
             {
@@ -245,7 +245,7 @@ rect_list_type disjoint_union(rect_list_type original_list,
                 xl = xr2;
                 xr = xr1;
             }
-            
+
             if (yb1 < yb2)
             {
                 yb  = yb2;
@@ -258,7 +258,7 @@ rect_list_type disjoint_union(rect_list_type original_list,
             }
 
             todo.push_back(rect_type(xl, yb, xr-xl, yt-yb));
-            
+
             orig_count++;
         }
 
@@ -330,7 +330,7 @@ void test_disjoint_2_3()
 void test_disjoint_corner()
 {
     bool all_pass = false;
-    
+
     rect_list_type cliprects;
     rect_type mainrect(40,40,20,20);
     rect_type ul(35,55,10,10);

--- a/kiva/agg/src/kiva_rect.h
+++ b/kiva/agg/src/kiva_rect.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/numeric.i
+++ b/kiva/agg/src/numeric.i
@@ -1,5 +1,5 @@
 /* -*- c -*- */
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/numeric_ext.i
+++ b/kiva/agg/src/numeric_ext.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -16,23 +16,23 @@
 /* This is the basic array allocation function. */
 PyObject *PyArray_FromDimsAndStridesAndDataAndDescr(int nd, int *d, int* st,
                                                     PyArray_Descr *descr,
-                                                    char *data) 
+                                                    char *data)
 {
     PyArrayObject *self;
     int i,sd;
     int *dimensions, *strides;
     int flags= CONTIGUOUS | OWN_DIMENSIONS | OWN_STRIDES;
-    
+
     dimensions = strides = NULL;
-        
-    if (nd < 0) 
+
+    if (nd < 0)
     {
-        PyErr_SetString(PyExc_ValueError, 
+        PyErr_SetString(PyExc_ValueError,
                         "number of dimensions must be >= 0");
         return NULL;
     }
-        
-    if (nd > 0) 
+
+    if (nd > 0)
     {
         if ((dimensions = (int *)malloc(nd*sizeof(int))) == NULL) {
             PyErr_SetString(PyExc_MemoryError, "can't allocate memory for array");
@@ -45,17 +45,17 @@ PyObject *PyArray_FromDimsAndStridesAndDataAndDescr(int nd, int *d, int* st,
         memmove(dimensions, d, sizeof(int)*nd);
         memmove(strides, st, sizeof(int)*nd);
     }
-        
+
     // This test for continguity
     sd = descr->elsize;
-    for(i=nd-1;i>=0;i--) 
+    for(i=nd-1;i>=0;i--)
     {
-        if (strides[i] <= 0) 
+        if (strides[i] <= 0)
         {
             PyErr_SetString(PyExc_ValueError, "strides must be positive");
             goto fail;
         }
-        if (dimensions[i] <= 0) 
+        if (dimensions[i] <= 0)
         {
             /* only allow positive dimensions in this function */
             PyErr_SetString(PyExc_ValueError, "dimensions must be positive");
@@ -64,21 +64,21 @@ PyObject *PyArray_FromDimsAndStridesAndDataAndDescr(int nd, int *d, int* st,
         if (strides[i] != sd)
         {
             flags &= !CONTIGUOUS;
-        }    
-        /* 
+        }
+        /*
            This may waste some space, but it seems to be
            (unsuprisingly) unhealthy to allow strides that are
            longer than sd.
         */
         sd *= dimensions[i] ? dimensions[i] : 1;
     }
-        
+
     /* Make sure we're alligned on ints. */
-    sd += sizeof(int) - sd%sizeof(int); 
-        
-    if (data == NULL) 
+    sd += sizeof(int) - sd%sizeof(int);
+
+    if (data == NULL)
     {
-        if ((data = (char *)malloc(sd)) == NULL) 
+        if ((data = (char *)malloc(sd)) == NULL)
         {
             PyErr_SetString(PyExc_MemoryError, "can't allocate memory for array");
             goto fail;
@@ -86,11 +86,11 @@ PyObject *PyArray_FromDimsAndStridesAndDataAndDescr(int nd, int *d, int* st,
         flags |= OWN_DATA;
     }
 
-    if((self = PyObject_NEW(PyArrayObject, &PyArray_Type)) == NULL) 
+    if((self = PyObject_NEW(PyArrayObject, &PyArray_Type)) == NULL)
         goto fail;
-    if (flags & OWN_DATA) 
+    if (flags & OWN_DATA)
         memset(data, 0, sd);
-        
+
     self->data=data;
     self->dimensions = dimensions;
     self->strides = strides;
@@ -99,21 +99,21 @@ PyObject *PyArray_FromDimsAndStridesAndDataAndDescr(int nd, int *d, int* st,
     self->base = (PyObject *)NULL;
     self->flags = flags;
 
-/* Numeric versions prior to 23.3 do not have the weakreflist field. 
+/* Numeric versions prior to 23.3 do not have the weakreflist field.
    By default we include it.  You must explicitly define:
-    NUMERIC_DOES_NOT_HAVE_WEAKREF    
+    NUMERIC_DOES_NOT_HAVE_WEAKREF
 */
-#ifndef NUMERIC_DOES_NOT_HAVE_WEAKREF    
+#ifndef NUMERIC_DOES_NOT_HAVE_WEAKREF
     self->weakreflist = (PyObject *)NULL;
 #endif
 
     return (PyObject*)self;
-        
- fail:        
+
+ fail:
     if (flags & OWN_DATA) free(data);
     if (dimensions != NULL) free(dimensions);
     if (strides != NULL) free(strides);
-    return NULL;    
+    return NULL;
 }
 #endif
 

--- a/kiva/agg/src/osx/agg_bmp.cpp
+++ b/kiva/agg/src/osx/agg_bmp.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/osx/agg_bmp.h
+++ b/kiva/agg/src/osx/agg_bmp.h
@@ -1,5 +1,5 @@
 // -*- c++ -*-
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/osx/plat_support.i
+++ b/kiva/agg/src/osx/plat_support.i
@@ -1,5 +1,5 @@
 // -*- c++ -*-
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -24,7 +24,7 @@ namespace agg24
         npy_intp rows = pix_map.height();
         npy_intp cols = pix_map.width();
         npy_intp depth = pix_map.bpp() / 8;
-    
+
         dims[0] = rows;
         dims[1] = cols;
         dims[2] = depth;
@@ -35,7 +35,7 @@ namespace agg24
 
 %}
 
-// More permissive unsigned typemap that converts any numeric type to an 
+// More permissive unsigned typemap that converts any numeric type to an
 // unsigned value.  It is cleared at the end of this file.
 %typemap(in) unsigned
 {
@@ -43,13 +43,13 @@ namespace agg24
     if (PyErr_Occurred()) SWIG_fail;
     $1 = (unsigned) PyLong_AsLong(obj);
     if (PyErr_Occurred()) SWIG_fail;
-}   
+}
 
 namespace agg24
 {
     enum pix_format_e
     {
-        pix_format_undefined = 0,  // By default. No conversions are applied 
+        pix_format_undefined = 0,  // By default. No conversions are applied
         pix_format_gray8,          // Simple 256 level grayscale
         pix_format_rgb555,         // 15 bit rgb. Depends on the byte ordering!
         pix_format_rgb565,         // 16 bit rgb. Depends on the byte ordering!
@@ -59,7 +59,7 @@ namespace agg24
         pix_format_argb32,         // A-R-G-B, native MAC format
         pix_format_abgr32,         // A-B-G-R, one byte per color component
         pix_format_bgra32,         // B-G-R-A, native win32 BMP format
-  
+
         end_of_pix_formats
     };
 

--- a/kiva/agg/src/rect.i
+++ b/kiva/agg/src/rect.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -11,26 +11,26 @@
 #include "kiva_rect.h"
 %}
 
-%typemap(in)  (kiva::rect_type &rect) 
-{   
+%typemap(in)  (kiva::rect_type &rect)
+{
     PyArrayObject* ary=NULL;
-    int is_new_object; 
+    int is_new_object;
     ary = obj_to_array_contiguous_allow_conversion($input, PyArray_DOUBLE,
                                                    is_new_object);
 
     int size[1] = {4};
-    if (!ary || 
+    if (!ary ||
         !require_dimensions(ary, 1) ||
         !require_size(ary, size, 1))
-    {    
+    {
         goto fail;
     }
 
     double* data = (double*)(ary->data);
-    kiva::rect_type rect(data[0], data[1], 
+    kiva::rect_type rect(data[0], data[1],
                          data[2], data[3]);
     $1 = &rect;
-    
+
     if (is_new_object)
     {
         Py_DECREF(ary);

--- a/kiva/agg/src/rgba.i
+++ b/kiva/agg/src/rgba.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -30,7 +30,7 @@
    $result = PyArray_Return(ary_obj);
 }
 
-%typemap(check) (double r) 
+%typemap(check) (double r)
 {
     if ($1 < 0.0 || $1 > 1.0)
     {
@@ -39,7 +39,7 @@
     }
 }
 
-%apply (double r) {double g, double b, double a};  
+%apply (double r) {double g, double b, double a};
 
 
 namespace agg24
@@ -61,7 +61,7 @@ namespace agg24
 }
 
 %extend agg24::rgba
-{    
+{
     char *__repr__()
     {
         static char tmp[1024];
@@ -70,7 +70,7 @@ namespace agg24
     }
     int __eq__(agg24::rgba& o)
     {
-        return (self->r == o.r && self->g == o.g && 
+        return (self->r == o.r && self->g == o.g &&
                 self->b == o.b && self->a == o.a);
     }
     void asarray(double* out)
@@ -78,7 +78,7 @@ namespace agg24
         out[0] = self->r;
         out[1] = self->g;
         out[2] = self->b;
-        out[3] = self->a;    
+        out[3] = self->a;
     }
 }
 

--- a/kiva/agg/src/rgba_array.i
+++ b/kiva/agg/src/rgba_array.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -9,13 +9,13 @@
 // Thanks for using Enthought open source!
 
 // --------------------------------------------------------------------------
-// 
-// Convert agg24::rgba types to/from Numeric arrays.  The rgba_as_array 
-// typemap will accept any 3 or 4 element sequence of float compatible 
+//
+// Convert agg24::rgba types to/from Numeric arrays.  The rgba_as_array
+// typemap will accept any 3 or 4 element sequence of float compatible
 // objects and convert them into an agg24::rgba object.
-// 
+//
 // The typemap also converts any rgba output value back to a numeric array
-// in python.  This is a more useful representation for numerical 
+// in python.  This is a more useful representation for numerical
 // manipulation.
 //
 // --------------------------------------------------------------------------
@@ -30,19 +30,19 @@
 
 %typemap(in) rgba_as_array (int must_free=0)
 {
-  must_free = 0;  
+  must_free = 0;
   if ((SWIG_ConvertPtr($input,(void **) &$1, SWIGTYPE_p_agg24__rgba,
-                       SWIG_POINTER_EXCEPTION | 0 )) == -1) 
+                       SWIG_POINTER_EXCEPTION | 0 )) == -1)
   {
       PyErr_Clear();
-      if (!PySequence_Check($input)) 
+      if (!PySequence_Check($input))
       {
           PyErr_SetString(PyExc_TypeError,"Expecting a sequence");
           return NULL;
       }
-      
+
       int seq_len = PyObject_Length($input);
-      if (seq_len != 3 && seq_len != 4) 
+      if (seq_len != 3 && seq_len != 4)
       {
           PyErr_SetString(PyExc_ValueError,
                           "Expecting a sequence with 3 or 4 elements");
@@ -50,23 +50,23 @@
       }
 
       double temp[4] = {0.0,0.0,0.0,1.0};
-      for (int i =0; i < seq_len; i++) 
+      for (int i =0; i < seq_len; i++)
       {
           PyObject *o = PySequence_GetItem($input,i);
-          if (PyFloat_Check(o)) 
+          if (PyFloat_Check(o))
           {
              temp[i] = PyFloat_AsDouble(o);
-          }  
-          else 
+          }
+          else
           {
              PyObject* converted = PyNumber_Float(o);
-             if (!converted) 
+             if (!converted)
              {
                  PyErr_SetString(PyExc_TypeError,
                                  "Expecting a sequence of floats");
                  return NULL;
              }
-             temp[i] = PyFloat_AsDouble(converted);  
+             temp[i] = PyFloat_AsDouble(converted);
              Py_DECREF(converted);
           }
           if ((temp[i] < 0.0) || (temp [i] > 1.0))
@@ -74,22 +74,22 @@
               PyErr_SetString(PyExc_ValueError,
                               "Color values must be between 0.0 an 1.0");
               return NULL;
-          }         
+          }
       }
       $1 = new agg24::rgba(temp[0],temp[1],temp[2],temp[3]);
       must_free = 1;
-   }   
+   }
 }
 
 %typemap(freearg) rgba_as_array {
-   if (must_free$argnum) 
+   if (must_free$argnum)
     delete $1;
 }
 
-%typemap(out) rgba_as_array 
+%typemap(out) rgba_as_array
 {
     npy_intp size = 4;
-    $result = PyArray_SimpleNew(1, &size, PyArray_DOUBLE);        
+    $result = PyArray_SimpleNew(1, &size, PyArray_DOUBLE);
     double* data = (double*)((PyArrayObject*)$result)->data;
     data[0] = $1->r;
     data[1] = $1->g;

--- a/kiva/agg/src/sequence_to_array.i
+++ b/kiva/agg/src/sequence_to_array.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -28,14 +28,14 @@
       PyObject *o = PySequence_GetItem($input,i);
       if (PyFloat_Check(o)) {
          temp[i] = PyFloat_AsDouble(o);
-      }  
+      }
       else {
          PyObject* converted = PyNumber_Float(o);
          if (!converted) {
              PyErr_SetString(PyExc_TypeError,"Expecting a sequence of floats");
              return NULL;
          }
-         temp[i] = PyFloat_AsDouble(converted);  
+         temp[i] = PyFloat_AsDouble(converted);
          Py_DECREF(converted);
       }
   }

--- a/kiva/agg/src/win32/agg_bmp.cpp
+++ b/kiva/agg/src/win32/agg_bmp.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/win32/agg_bmp.h
+++ b/kiva/agg/src/win32/agg_bmp.h
@@ -1,5 +1,5 @@
 // -*- c++ -*-
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -25,7 +25,7 @@ namespace agg24
             void draw(HDC h_dc, int draw_x=-1, int draw_y=-1, int draw_width=-1,
             		  int draw_height=-1) const;
             pix_format_e get_pix_format() const;
-        
+
             unsigned char* buf();
             unsigned       width() const;
             unsigned       height() const;
@@ -34,19 +34,19 @@ namespace agg24
             rendering_buffer& rbuf() { return m_rbuf_window; }
             platform_specific*  m_specific;
             PyObject* convert_to_argb32string() const;
-        
+
         private:
             void        destroy();
-            void        create(unsigned width, 
+            void        create(unsigned width,
                                unsigned height,
                                unsigned clear_val=256);
-        
+
             unsigned char*   m_buf;
             unsigned         m_bpp;
             rendering_buffer m_rbuf_window;
-        
+
         public:
-        
+
     };
 
 }

--- a/kiva/agg/src/win32/agg_platform_specific.cpp
+++ b/kiva/agg/src/win32/agg_platform_specific.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -40,7 +40,7 @@ namespace agg24
 
     {
         DEBUG_MTH("dib_display::create_image");
-        unsigned width = rbuf->width(); 
+        unsigned width = rbuf->width();
         unsigned height = rbuf->height();
         unsigned line_len = platform_specific::calc_row_len(width, bits_per_pixel);
         unsigned img_size = line_len * height;
@@ -68,8 +68,8 @@ namespace agg24
         {
             brightness = (255 * i) / (rgb_size - 1);
             rgb->rgbBlue =
-            rgb->rgbGreen =  
-            rgb->rgbRed = (unsigned char)brightness; 
+            rgb->rgbGreen =
+            rgb->rgbRed = (unsigned char)brightness;
             rgb->rgbReserved = 0;
             rgb++;
         }
@@ -123,11 +123,11 @@ namespace agg24
 
         }
     }
-    
+
     unsigned dib_display::calc_palette_size(unsigned  clr_used, unsigned bits_per_pixel)
     {
         int palette_size = 0;
-        
+
         if(bits_per_pixel <= 8)
         {
             palette_size = clr_used;
@@ -149,7 +149,7 @@ namespace agg24
         // If specified, only do a partial blit of the image
         int dest_x, dest_y, src_x, src_y, src_width, src_height;
 
-        
+
         if (draw_x != -1 &&
             draw_y != -1 &&
             draw_width != -1 &&
@@ -169,10 +169,10 @@ namespace agg24
 	        src_width = image->bmp->bmiHeader.biWidth;
 	        src_height = -image->bmp->bmiHeader.biHeight;
         }
-	        
+
         ::SetDIBitsToDevice(
 	        dc,                           // handle to device context
-	        dest_x,                       // x-coordinate of upper-left corner of dest 
+	        dest_x,                       // x-coordinate of upper-left corner of dest
 	        dest_y,                       // y-coordinate of upper-left corner of  dest
 	        src_width,                    // source rectangle width
 	        src_height,                  // source rectangle height
@@ -189,7 +189,7 @@ namespace agg24
 
 
     dib_display platform_specific::dib;
-    
+
     //------------------------------------------------------------------------
     platform_specific::platform_specific(pix_format_e format, bool flip_y) :
                                             m_bpp(0),
@@ -198,7 +198,7 @@ namespace agg24
                                             m_format(format),
                                             m_sys_format(pix_format_undefined),
                                             m_sys_bpp(0)
-    {  
+    {
         switch(m_format)
         {
         case pix_format_gray8:
@@ -206,14 +206,14 @@ namespace agg24
             m_bpp = 8;
             m_sys_bpp = 8;
             break;
-            
+
         case pix_format_rgb565:
         case pix_format_rgb555:
             m_sys_format = pix_format_rgb555;
             m_bpp = 16;
             m_sys_bpp = 16;
             break;
-            
+
         case pix_format_rgb24:
         case pix_format_bgr24:
             m_sys_format = pix_format_bgr24;
@@ -262,35 +262,35 @@ namespace agg24
             dib.put_image(dc, m_bimage, draw_x, draw_y, draw_width, draw_height);
             return;
         }
-        
+
         // Optimization hint: make pmap_tmp as a private class member and reused it when possible.
         pixel_map pmap_tmp(rbuf->width(), rbuf->height(), m_sys_format, 256, m_flip_y);
         rendering_buffer* rbuf2 = &pmap_tmp.rbuf();
-        
+
         switch(m_format)
         {
         case pix_format_rgb565:
             color_conv(rbuf2, rbuf, color_conv_rgb565_to_rgb555());
             break;
-            
+
         case pix_format_rgb24:
             color_conv(rbuf2, rbuf, color_conv_rgb24_to_bgr24());
             break;
-            
+
         case pix_format_abgr32:
             color_conv(rbuf2, rbuf, color_conv_abgr32_to_bgra32());
             break;
-            
+
         case pix_format_argb32:
             color_conv(rbuf2, rbuf, color_conv_argb32_to_bgra32());
             break;
-            
+
         case pix_format_rgba32:
             color_conv(rbuf2, rbuf, color_conv_rgba32_to_bgra32());
             break;
-            
+
         case pix_format_gray8:
-        case end_of_pix_formats: 
+        case end_of_pix_formats:
         case pix_format_undefined:
             ;
         }
@@ -298,29 +298,29 @@ namespace agg24
         // This will ultimately call back to us, going to the top if branch since
         // the pix_format is compatible.
         pmap_tmp.draw(dc, draw_x, draw_y, draw_width, draw_height);
-        
+
     }
-    
+
     //------------------------------------------------------------------------
     unsigned platform_specific::calc_row_len(unsigned width, unsigned bits_per_pixel)
     {
         unsigned n = width;
-        unsigned k; 
+        unsigned k;
         switch(bits_per_pixel)
         {
         case  1: k = n;
             n = n >> 3;
-            if(k & 7) n++; 
+            if(k & 7) n++;
             break;
         case  4: k = n;
             n = n >> 1;
-            if(k & 3) n++; 
+            if(k & 3) n++;
             break;
         case  8:
             break;
         case 16: n = n << 1;
             break;
-        case 24: n = (n << 1) + n; 
+        case 24: n = (n << 1) + n;
             break;
         case 32: n = n << 2;
             break;

--- a/kiva/agg/src/win32/agg_platform_specific.h
+++ b/kiva/agg/src/win32/agg_platform_specific.h
@@ -1,5 +1,5 @@
 // -*- c++ -*-
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -17,10 +17,10 @@
 
 namespace agg24
 {
- 
+
     enum pix_format_e
     {
-        pix_format_undefined = 0,  // By default. No conversions are applied 
+        pix_format_undefined = 0,  // By default. No conversions are applied
             pix_format_gray8,          // Simple 256 level grayscale
             pix_format_rgb555,         // 15 bit rgb. Depends on the byte ordering!
             pix_format_rgb565,         // 16 bit rgb. Depends on the byte ordering!
@@ -30,17 +30,17 @@ namespace agg24
             pix_format_argb32,         // A-R-G-B, native MAC format
             pix_format_abgr32,         // A-B-G-R, one byte per color component
             pix_format_bgra32,         // B-G-R-A, native win32 BMP format
-            
+
             end_of_pix_formats
     };
-    
+
     typedef struct {
         BITMAPINFO* bmp;
         unsigned char* data;
     } BImage;
-    
+
     class dib_display {
-        
+
         public:
             dib_display();
             ~dib_display();
@@ -48,20 +48,20 @@ namespace agg24
             		       int draw_width=-1, int draw_height=-1);
             BImage* create_image(const rendering_buffer* rbuf, unsigned bits_per_pixel);
             void destroy_image(BImage* image);
-        
+
         private:
             static unsigned calc_header_size(BITMAPINFO *bmp);
             static unsigned calc_palette_size(BITMAPINFO *bmp);
             static unsigned calc_palette_size(unsigned  clr_used, unsigned bits_per_pixel);
     };
-    
+
 
 
     class platform_specific
     {
-        
+
         static dib_display dib;
-        
+
         public:
             platform_specific(pix_format_e format, bool flip_y);
             ~platform_specific() {}
@@ -69,19 +69,19 @@ namespace agg24
             		          int draw_x=-1, int draw_y=-1,
             		          int draw_width=-1, int draw_height=-1);
             void destroy();
-        
+
             static unsigned calc_row_len(unsigned width, unsigned bits_per_pixel);
-        
-        
+
+
             unsigned             m_bpp;
             bool                 m_flip_y;
             BImage*              m_bimage;
             pix_format_e  m_format;
-        
+
         private:
             pix_format_e  m_sys_format;
             unsigned      m_sys_bpp;
-        
+
     };
 
 }

--- a/kiva/agg/src/win32/plat_support.i
+++ b/kiva/agg/src/win32/plat_support.i
@@ -1,5 +1,5 @@
 // -*- c++ -*-
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -57,7 +57,7 @@ namespace agg24
 
 %apply HDC { HWND };
 
-// More permissive unsigned typemap that converts any numeric type to an 
+// More permissive unsigned typemap that converts any numeric type to an
 // unsigned value.  It is cleared at the end of this file.
 %typemap(in) unsigned
 {
@@ -65,13 +65,13 @@ namespace agg24
     if (PyErr_Occurred()) SWIG_fail;
     $1 = (unsigned) PyLong_AsLong(obj);
     if (PyErr_Occurred()) SWIG_fail;
-}   
+}
 
 namespace agg24
 {
     enum pix_format_e
     {
-        pix_format_undefined = 0,  // By default. No conversions are applied 
+        pix_format_undefined = 0,  // By default. No conversions are applied
         pix_format_gray8,          // Simple 256 level grayscale
         pix_format_rgb555,         // 15 bit rgb. Depends on the byte ordering!
         pix_format_rgb565,         // 16 bit rgb. Depends on the byte ordering!
@@ -81,25 +81,25 @@ namespace agg24
         pix_format_argb32,         // A-R-G-B, native MAC format
         pix_format_abgr32,         // A-B-G-R, one byte per color component
         pix_format_bgra32,         // B-G-R-A, native win32 BMP format
-  
+
         end_of_pix_formats
     };
 
     %rename(PixelMap) pixel_map;
-    
+
     class pixel_map
     {
     public:
         ~pixel_map();
-        pixel_map(unsigned width, unsigned height, 
+        pixel_map(unsigned width, unsigned height,
                   pix_format_e format,
                   unsigned clear_val, bool bottom_up);
-                  
+
     public:
        %feature("shadow") draw(HDC h_dc, int x, int y, double scale) const
        %{
        def draw(self, h_dc, x=0, y=0, width=0, height=0):
-           # fix me: brittle becuase we are hard coding 
+           # fix me: brittle becuase we are hard coding
            # module and class name.  Done cause SWIG 1.3.24 does
            # some funky overloading stuff in it that breaks keyword
            # arguments.
@@ -131,7 +131,7 @@ PyObject* pixel_map_as_unowned_array(pixel_map& pix_map);
 }
 
 HDC GetDC(HWND hWnd);
-int ReleaseDC(HWND hWnd, HDC hDC);    
+int ReleaseDC(HWND hWnd, HDC hDC);
 
 // clear the "permissive" unsigned typemap we are using.
 %typemap(in) unsigned;

--- a/kiva/agg/src/x11/agg_bmp.cpp
+++ b/kiva/agg/src/x11/agg_bmp.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/x11/agg_bmp.h
+++ b/kiva/agg/src/x11/agg_bmp.h
@@ -1,5 +1,5 @@
 // -*- c++ -*-
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/src/x11/agg_platform_specific.cpp
+++ b/kiva/agg/src/x11/agg_platform_specific.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -132,16 +132,16 @@ namespace agg24
 
   XImage* x11_display::create_image(const rendering_buffer* rbuf) {
     DEBUG_MTH("x11_display::create_image");
-    unsigned width = rbuf->width(); 
-    unsigned height = rbuf->height(); 
-    return XCreateImage(m_display, 
-			m_visual, //CopyFromParent, 
-			m_depth, 
-			ZPixmap, 
+    unsigned width = rbuf->width();
+    unsigned height = rbuf->height();
+    return XCreateImage(m_display,
+			m_visual, //CopyFromParent,
+			m_depth,
+			ZPixmap,
 			0,
-			(char*)(rbuf->buf()), 
+			(char*)(rbuf->buf()),
 			width,
-			height, 
+			height,
 			m_sys_bpp,
 			width * (m_sys_bpp / 8));
   }
@@ -203,7 +203,7 @@ namespace agg24
       case pix_format_gray8:
 	m_bpp = 8;
 	break;
-	
+
       case pix_format_rgb565:
       case pix_format_rgb555:
 	m_bpp = 16;
@@ -260,15 +260,15 @@ namespace agg24
 		  m_sys_format = pix_format_rgba32;
 		  m_byte_order = LSBFirst;
 		  break;
-		  
+
 		case pix_format_abgr32:
 		  m_sys_format = pix_format_abgr32;
 		  m_byte_order = MSBFirst;
 		  break;
-		  
-		default:                            
+
+		default:
 		  m_byte_order = hw_byte_order;
-		  m_sys_format = 
+		  m_sys_format =
 		    (hw_byte_order == LSBFirst) ?
 		    pix_format_rgba32 :
 		    pix_format_abgr32;
@@ -283,15 +283,15 @@ namespace agg24
 		  m_sys_format = pix_format_argb32;
 		  m_byte_order = MSBFirst;
 		  break;
-		  
+
 		case pix_format_bgra32:
 		  m_sys_format = pix_format_bgra32;
 		  m_byte_order = LSBFirst;
 		  break;
-		  
-		default:                            
+
+		default:
 		  m_byte_order = hw_byte_order;
-		  m_sys_format = 
+		  m_sys_format =
 		    (hw_byte_order == MSBFirst) ?
 		    pix_format_argb32 :
 		    pix_format_bgra32;
@@ -359,7 +359,7 @@ namespace agg24
 	    UNHANDLED_PIX_FORMATS;
 	  }
 	break;
-                    
+
       case pix_format_rgb565:
 	switch(m_format)
 	  {
@@ -374,7 +374,7 @@ namespace agg24
 	    UNHANDLED_PIX_FORMATS;
 	  }
 	break;
-	
+
       case pix_format_rgba32:
 	switch(m_format)
 	  {
@@ -389,7 +389,7 @@ namespace agg24
 	    UNHANDLED_PIX_FORMATS;
 	  }
 	break;
-	
+
       case pix_format_abgr32:
 	switch(m_format)
 	  {
@@ -404,7 +404,7 @@ namespace agg24
 	    UNHANDLED_PIX_FORMATS;
 	  }
 	break;
-	
+
       case pix_format_argb32:
 	switch(m_format)
 	  {
@@ -419,7 +419,7 @@ namespace agg24
 	    UNHANDLED_PIX_FORMATS;
 	  }
 	break;
-	
+
       case pix_format_bgra32:
 	switch(m_format)
 	  {

--- a/kiva/agg/src/x11/agg_platform_specific.h
+++ b/kiva/agg/src/x11/agg_platform_specific.h
@@ -1,5 +1,5 @@
 // -*- c++ -*-
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -20,7 +20,7 @@ namespace agg24
 
   enum pix_format_e
     {
-      pix_format_undefined = 0,  // By default. No conversions are applied 
+      pix_format_undefined = 0,  // By default. No conversions are applied
       pix_format_gray8,          // Simple 256 level grayscale
       pix_format_rgb555,         // 15 bit rgb. Depends on the byte ordering!
       pix_format_rgb565,         // 16 bit rgb. Depends on the byte ordering!
@@ -30,7 +30,7 @@ namespace agg24
       pix_format_argb32,         // A-R-G-B, native MAC format
       pix_format_abgr32,         // A-B-G-R, one byte per color component
       pix_format_bgra32,         // B-G-R-A, native win32 BMP format
-      
+
       end_of_pix_formats
     };
 
@@ -46,7 +46,7 @@ namespace agg24
     void destroy_image(XImage* ximg);
 
   public:
-    Display*             m_display;    
+    Display*             m_display;
     int                  m_screen;
     int                  m_depth;
     Visual*              m_visual;
@@ -60,7 +60,7 @@ namespace agg24
   //------------------------------------------------------------------------
   class platform_specific
   {
-    
+
     static x11_display x11;
 
   public:
@@ -84,7 +84,7 @@ namespace agg24
     int                  m_byte_order;  // init()
     unsigned             m_sys_bpp;     // init()
     pix_format_e         m_sys_format;  // init()
-    
+
   };
 
 }

--- a/kiva/agg/src/x11/plat_support.i
+++ b/kiva/agg/src/x11/plat_support.i
@@ -1,5 +1,5 @@
 // -*- c++ -*-
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -24,11 +24,11 @@ namespace agg24
         npy_intp rows = pix_map.height();
         npy_intp cols = pix_map.width();
         npy_intp depth = pix_map.bpp() / 8;
-    
+
         dims[0] = rows;
         dims[1] = cols;
         dims[2] = depth;
-        
+
         return PyArray_SimpleNewFromData(3,dims,NPY_UINT8,(void*)pix_map.buf());
     }
 
@@ -41,7 +41,7 @@ namespace agg24
     $1 = (Window) PyInt_AsLong($input);
 }
 
-// More permissive unsigned typemap that converts any numeric type to an 
+// More permissive unsigned typemap that converts any numeric type to an
 // unsigned value.  It is cleared at the end of this file.
 %typemap(in) unsigned
 {
@@ -49,13 +49,13 @@ namespace agg24
     if (PyErr_Occurred()) SWIG_fail;
     $1 = (unsigned) PyLong_AsLong(obj);
     if (PyErr_Occurred()) SWIG_fail;
-}   
+}
 
 namespace agg24
 {
     enum pix_format_e
     {
-        pix_format_undefined = 0,  // By default. No conversions are applied 
+        pix_format_undefined = 0,  // By default. No conversions are applied
         pix_format_gray8,          // Simple 256 level grayscale
         pix_format_rgb555,         // 15 bit rgb. Depends on the byte ordering!
         pix_format_rgb565,         // 16 bit rgb. Depends on the byte ordering!
@@ -65,7 +65,7 @@ namespace agg24
         pix_format_argb32,         // A-R-G-B, native MAC format
         pix_format_abgr32,         // A-B-G-R, one byte per color component
         pix_format_bgra32,         // B-G-R-A, native win32 BMP format
-  
+
         end_of_pix_formats
     };
 
@@ -81,7 +81,7 @@ namespace agg24
        %feature("shadow") draw(Window h_dc, int x, int y, double scale) const
        %{
        def draw(self, h_dc, x=0, y=0, scale=1.0):
-           # fix me: brittle becuase we are hard coding 
+           # fix me: brittle becuase we are hard coding
            # module and class name.  Done cause SWIG 1.3.24 does
            # some funky overloading stuff in it that breaks keyword
            # arguments.

--- a/kiva/agg/tests/test_affine_matrix.py
+++ b/kiva/agg/tests/test_affine_matrix.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/tests/test_clip_to_rect.py
+++ b/kiva/agg/tests/test_clip_to_rect.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/tests/test_compiled_path.py
+++ b/kiva/agg/tests/test_compiled_path.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/tests/test_font_loading.py
+++ b/kiva/agg/tests/test_font_loading.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/tests/test_graphics_context.py
+++ b/kiva/agg/tests/test_graphics_context.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/tests/test_graphics_context_system.py
+++ b/kiva/agg/tests/test_graphics_context_system.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/tests/test_join_stroke_path.py
+++ b/kiva/agg/tests/test_join_stroke_path.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/tests/test_rgba.py
+++ b/kiva/agg/tests/test_rgba.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/tests/test_save.py
+++ b/kiva/agg/tests/test_save.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/tests/test_stroke_path.py
+++ b/kiva/agg/tests/test_stroke_path.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/tests/test_unicode_font.py
+++ b/kiva/agg/tests/test_unicode_font.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/agg/tests/test_utils.py
+++ b/kiva/agg/tests/test_utils.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/api.py
+++ b/kiva/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/arc_conversion.py
+++ b/kiva/arc_conversion.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/basecore2d.py
+++ b/kiva/basecore2d.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/blend2d.py
+++ b/kiva/blend2d.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/cairo.py
+++ b/kiva/cairo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/celiagg.py
+++ b/kiva/celiagg.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/constants.py
+++ b/kiva/constants.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/benchmark.py
+++ b/kiva/examples/kiva/agg/benchmark.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/compiled_path.py
+++ b/kiva/examples/kiva/agg/compiled_path.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/conv.py
+++ b/kiva/examples/kiva/agg/conv.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/dash.py
+++ b/kiva/examples/kiva/agg/dash.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/lion.py
+++ b/kiva/examples/kiva/agg/lion.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/polygon_hit_test.py
+++ b/kiva/examples/kiva/agg/polygon_hit_test.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/rect.py
+++ b/kiva/examples/kiva/agg/rect.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/simple.py
+++ b/kiva/examples/kiva/agg/simple.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/simple2.py
+++ b/kiva/examples/kiva/agg/simple2.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/simple_clip.py
+++ b/kiva/examples/kiva/agg/simple_clip.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/star.py
+++ b/kiva/examples/kiva/agg/star.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/star1.py
+++ b/kiva/examples/kiva/agg/star1.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/star2.py
+++ b/kiva/examples/kiva/agg/star2.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/star_path.py
+++ b/kiva/examples/kiva/agg/star_path.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/sub_path.py
+++ b/kiva/examples/kiva/agg/sub_path.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/agg/text_ex.py
+++ b/kiva/examples/kiva/agg/text_ex.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/compiled_path.py
+++ b/kiva/examples/kiva/compiled_path.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/dash.py
+++ b/kiva/examples/kiva/dash.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/dummy.py
+++ b/kiva/examples/kiva/dummy.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/ellipse.py
+++ b/kiva/examples/kiva/ellipse.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/gradient.py
+++ b/kiva/examples/kiva/gradient.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/image_explorer.py
+++ b/kiva/examples/kiva/image_explorer.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/kiva_explorer.py
+++ b/kiva/examples/kiva/kiva_explorer.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/pdf_arcs.py
+++ b/kiva/examples/kiva/pdf_arcs.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/pyglet_gl.py
+++ b/kiva/examples/kiva/pyglet_gl.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/qt4_simple.py
+++ b/kiva/examples/kiva/qt4_simple.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/rect.py
+++ b/kiva/examples/kiva/rect.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/simple.py
+++ b/kiva/examples/kiva/simple.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/simple2.py
+++ b/kiva/examples/kiva/simple2.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/simple_clip.py
+++ b/kiva/examples/kiva/simple_clip.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/star.py
+++ b/kiva/examples/kiva/star.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/star1.py
+++ b/kiva/examples/kiva/star1.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/star_path.py
+++ b/kiva/examples/kiva/star_path.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/sub_path.py
+++ b/kiva/examples/kiva/sub_path.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/ui_gradient.py
+++ b/kiva/examples/kiva/ui_gradient.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/kiva/ui_text.py
+++ b/kiva/examples/kiva/ui_text.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/examples/tests/test_etsdemo_info.py
+++ b/kiva/examples/tests/test_etsdemo_info.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/__init__.py
+++ b/kiva/fonttools/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/_constants.py
+++ b/kiva/fonttools/_constants.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/_database.py
+++ b/kiva/fonttools/_database.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/_query.py
+++ b/kiva/fonttools/_query.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/_scan_parse.py
+++ b/kiva/fonttools/_scan_parse.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/_scan_sys.py
+++ b/kiva/fonttools/_scan_sys.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/_score.py
+++ b/kiva/fonttools/_score.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/_util.py
+++ b/kiva/fonttools/_util.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/app_font.py
+++ b/kiva/fonttools/app_font.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/font.py
+++ b/kiva/fonttools/font.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/font_manager.py
+++ b/kiva/fonttools/font_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/tests/_testing.py
+++ b/kiva/fonttools/tests/_testing.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/tests/test_app_font.py
+++ b/kiva/fonttools/tests/test_app_font.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/tests/test_font.py
+++ b/kiva/fonttools/tests/test_font.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/tests/test_font_manager.py
+++ b/kiva/fonttools/tests/test_font_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/tests/test_font_query.py
+++ b/kiva/fonttools/tests/test_font_query.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/tests/test_scan_parse.py
+++ b/kiva/fonttools/tests/test_scan_parse.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/tests/test_scan_sys.py
+++ b/kiva/fonttools/tests/test_scan_sys.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/tests/test_score.py
+++ b/kiva/fonttools/tests/test_score.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/text/_language.py
+++ b/kiva/fonttools/text/_language.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/text/_parse_scripts.py
+++ b/kiva/fonttools/text/_parse_scripts.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/text/_unicode_lookup.py
+++ b/kiva/fonttools/text/_unicode_lookup.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/fonttools/text/tests/test_unicode_lookup.py
+++ b/kiva/fonttools/text/tests/test_unicode_lookup.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/__init__.py
+++ b/kiva/gl/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/gl.i
+++ b/kiva/gl/gl.i
@@ -1,5 +1,5 @@
 /* -*- c++ -*- */
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/kiva_gl_affine_helpers.cpp
+++ b/kiva/gl/src/kiva_gl_affine_helpers.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/kiva_gl_affine_helpers.h
+++ b/kiva/gl/src/kiva_gl_affine_helpers.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/kiva_gl_basics.h
+++ b/kiva/gl/src/kiva_gl_basics.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/kiva_gl_compiled_path.cpp
+++ b/kiva/gl/src/kiva_gl_compiled_path.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/kiva_gl_compiled_path.h
+++ b/kiva/gl/src/kiva_gl_compiled_path.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/kiva_gl_constants.h
+++ b/kiva/gl/src/kiva_gl_constants.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -144,7 +144,7 @@ namespace kiva_gl
         marker_dash,
         marker_dot,
         marker_pixel,
-        
+
         end_of_markers
     };
 

--- a/kiva/gl/src/kiva_gl_dash_type.h
+++ b/kiva/gl/src/kiva_gl_dash_type.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/kiva_gl_exceptions.h
+++ b/kiva/gl/src/kiva_gl_exceptions.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/kiva_gl_font_type.cpp
+++ b/kiva/gl/src/kiva_gl_font_type.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -35,7 +35,7 @@
         "/usr/share/fonts/truetype/",
         "/usr/share/fonts/msttcorefonts/",
         "/var/lib/defoma/x-ttcidfont-conf.d/dirs/TrueType/",
-        "/usr/share/fonts/truetype/msttcorefonts/", 
+        "/usr/share/fonts/truetype/msttcorefonts/",
 };
 #endif
 

--- a/kiva/gl/src/kiva_gl_font_type.h
+++ b/kiva/gl/src/kiva_gl_font_type.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/kiva_gl_graphics_context.cpp
+++ b/kiva/gl/src/kiva_gl_graphics_context.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/kiva_gl_graphics_context.h
+++ b/kiva/gl/src/kiva_gl_graphics_context.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/kiva_gl_graphics_context_base.cpp
+++ b/kiva/gl/src/kiva_gl_graphics_context_base.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/kiva_gl_graphics_context_base.h
+++ b/kiva/gl/src/kiva_gl_graphics_context_base.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/kiva_gl_graphics_state.h
+++ b/kiva/gl/src/kiva_gl_graphics_state.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/kiva_gl_rect.cpp
+++ b/kiva/gl/src/kiva_gl_rect.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -69,7 +69,7 @@ namespace kiva_gl
                 result_list.push_back(result_rect);
             }
         }
-        
+
         return result_list;
     }
 
@@ -97,7 +97,7 @@ namespace kiva_gl
             rlist = disjoint_union(rlist, rects[i]);
         }
         return rlist;
-        
+
     }
 
     rect_list_type
@@ -114,7 +114,7 @@ namespace kiva_gl
         rect_list_type additional_rects;
         rect_list_type todo;
         todo.push_back(new_rect);
-        
+
         // Iterate over each item in the todo list:
         unsigned int todo_count = 0;
         bool use_leftover = true;
@@ -155,7 +155,7 @@ namespace kiva_gl
                     use_leftover = false;
                     break;
                 }
-        
+
                 // Test for existing rect being wholly contained in new rect
                 bool x2inx1 = ((xl2 >= xl1) && (xr2 <= xr1));
                 bool y2iny1 = ((yb2 >= yb1) && (yt2 <= yt1));
@@ -225,7 +225,7 @@ namespace kiva_gl
                     orig_count++;
                     continue;
                 }
-                
+
                 // Test for rect 2 being within rect 1 along the y-axis:
                 if (y2iny1)
                 {
@@ -259,7 +259,7 @@ namespace kiva_gl
                     xl = xr2;
                     xr = xr1;
                 }
-                
+
                 if (yb1 < yb2)
                 {
                     yb = yb2;
@@ -274,7 +274,7 @@ namespace kiva_gl
                 }
 
                 todo.push_back(rect_type(xl, yb, xr-xl, yt-yb));
-                
+
                 orig_count++;
             }
 

--- a/kiva/gl/src/kiva_gl_rect.h
+++ b/kiva/gl/src/kiva_gl_rect.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/swig/affine_matrix.i
+++ b/kiva/gl/src/swig/affine_matrix.i
@@ -1,5 +1,5 @@
 /* -*- c -*- */
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/swig/agg_std_string.i
+++ b/kiva/gl/src/swig/agg_std_string.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/swig/agg_typemaps.i
+++ b/kiva/gl/src/swig/agg_typemaps.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/swig/compiled_path.i
+++ b/kiva/gl/src/swig/compiled_path.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/swig/constants.i
+++ b/kiva/gl/src/swig/constants.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/swig/font_type.i
+++ b/kiva/gl/src/swig/font_type.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/swig/graphics_context.i
+++ b/kiva/gl/src/swig/graphics_context.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/swig/numpy.i
+++ b/kiva/gl/src/swig/numpy.i
@@ -1,5 +1,5 @@
 /* -*- c -*- */
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/swig/rect.i
+++ b/kiva/gl/src/swig/rect.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/swig/rgba.i
+++ b/kiva/gl/src/swig/rgba.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/swig/rgba_array.i
+++ b/kiva/gl/src/swig/rgba_array.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/gl/src/swig/sequence_to_array.i
+++ b/kiva/gl/src/swig/sequence_to_array.i
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/graphics_state.py
+++ b/kiva/graphics_state.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/image.py
+++ b/kiva/image.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/line_state.py
+++ b/kiva/line_state.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/marker_renderer.py
+++ b/kiva/marker_renderer.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/markers/marker_renderer.h
+++ b/kiva/markers/marker_renderer.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/oldagg.py
+++ b/kiva/oldagg.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/pdf.py
+++ b/kiva/pdf.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/pdfmetrics.py
+++ b/kiva/pdfmetrics.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/ps.py
+++ b/kiva/ps.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/qpainter.py
+++ b/kiva/qpainter.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/quartz/ABCGI.pyx
+++ b/kiva/quartz/ABCGI.pyx
@@ -1,4 +1,4 @@
-# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/quartz/CTFont.pyx
+++ b/kiva/quartz/CTFont.pyx
@@ -1,4 +1,4 @@
-# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -75,7 +75,7 @@ cdef class CTFontStyle:
     cdef CFDictionaryRef attribute_dictionary
     cdef readonly object family_name
     cdef readonly object style
-    
+
     def __cinit__(self, *args, **kwargs):
         self.ct_font_descriptor = NULL
         self.attribute_dictionary = NULL
@@ -110,7 +110,7 @@ cdef class CTFontStyle:
         """ Get a CTFont matching the descriptor at the given size.
         """
         cdef CTFontRef ct_font
-        
+
         ct_font = CTFontCreateWithFontDescriptor(self.ct_font_descriptor,
                     font_size, NULL)
         font = CTFont()

--- a/kiva/quartz/CoreFoundation.pxi
+++ b/kiva/quartz/CoreFoundation.pxi
@@ -1,4 +1,4 @@
-# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -65,19 +65,19 @@ cdef extern from "CoreFoundation/CoreFoundation.h":
         CFStringRef filePath, CFURLPathStyle pathStyle, bool isDirectory)
     void CFShow(CFTypeRef cf)
     CFTypeID CFGetTypeID(CFTypeRef cf)
-    
+
     ctypedef struct CFArrayCallBacks:
         CFIndex version
         #CFArrayRetainCallBack retain
         #CFArrayReleaseCallBack release
         #CFArrayCopyDescriptionCallBack copyDescription
         #CFArrayEqualCallBack equal
-    
+
     cdef CFArrayCallBacks kCFTypeArrayCallBacks
     #ctypedef void (*CFArrayApplierFunction)(void *value, void *context)
     ctypedef CFTypeRef CFArrayRef
     ctypedef CFTypeRef CFMutableArrayRef
-    
+
     CFArrayRef CFArrayCreate(void* allocator, void **values,
         CFIndex numValues, CFArrayCallBacks *callBacks)
     CFArrayRef CFArrayCreateCopy(void* allocator, CFArrayRef theArray)
@@ -127,7 +127,7 @@ cdef extern from "CoreFoundation/CoreFoundation.h":
         #CFDictionaryCopyDescriptionCallBack copyDescription
         #CFDictionaryEqualCallBack equal
         #CFDictionaryHashCallBack hash
-    
+
     ctypedef struct CFDictionaryValueCallBacks:
         CFIndex version
         #CFDictionaryRetainCallBack retain
@@ -141,7 +141,7 @@ cdef extern from "CoreFoundation/CoreFoundation.h":
     CFDictionaryRef CFDictionaryCreate(void* allocator,
         void** keys, void** values, CFIndex numValues,
         CFDictionaryKeyCallBacks* keyCallBacks,
-        CFDictionaryValueCallBacks* valueCallBacks)    
+        CFDictionaryValueCallBacks* valueCallBacks)
     CFMutableDictionaryRef CFDictionaryCreateMutable(void* allocator,
         CFIndex capacity, CFDictionaryKeyCallBacks *keyCallBacks,
         CFDictionaryValueCallBacks *valueCallBacks)
@@ -161,7 +161,7 @@ cdef extern from "CoreFoundation/CoreFoundation.h":
         CFRange range, CFStringRef attrName, CFTypeRef value)
 
     ctypedef CFTypeRef CFNumberRef
-    
+
     ctypedef enum CFNumberType_:
         kCFNumberSInt8Type = 1
         kCFNumberSInt16Type = 2

--- a/kiva/quartz/CoreGraphics.pxi
+++ b/kiva/quartz/CoreGraphics.pxi
@@ -1,4 +1,4 @@
-# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/quartz/CoreText.pxi
+++ b/kiva/quartz/CoreText.pxi
@@ -1,4 +1,4 @@
-# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -27,7 +27,7 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     cdef CFStringRef kCTUnderlineStyleAttributeName
     cdef CFStringRef kCTVerticalFormsAttributeName
     cdef CFStringRef kCTGlyphInfoAttributeName
-    
+
     ctypedef enum CTUnderlineStyle:
         kCTUnderlineStyleNone   = 0x00
         kCTUnderlineStyleSingle = 0x01
@@ -89,7 +89,7 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     cdef CFStringRef kCTFontFeatureSettingsAttribute
     cdef CFStringRef kCTFontFixedAdvanceAttribute
     cdef CFStringRef kCTFontOrientationAttribute
-    
+
     ctypedef enum CTFontOrientation:
         kCTFontDefaultOrientation       = 0
         kCTFontHorizontalOrientation    = 1
@@ -231,13 +231,13 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
         void *matrix)
     CTFontRef CTFontCreateWithFontDescriptor(CTFontDescriptorRef descriptor,
         CGFloat size, void *matrix)
-    
+
     #CTFontRef CTFontCreateUIFontForLanguage(CTFontUIFontType uiType,
     #    CGFloat size, CFStringRef language)
     #CTFontRef CTFontCreateCopyWithAttributes(CTFontRef font, CGFloat size,
     #    void *matrix, CTFontDescriptorRef attributes)
     CTFontRef CTFontCreateCopyWithSymbolicTraits(CTFontRef font, CGFloat size,
-        void *matrix, CTFontSymbolicTraits symTraitValue, 
+        void *matrix, CTFontSymbolicTraits symTraitValue,
         CTFontSymbolicTraits symTraitMask)
     #CTFontRef CTFontCreateCopyWithFamily(CTFontRef font, CGFloat size,
     #    void *matrix, CFStringRef family)
@@ -282,10 +282,10 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
         CGGlyph glyphs[], CGSize translations[], CFIndex count)
     CGPathRef CTFontCreatePathForGlyph(CTFontRef font, CGGlyph glyph,
         void * transform)
-    
+
     CFArrayRef CTFontCopyVariationAxes(CTFontRef font)
     CFDictionaryRef CTFontCopyVariation(CTFontRef font)
-    
+
     CFArrayRef CTFontCopyFeatures(CTFontRef font)
     CFArrayRef CTFontCopyFeatureSettings(CTFontRef font)
     CGFontRef CTFontCopyGraphicsFont(CTFontRef font, CTFontDescriptorRef *attributes)
@@ -296,7 +296,7 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
     #    void *matrix, CTFontDescriptorRef attributes)
     #CTFontRef CTFontCreateWithQuickdrawInstance(ConstStr255Param name,
     #    int16_t identifier, uint8_t style, CGFloat size)
-    
+
     #CFArrayRef CTFontCopyAvailableTables(CTFontRef font,
     #    CTFontTableOptions options)
     #CFDataRef CTFontCopyTable(CTFontRef font, CTFontTableTag table,
@@ -322,7 +322,7 @@ cdef extern from "ApplicationServices/ApplicationServices.h":
         CFDictionaryRef attributes)
     CTFontDescriptorRef CTFontDescriptorCreateCopyWithAttributes(
         CTFontDescriptorRef original, CFDictionaryRef attributes)
-    
+
     #CTFontDescriptorRef CTFontDescriptorCreateCopyWithVariation(
     #    CTFontDescriptorRef original, CFNumberRef variationIdentifier,
     #    CGFloat variationValue)

--- a/kiva/quartz/Python.pxi
+++ b/kiva/quartz/Python.pxi
@@ -1,4 +1,4 @@
-# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/quartz/__init__.py
+++ b/kiva/quartz/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/quartz/c_numpy.pxd
+++ b/kiva/quartz/c_numpy.pxd
@@ -1,4 +1,4 @@
-# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -15,15 +15,15 @@ cdef extern from "numpy/arrayobject.h":
         NPY_BYTE
         NPY_UBYTE
         NPY_SHORT
-        NPY_USHORT 
+        NPY_USHORT
         NPY_INT
-        NPY_UINT 
+        NPY_UINT
         NPY_LONG
         NPY_ULONG
         NPY_LONGLONG
         NPY_ULONGLONG
         NPY_FLOAT
-        NPY_DOUBLE 
+        NPY_DOUBLE
         NPY_LONGDOUBLE
         NPY_CFLOAT
         NPY_CDOUBLE
@@ -64,7 +64,7 @@ cdef extern from "numpy/arrayobject.h":
         NPY_OUT_FARRAY
         NPY_INOUT_FARRAY
 
-        NPY_UPDATE_ALL 
+        NPY_UPDATE_ALL
 
     cdef enum defines:
         # Note: as of Pyrex 0.9.5, enums are type-checked more strictly, so this
@@ -79,7 +79,7 @@ cdef extern from "numpy/arrayobject.h":
         double real
         double imag
 
-    ctypedef int npy_intp 
+    ctypedef int npy_intp
 
     ctypedef extern class numpy.dtype [object PyArray_Descr]:
         cdef int type_num, elsize, alignment
@@ -100,7 +100,7 @@ cdef extern from "numpy/arrayobject.h":
         cdef npy_intp index, size
         cdef ndarray ao
         cdef char *dataptr
-        
+
     ctypedef extern class numpy.broadcast [object PyArrayMultiIterObject]:
         cdef int numiter
         cdef npy_intp size, index
@@ -115,7 +115,7 @@ cdef extern from "numpy/arrayobject.h":
     dtype PyArray_DescrFromTypeNum(NPY_TYPES type_num)
     object PyArray_SimpleNew(int ndims, npy_intp* dims, NPY_TYPES type_num)
     int PyArray_Check(object obj)
-    object PyArray_ContiguousFromAny(object obj, NPY_TYPES type, 
+    object PyArray_ContiguousFromAny(object obj, NPY_TYPES type,
         int mindim, int maxdim)
     npy_intp PyArray_SIZE(ndarray arr)
     npy_intp PyArray_NBYTES(ndarray arr)

--- a/kiva/quartz/mac_context.c
+++ b/kiva/quartz/mac_context.c
@@ -1,4 +1,4 @@
-// (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/quartz/mac_context.h
+++ b/kiva/quartz/mac_context.h
@@ -1,4 +1,4 @@
-// (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/quartz/mac_context_cocoa.m
+++ b/kiva/quartz/mac_context_cocoa.m
@@ -1,4 +1,4 @@
-// (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD

--- a/kiva/quartz/macport26.cpp
+++ b/kiva/quartz/macport26.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -17,12 +17,12 @@ extern "C"
     void initmacport(void);
 }
 
-/* This converts a string of hex digits into an unsigned long.  It reads 
+/* This converts a string of hex digits into an unsigned long.  It reads
    This code is a modified version of SWIG_UnpackData from weave/swigptr2.py,
    and which I believe originated from the SWIG sources. */
 unsigned long hexstr_to_long(const char *c, char bytesize = 4) {
     unsigned long retval = 0;
-    
+
     unsigned char *u = reinterpret_cast<unsigned char*>(&retval);
     const unsigned char *eu =  u + bytesize;
     for (; u != eu; ++u) {
@@ -32,14 +32,14 @@ unsigned long hexstr_to_long(const char *c, char bytesize = 4) {
             uu = ((d - '0') << 4);
         else if ((d >= 'a') && (d <= 'f'))
             uu = ((d - ('a'-10)) << 4);
-        else 
+        else
             return 0;
         d = *(c++);
         if ((d >= '0') && (d <= '9'))
             uu |= (d - '0');
         else if ((d >= 'a') && (d <= 'f'))
             uu |= (d - ('a'-10));
-        else 
+        else
             return 0;
         *u = uu;
     }
@@ -49,15 +49,15 @@ unsigned long hexstr_to_long(const char *c, char bytesize = 4) {
 PyObject* get_macport(PyObject *self, PyObject *args)
 {
     const char err_string[] = "get_macport() requires a SWIG 'this' string.";
-    
+
     // the string representing the address embedded in the SWIG this ptr
     char *dc_addr_str = NULL;
     int length = 0;
     int err = 0;
     wxDC *p_dc = NULL;
-    
-    
-    
+
+
+
     err = PyArg_ParseTuple(args, "s#", &dc_addr_str, &length);
     if (err != 1)
     {

--- a/kiva/quartz/macport28.cpp
+++ b/kiva/quartz/macport28.cpp
@@ -1,4 +1,4 @@
-// (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+// (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 // All rights reserved.
 //
 // This software is provided without warranty under the terms of the BSD
@@ -17,12 +17,12 @@ extern "C"
     void initmacport(void);
 }
 
-/* This converts a string of hex digits into an unsigned long.  It reads 
+/* This converts a string of hex digits into an unsigned long.  It reads
    This code is a modified version of SWIG_UnpackData from weave/swigptr2.py,
    and which I believe originated from the SWIG sources. */
 unsigned long hexstr_to_long(const char *c, char bytesize = 4) {
     unsigned long retval = 0;
-    
+
     unsigned char *u = reinterpret_cast<unsigned char*>(&retval);
     const unsigned char *eu =  u + bytesize;
     for (; u != eu; ++u) {
@@ -32,14 +32,14 @@ unsigned long hexstr_to_long(const char *c, char bytesize = 4) {
             uu = ((d - '0') << 4);
         else if ((d >= 'a') && (d <= 'f'))
             uu = ((d - ('a'-10)) << 4);
-        else 
+        else
             return 0;
         d = *(c++);
         if ((d >= '0') && (d <= '9'))
             uu |= (d - '0');
         else if ((d >= 'a') && (d <= 'f'))
             uu |= (d - ('a'-10));
-        else 
+        else
             return 0;
         *u = uu;
     }
@@ -49,7 +49,7 @@ unsigned long hexstr_to_long(const char *c, char bytesize = 4) {
 PyObject* get_macport(PyObject *self, PyObject *args)
 {
     const char err_string[] = "get_macport() requires a SWIG 'this' string.";
-    
+
     // the string representing the address embedded in the SWIG this ptr
     char *dc_addr_str = NULL;
     int length = 0;

--- a/kiva/quartz/numpy.pxi
+++ b/kiva/quartz/numpy.pxi
@@ -1,4 +1,4 @@
-# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/svg.py
+++ b/kiva/svg.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/testing.py
+++ b/kiva/testing.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/_testing.py
+++ b/kiva/tests/_testing.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/agg/test_arc.py
+++ b/kiva/tests/agg/test_arc.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/agg/test_image.py
+++ b/kiva/tests/agg/test_image.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/agg/test_text.py
+++ b/kiva/tests/agg/test_text.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/drawing_tester.py
+++ b/kiva/tests/drawing_tester.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/dummy.py
+++ b/kiva/tests/dummy.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_affine.py
+++ b/kiva/tests/test_affine.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_agg_drawing.py
+++ b/kiva/tests/test_agg_drawing.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_basecore2d.py
+++ b/kiva/tests/test_basecore2d.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_cairo_drawing.py
+++ b/kiva/tests/test_cairo_drawing.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_celiagg_drawing.py
+++ b/kiva/tests/test_celiagg_drawing.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_gl_drawing.py
+++ b/kiva/tests/test_gl_drawing.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_graphics_context.py
+++ b/kiva/tests/test_graphics_context.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_kiva_test_assistant.py
+++ b/kiva/tests/test_kiva_test_assistant.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_marker_rendering.py
+++ b/kiva/tests/test_marker_rendering.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_pdf_drawing.py
+++ b/kiva/tests/test_pdf_drawing.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_pdfmetrics.py
+++ b/kiva/tests/test_pdfmetrics.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_points_in_polygon.py
+++ b/kiva/tests/test_points_in_polygon.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_ps_drawing.py
+++ b/kiva/tests/test_ps_drawing.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_qpainter_drawing.py
+++ b/kiva/tests/test_qpainter_drawing.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_quartz.py
+++ b/kiva/tests/test_quartz.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_quartz_drawing.py
+++ b/kiva/tests/test_quartz_drawing.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/tests/test_svg_drawing.py
+++ b/kiva/tests/test_svg_drawing.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/trait_defs/api.py
+++ b/kiva/trait_defs/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/trait_defs/kiva_font_trait.py
+++ b/kiva/trait_defs/kiva_font_trait.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/trait_defs/ui/wx/kiva_font_editor.py
+++ b/kiva/trait_defs/ui/wx/kiva_font_editor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/kiva/trait_defs/ui/wx/tests/test_kiva_font_editor.py
+++ b/kiva/trait_defs/ui/wx/tests/test_kiva_font_editor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2008-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD


### PR DESCRIPTION
This is a simple search-and-replace to update copyright headers to 2022.

Fixes #898 