### PR TITLE
Fix `SCRIPT` font family in Kiva

### DIFF
--- a/kiva/fonttools/font.py
+++ b/kiva/fonttools/font.py
@@ -186,7 +186,7 @@ class Font(object):
         ROMAN: "serif",
         MODERN: "sans-serif",
         DECORATIVE: "fantasy",
-        SCRIPT: "script",
+        SCRIPT: "cursive",
         TELETYPE: "monospace",
     }
 

--- a/kiva/fonttools/tests/test_font.py
+++ b/kiva/fonttools/tests/test_font.py
@@ -14,9 +14,10 @@ import os
 import unittest
 
 from kiva.constants import (
-    BOLD, BOLD_ITALIC, DEFAULT, ITALIC, MODERN, NORMAL, ROMAN, WEIGHT_BOLD,
+    BOLD, BOLD_ITALIC, DECORATIVE, DEFAULT, ITALIC, MODERN, NORMAL, ROMAN, SCRIPT, TELETYPE, WEIGHT_BOLD,
     WEIGHT_LIGHT, WEIGHT_NORMAL, SWISS,
 )
+from kiva.fonttools._constants import font_family_aliases, preferred_fonts
 from kiva.fonttools.tests._testing import patch_global_font_manager
 from kiva.fonttools.font import (
     DECORATIONS, FAMILIES, NOISE, STYLES, WEIGHTS, Font, str_to_font,
@@ -192,6 +193,23 @@ class TestFont(unittest.TestCase):
             query = font._make_font_query()
         self.assertEqual(query.get_weight(), WEIGHT_LIGHT)
         self.assertEqual(query.get_style(), "italic")
+
+    def test_family_queries(self):
+        # regression test for Enable #971
+        # this ensures every font family creates a valid query populated
+        # with query families that work
+        families = [
+            DECORATIVE, DEFAULT, MODERN, ROMAN, SCRIPT, SWISS, TELETYPE
+        ]
+        for family in families:
+            with self.subTest(family=family):
+                font = Font(family=family)
+                query = font._make_font_query()
+                query_family = query.get_family()[0]
+
+                self.assertEqual(query_family, Font.familymap.get(family))
+                self.assertIn(query_family, font_family_aliases)
+                self.assertIn(query_family, preferred_fonts)
 
 
 class TestSimpleParser(unittest.TestCase):

--- a/kiva/fonttools/tests/test_font.py
+++ b/kiva/fonttools/tests/test_font.py
@@ -14,8 +14,8 @@ import os
 import unittest
 
 from kiva.constants import (
-    BOLD, BOLD_ITALIC, DECORATIVE, DEFAULT, ITALIC, MODERN, NORMAL, ROMAN, SCRIPT, TELETYPE, WEIGHT_BOLD,
-    WEIGHT_LIGHT, WEIGHT_NORMAL, SWISS,
+    BOLD, BOLD_ITALIC, DECORATIVE, DEFAULT, ITALIC, MODERN, NORMAL, ROMAN,
+    SCRIPT, TELETYPE, WEIGHT_BOLD, WEIGHT_LIGHT, WEIGHT_NORMAL, SWISS,
 )
 from kiva.fonttools._constants import font_family_aliases, preferred_fonts
 from kiva.fonttools.tests._testing import patch_global_font_manager


### PR DESCRIPTION
Fix is a matter of having `Font.familymap` map to the right thing.  This is a _very_ old bug.

This is the benchmark rendering in the agg backend after the fix (note the "script" column):
![image](https://user-images.githubusercontent.com/600761/182909248-632861f2-dc26-4873-be60-f4a5bfd6f9d8.png)

Fixes #971.