### PR TITLE
Correct first point and orientation of Kiva QPainter arcs

### DIFF
--- a/kiva/qpainter.py
+++ b/kiva/qpainter.py
@@ -892,9 +892,16 @@ class CompiledPath(object):
             if not clockwise
             else start_angle - end_angle
         )
-        self.path.moveTo(x, y)
+        if self.is_empty():
+            # if this is the first point of the path, don't draw a line
+            # to the start point
+            self.path.moveTo(
+                x + r * np.cos(start_angle),
+                y + r * np.sin(start_angle),
+            )
+        # draw arc flipped in y-axis because QPainter has origin-up
         self.path.arcTo(
-            QtCore.QRectF(x - r, y - r, r * 2, r * 2),
+            QtCore.QRectF(x - r, y + r, r * 2, -r * 2),
             np.rad2deg(start_angle),
             np.rad2deg(sweep_angle),
         )

--- a/kiva/qpainter.py
+++ b/kiva/qpainter.py
@@ -899,7 +899,7 @@ class CompiledPath(object):
                 x + r * np.cos(start_angle),
                 y + r * np.sin(start_angle),
             )
-        # draw arc flipped in y-axis because QPainter has origin-up
+        # draw arc flipped in y-axis because QPainter has top-left origin
         self.path.arcTo(
             QtCore.QRectF(x - r, y + r, r * 2, -r * 2),
             np.rad2deg(start_angle),


### PR DESCRIPTION
This fixes #962 but not #960.

Anticlockwise arcs are drawn the same as Agg, and it isn't drawing sectors any more:
![image](https://user-images.githubusercontent.com/600761/182801984-68554418-04b8-4a49-aa17-c9e52975f9a3.png)