### PR TITLE
Rename CoordinateBoxTestCase test methods

### DIFF
--- a/enable/tests/test_coordinate_box.py
+++ b/enable/tests/test_coordinate_box.py
@@ -13,14 +13,14 @@ from enable.api import CoordinateBox
 
 
 class CoordinateBoxTestCase(unittest.TestCase):
-    def check_position(self):
+    def test_position(self):
         c = CoordinateBox(bounds=[50.0, 50.0])
         self.assertTrue(c.position[0] == c.x)
         self.assertTrue(c.position[1] == c.y)
         self.assertTrue(c.x == 0.0)
         self.assertTrue(c.y == 0.0)
 
-    def check_bounds(self):
+    def test_bounds(self):
         c = CoordinateBox(bounds=[50.0, 60.0])
         self.assertTrue(c.width == c.bounds[0])
         self.assertTrue(c.height == c.bounds[1])
@@ -29,7 +29,7 @@ class CoordinateBoxTestCase(unittest.TestCase):
         self.assertTrue(c.x2 == 49.0)
         self.assertTrue(c.y2 == 59.0)
 
-    def check_is_in(self):
+    def test_is_in(self):
         c = CoordinateBox(x=10, y=20)
         c.width = 100
         c.height = 100


### PR DESCRIPTION
The test methods in `CoordinateBoxTestCase` were not being executed. This PR renames the test methods so that they're identified as such by unittest.

Closes #936 
