### PR TITLE
Fix the rendering of polygons in basecore2d-based backends

### DIFF
--- a/kiva/basecore2d.py
+++ b/kiva/basecore2d.py
@@ -40,7 +40,7 @@ from .constants import (
     TRANSLATE_CTM,
 )
 from .abstract_graphics_context import AbstractGraphicsContext
-from .line_state import LineState, line_state_equal
+from .line_state import LineState, line_state_equal  # noqa: F401
 from .graphics_state import GraphicsState
 from .fonttools import Font
 import kiva.affine as affine

--- a/kiva/basecore2d.py
+++ b/kiva/basecore2d.py
@@ -1236,16 +1236,16 @@ class GraphicsContextBase(AbstractGraphicsContext):
     def clear_subpath_points(self):
         self.draw_points = []
 
-    def get_subpath_points(self, debug=0):
-        """ Gets the points that are in the current path.
+    def get_subpath_points(self, debug=False):
+        """ Gets the points that are in the current subpath as an Nx2 array.
 
-            The first entry in the draw_points list may actually
-            be an array.  If this is true, the other points are
-            converted to an array and concatenated with the first
+        The draw_points attribute holds the current set of points as a
+        list of Nx2 arrays.
         """
         if self.draw_points:
             pts = np.vstack(self.draw_points)
         else:
+            # list is empty, convert to an empty array
             pts = asarray(self.draw_points)
         return pts
 

--- a/kiva/basecore2d.py
+++ b/kiva/basecore2d.py
@@ -504,6 +504,8 @@ class GraphicsContextBase(AbstractGraphicsContext):
             Starts and ends should have the same length.
             The current point is moved to the last point in 'ends'.
         """
+        starts = asarray(starts)
+        ends = asarray(ends)
         self._new_subpath()
         for i in range(min(len(starts), len(ends))):
             self.active_subpath.append((POINT, starts[i]))
@@ -1138,8 +1140,11 @@ class GraphicsContextBase(AbstractGraphicsContext):
                     self.add_point_to_subpath(args)
                     self.first_point = args[0]
                 elif func == CLOSE:
-                    self.add_point_to_subpath(self.first_point.reshape(1, 2))
-                    self.draw_subpath(mode)
+                    if self.first_point is not None:
+                        self.add_point_to_subpath(
+                            self.first_point.reshape(1, 2)
+                        )
+                        self.draw_subpath(mode)
                 elif func == RECT:
                     self.draw_subpath(mode)
                     self.device_draw_rect(
@@ -1235,6 +1240,7 @@ class GraphicsContextBase(AbstractGraphicsContext):
 
     def clear_subpath_points(self):
         self.draw_points = []
+        self.first_point = None
 
     def get_subpath_points(self, debug=False):
         """ Gets the points that are in the current subpath as an Nx2 array.

--- a/kiva/basecore2d.py
+++ b/kiva/basecore2d.py
@@ -40,7 +40,7 @@ from .constants import (
     TRANSLATE_CTM,
 )
 from .abstract_graphics_context import AbstractGraphicsContext
-from .line_state import LineState
+from .line_state import LineState, line_state_equal
 from .graphics_state import GraphicsState
 from .fonttools import Font
 import kiva.affine as affine

--- a/kiva/basecore2d.py
+++ b/kiva/basecore2d.py
@@ -29,7 +29,7 @@ transform
 
 """
 import numpy as np
-from numpy import alltrue, array, asarray, concatenate, float64, pi, shape
+from numpy import alltrue, array, asarray, float64, pi
 
 from .constants import (
     CAP_BUTT, CAP_ROUND, CAP_SQUARE, CLOSE, CONCAT_CTM, EOF_FILL_STROKE,
@@ -40,7 +40,7 @@ from .constants import (
     TRANSLATE_CTM,
 )
 from .abstract_graphics_context import AbstractGraphicsContext
-from .line_state import LineState, line_state_equal
+from .line_state import LineState
 from .graphics_state import GraphicsState
 from .fonttools import Font
 import kiva.affine as affine

--- a/kiva/tests/test_basecore2d.py
+++ b/kiva/tests/test_basecore2d.py
@@ -24,6 +24,7 @@ from numpy import alltrue, array, ravel
 from kiva import affine
 from kiva import basecore2d
 from kiva import constants
+from kiva.line_state import line_state_equal
 
 
 class TestIsFullyTransparent(unittest.TestCase):
@@ -70,31 +71,31 @@ class LineStateTestCase(unittest.TestCase):
         ls1 = self.create_ls()
         ls2 = ls1.copy()
         ls1.line_color[1] = 10
-        self.assertTrue(not basecore2d.line_state_equal(ls1, ls2))
+        self.assertTrue(not line_state_equal(ls1, ls2))
 
     def test_dash_on_copy(self):
         ls1 = self.create_ls()
         ls2 = ls1.copy()
         ls1.line_dash[1][0] = 10
-        self.assertTrue(not basecore2d.line_state_equal(ls1, ls2))
+        self.assertTrue(not line_state_equal(ls1, ls2))
 
     def test_cmp_for_different_length_dash_patterns(self):
         ls1 = self.create_ls()
         ls2 = ls1.copy()
         ls1.line_dash = (ls1.line_dash[0], array([10, 10, 10, 10]))
-        self.assertTrue(not basecore2d.line_state_equal(ls1, ls2))
+        self.assertTrue(not line_state_equal(ls1, ls2))
 
     def test_cmp(self):
         ls1 = self.create_ls()
         ls2 = ls1.copy()
-        self.assertTrue(basecore2d.line_state_equal(ls1, ls2))
+        self.assertTrue(line_state_equal(ls1, ls2))
 
     # line_dash no longer allowed to be none.
     # def test_cmp_with_dash_as_none(self):
     #    ls1 = self.create_ls()
     #    ls2 = ls1.copy()
     #    #ls1.line_dash = None
-    #    assert(not basecore2d.line_state_equal(ls1,ls2))
+    #    assert(not line_state_equal(ls1,ls2))
 
 
 class GraphicsContextTestCase(unittest.TestCase):


### PR DESCRIPTION
This:

- consistently uses Nx2 numpy arrays to store path points
- doesn't create a new subpath after a `LINES` function (so consecutive arc, curve, etc. commands add to the subpath).

A drive-by fix gives a default implementation for `show_text_at_point()`.

Image from the benchmark suite (for SVG):
![image](https://user-images.githubusercontent.com/600761/183844838-1633269c-3dcf-4870-b621-7a0081870e4e.png)

Fixes #986.