### PR TITLE
Add a github workflow that publishes to sdists to PyPI on release

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -1,0 +1,37 @@
+name: Publish release to PyPI
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the release commit
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install Python packages needed for build and upload
+      run: |
+        python -m pip install build twine
+
+    - name: Build sdist and wheel
+      run: |
+        python setup.py sdist
+
+    - name: Publish to PyPI
+
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+
+      run: |
+        python -m twine check --strict dist/*
+        python -m twine upload dist/*

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -22,9 +22,9 @@ jobs:
       run: |
         python -m pip install build twine
 
-    - name: Build sdist and wheel
+    - name: Build sdist
       run: |
-        python setup.py sdist
+        python -m build --sdist
 
     - name: Publish to PyPI
 


### PR DESCRIPTION
This doesn't attempt to do any sort of building, just packages up the sdist.

PyPI secrets will need to be added for the project.