### PR TITLE
Fix Quartz font rendering

### DIFF
--- a/kiva/quartz/ABCGI.pyx
+++ b/kiva/quartz/ABCGI.pyx
@@ -809,7 +809,11 @@ cdef class CGContext:
             constants.ITALIC: 'italic',
             constants.BOLD_ITALIC: 'bold italic',
         }[font.is_bold() | font.style]
-        self.select_font(font.face_name, font.size, style=style)
+        if font.face_name:
+            name = font.face_name
+        else:
+            name = font.findfontname()
+        self.select_font(name, font.size, style=style)
 
     def set_font_size(self, float size):
         """ Change the size of the currently selected font

--- a/kiva/quartz/ABCGI.pyx
+++ b/kiva/quartz/ABCGI.pyx
@@ -938,7 +938,8 @@ cdef class CGContext:
 
         pointer = self.current_font.get_pointer()
         ct_font = <CTFontRef>pointer
-        ct_line = _create_ct_line(text, ct_font, self.stroke_color)
+        # using fill_color here brings rendering in line with Agg backends
+        ct_line = _create_ct_line(text, ct_font, self.fill_color)
         if ct_line == NULL:
             return
 


### PR DESCRIPTION
This looks up font family names if no specific face name is given, and switches rendering of text to use the fill color rather than the stroke color, to match Agg, etc. rendering.

Font rendering benchmark now looks like this:
![image](https://user-images.githubusercontent.com/600761/183035236-20c4ced6-bbf8-42c9-8645-432ea32277b2.png)

Fixes #976.