### PR TITLE
Fix Kiva Quartz backend string encoding

### DIFF
--- a/kiva/quartz/CTFont.pyx
+++ b/kiva/quartz/CTFont.pyx
@@ -17,14 +17,14 @@ include "CoreText.pxi"
 cdef object _cf_string_to_pystring(CFStringRef cf_string):
     cdef char* c_string
     cdef char buf[256]
-    c_string = CFStringGetCStringPtr(cf_string, kCFStringEncodingMacRoman)
+    c_string = CFStringGetCStringPtr(cf_string, kCFStringEncodingUTF8)
     if c_string == NULL:
         success = CFStringGetCString(cf_string, buf, 256,
-                    kCFStringEncodingMacRoman)
+                    kCFStringEncodingUTF8)
         retval = bytes(buf)
     else:
         retval = bytes(c_string)
-    return retval.decode('mac-roman')
+    return retval.decode('utf-8')
 
 cdef CFArrayRef _get_system_fonts():
         cdef CFIndex value = 1

--- a/kiva/quartz/CTFont.pyx
+++ b/kiva/quartz/CTFont.pyx
@@ -21,10 +21,10 @@ cdef object _cf_string_to_pystring(CFStringRef cf_string):
     if c_string == NULL:
         success = CFStringGetCString(cf_string, buf, 256,
                     kCFStringEncodingMacRoman)
-        retval = str(buf)
+        retval = bytes(buf)
     else:
-        retval = str(c_string)
-    return retval
+        retval = bytes(c_string)
+    return retval.decode('mac-roman')
 
 cdef CFArrayRef _get_system_fonts():
         cdef CFIndex value = 1

--- a/kiva/tests/_testing.py
+++ b/kiva/tests/_testing.py
@@ -12,6 +12,7 @@
 This is not a public module and should not to be used outside of Kiva.
 """
 
+import sys
 import unittest
 
 from traits.etsconfig.api import ETSConfig
@@ -21,5 +22,11 @@ def is_wx():
     """ Return true if the toolkit backend is wx. """
     return ETSConfig.toolkit == "wx"
 
-
 skip_if_not_wx = unittest.skipIf(not is_wx(), "Test only for wx")
+
+
+def is_mac():
+    return sys.platform == 'darwin'
+
+
+skip_unless_mac = unittest.skipUnless(is_mac(), "Test only on Mac OS")

--- a/kiva/tests/test_quartz.py
+++ b/kiva/tests/test_quartz.py
@@ -25,11 +25,6 @@ class TestQuartz(unittest.TestCase):
 
     @skip_if_not_wx
     def test_macport(self):
-        if sys.platform != "darwin":
-            from unittest.case import SkipTest
-
-            raise SkipTest("macport is only built on OS X")
-
         import wx
 
         from kiva.quartz import get_macport

--- a/kiva/tests/test_quartz.py
+++ b/kiva/tests/test_quartz.py
@@ -10,16 +10,12 @@
 import sys
 import unittest
 
-from kiva.tests._testing import skip_if_not_wx
+from kiva.tests._testing import skip_if_not_wx, skip_unless_mac
 
 
+@skip_unless_mac
 class TestQuartz(unittest.TestCase):
     def test_quartz_importable(self):
-        if sys.platform != "darwin":
-            from unittest.case import SkipTest
-
-            raise SkipTest("quartz is only built on OS X")
-
         from kiva.quartz import ABCGI
         from kiva.quartz import CTFont
         from kiva.quartz import mac_context

--- a/kiva/tests/test_quartz.py
+++ b/kiva/tests/test_quartz.py
@@ -34,6 +34,8 @@ class TestQuartz(unittest.TestCase):
 
         from kiva.quartz import get_macport
 
+        success = []
+
         class SimpleWindow(wx.Frame):
             """
             Simple test of get_macport().
@@ -62,10 +64,10 @@ class TestQuartz(unittest.TestCase):
                 try:
                     print("paintdc.macport: %x" % get_macport(dc))
                     print("memdc.macport: %x" % get_macport(self.memdc))
-                    self.success = True
+                    success.append(True)
                 except Exception as exc:
                     print(repr(exc))
-                    self.success = False
+                    success.append(False)
 
                 # We're done here
                 self.Close()
@@ -78,7 +80,8 @@ class TestQuartz(unittest.TestCase):
         app = MyApp(False)
         app.MainLoop()
 
-        self.assertTrue(app.success)
+        self.assertEqual(len(success), 1)
+        self.assertTrue(success[0])
 
     def test_font_names(self):
         from kiva.quartz.CTFont import default_font_info

--- a/kiva/tests/test_quartz.py
+++ b/kiva/tests/test_quartz.py
@@ -59,10 +59,13 @@ class TestQuartz(unittest.TestCase):
 
             def OnPaint(self, evt):
                 dc = wx.PaintDC(self)
-                print("paintdc.this:", dc.this)
-                print("paintdc.macport: %x" % get_macport(dc))
-                print("memdc.this:", self.memdc.this)
-                print("memdc.macport: %x" % get_macport(self.memdc))
+                try:
+                    print("paintdc.macport: %x" % get_macport(dc))
+                    print("memdc.macport: %x" % get_macport(self.memdc))
+                    self.success = True
+                except Exception as exc:
+                    print(repr(exc))
+                    self.success = False
 
                 # We're done here
                 self.Close()
