### PR TITLE
Get things working on wxPython again

### DIFF
--- a/kiva/agg/src/x11/plat_support.i
+++ b/kiva/agg/src/x11/plat_support.i
@@ -106,13 +106,11 @@ namespace agg24
             window_dc = wx.PaintDC(window)
         arr = self.convert_to_rgbarray()
         sz = arr.shape[:2]
-        image = wx.EmptyImage(*sz)
+        image = wx.Image(*sz)
         image.SetDataBuffer(arr.data)
-        bmp = wx.BitmapFromImage(image, depth=-1)
+        bmp = wx.Bitmap(image)
 
-        window_dc.BeginDrawing()
         window_dc.DrawBitmap(bmp,x,y)
-        window_dc.EndDrawing()
         return
 
       %}


### PR DESCRIPTION
Addresses these warnings/exceptions:
- TypeError: BitmapFromImage() got an unexpected keyword argument 'depth'
- AttributeError: 'PaintDC' object has no attribute 'BeginDrawing'
- wxPyDeprecationWarning: Call to deprecated item EmptyImage. Use :class:`Image` instead.
    image = wx.EmptyImage(*sz)
- wxPyDeprecationWarning: Call to deprecated item BitmapFromImage. Use :class:`wx.Bitmap` instead
    bmp = wx.BitmapFromImage(image, depth=-1)

See https://forums.wxwidgets.org/viewtopic.php?t=39930 why the Begin/EndDrawing calls can simply be removed.

Related issues: #798 and enthought/chaco#531