@@ -74,6 +77,8 @@ class TestQuartz(unittest.TestCase):
 
         app = MyApp(False)
         app.MainLoop()
+
+        self.assertTrue(app.success)
 
     def test_font_names(self):
         from kiva.quartz.CTFont import default_font_info

--- a/kiva/tests/test_quartz.py
+++ b/kiva/tests/test_quartz.py
@@ -8,72 +8,81 @@
 #
 # Thanks for using Enthought open source!
 import sys
+import unittest
 
 from kiva.tests._testing import skip_if_not_wx
 
 
-def test_quartz_importable():
-    if sys.platform != "darwin":
-        from unittest.case import SkipTest
+class TestQuartz(unittest.TestCase):
+    def test_quartz_importable(self):
+        if sys.platform != "darwin":
+            from unittest.case import SkipTest
 
-        raise SkipTest("quartz is only built on OS X")
+            raise SkipTest("quartz is only built on OS X")
 
-    from kiva.quartz import ABCGI
-    from kiva.quartz import CTFont
-    from kiva.quartz import mac_context
-    del ABCGI
-    del CTFont
-    del mac_context
+        from kiva.quartz import ABCGI
+        from kiva.quartz import CTFont
+        from kiva.quartz import mac_context
+        del ABCGI
+        del CTFont
+        del mac_context
 
+    @skip_if_not_wx
+    def test_macport(self):
+        if sys.platform != "darwin":
+            from unittest.case import SkipTest
 
-@skip_if_not_wx
-def test_macport():
-    if sys.platform != "darwin":
-        from unittest.case import SkipTest
+            raise SkipTest("macport is only built on OS X")
 
-        raise SkipTest("macport is only built on OS X")
+        import wx
 
-    import wx
+        from kiva.quartz import get_macport
 
-    from kiva.quartz import get_macport
+        class SimpleWindow(wx.Frame):
+            """
+            Simple test of get_macport().
+            """
 
-    class SimpleWindow(wx.Frame):
-        """
-        Simple test of get_macport().
-        """
+            def __init__(self):
+                wx.Frame.__init__(
+                    self,
+                    parent=None,
+                    id=-1,
+                    title="foo",
+                    pos=(100, 100),
+                    size=(300, 300),
+                )
+                oldstyle = self.GetWindowStyle()
+                oldstyle = oldstyle | wx.FULL_REPAINT_ON_RESIZE
+                self.SetWindowStyle(oldstyle)
+                self.Show(1)
+                self.Bind(wx.EVT_PAINT, self.OnPaint)
+                self.memdc = wx.MemoryDC()
+                self.bitmap = wx.EmptyBitmap(200, 200)
+                self.memdc.SelectObject(self.bitmap)
 
-        def __init__(self):
-            wx.Frame.__init__(
-                self,
-                parent=None,
-                id=-1,
-                title="foo",
-                pos=(100, 100),
-                size=(300, 300),
-            )
-            oldstyle = self.GetWindowStyle()
-            oldstyle = oldstyle | wx.FULL_REPAINT_ON_RESIZE
-            self.SetWindowStyle(oldstyle)
-            self.Show(1)
-            self.Bind(wx.EVT_PAINT, self.OnPaint)
-            self.memdc = wx.MemoryDC()
-            self.bitmap = wx.EmptyBitmap(200, 200)
-            self.memdc.SelectObject(self.bitmap)
+            def OnPaint(self, evt):
+                dc = wx.PaintDC(self)
+                print("paintdc.this:", dc.this)
+                print("paintdc.macport: %x" % get_macport(dc))
+                print("memdc.this:", self.memdc.this)
+                print("memdc.macport: %x" % get_macport(self.memdc))
 
-        def OnPaint(self, evt):
-            dc = wx.PaintDC(self)
-            print("paintdc.this:", dc.this)
-            print("paintdc.macport: %x" % get_macport(dc))
-            print("memdc.this:", self.memdc.this)
-            print("memdc.macport: %x" % get_macport(self.memdc))
+                # We're done here
+                self.Close()
 
-            # We're done here
-            self.Close()
+        class MyApp(wx.App):
+            def OnInit(self):
+                SimpleWindow()
+                return 1
 
-    class MyApp(wx.App):
-        def OnInit(self):
-            SimpleWindow()
-            return 1
+        app = MyApp(False)
+        app.MainLoop()
 
-    app = MyApp(False)
-    app.MainLoop()
+    def test_font_names(self):
+        from kiva.quartz.CTFont import default_font_info
+
+        names = default_font_info.names()
+
+        # regression test for Enable#964
+        self.assertFalse(any(s.startswith("b'") for s in names))


### PR DESCRIPTION
Fixes #964.

Bytes seem to be assuming `mac-roman` encoding, so use that in decoder.

Also a drive-by fix to make quartz tests proper unittest tests rather than nose/pytest-style.