### PR TITLE
Ensure all backends implement `arc_to` and `quad_curve_to`

### DIFF
--- a/kiva/basecore2d.py
+++ b/kiva/basecore2d.py
@@ -659,7 +659,7 @@ class GraphicsContextBase(AbstractGraphicsContext):
         Consider the common case of rounding a rectangle's upper left corner.
         Let "r" be the radius of rounding. Let the current point be
         ``(x_left + r, y_top)``. Then ``(x2, y2)`` would be
-        ``(x_left, y_top - radius)``, and ``(x1, y1)`` would be
+        ``(x_left, y_top - r)``, and ``(x1, y1)`` would be
         ``(x_left, y_top)``.
 
         Note: this, like many backends, actually draws a quadratic Bezier curve

--- a/kiva/cairo.py
+++ b/kiva/cairo.py
@@ -710,7 +710,7 @@ class GraphicsContext(basecore2d.GraphicsContextBase):
         self._ctx.line_to(x2, y2)
 
     # ----------------------------------------------------------------
-    # Getting infomration on paths
+    # Getting information on paths
     # ----------------------------------------------------------------
 
     def is_path_empty(self):

--- a/kiva/celiagg.py
+++ b/kiva/celiagg.py
@@ -452,7 +452,7 @@ class GraphicsContext(object):
         self.path.arc_to(x1, y1, x2, y2, radius)
 
     # ----------------------------------------------------------------
-    # Getting infomration on paths
+    # Getting information on paths
     # ----------------------------------------------------------------
 
     def is_path_empty(self):

--- a/kiva/pdf.py
+++ b/kiva/pdf.py
@@ -418,7 +418,7 @@ class GraphicsContext(GraphicsContextBase):
         self.current_point = (x, y)
 
     # ----------------------------------------------------------------
-    # Getting infomration on paths
+    # Getting information on paths
     # ----------------------------------------------------------------
 
     def is_path_empty(self):

--- a/kiva/pdf.py
+++ b/kiva/pdf.py
@@ -403,12 +403,6 @@ class GraphicsContext(GraphicsContextBase):
         self.current_pdf_path.curveTo(cp1x, cp1y, cp2x, cp2y, x, y)
         self.current_point = (x, y)
 
-    def quad_curve_to(self, cpx, cpy, x, y):
-        """
-        """
-        msg = "quad curve to not implemented yet on PDF"
-        raise NotImplementedError(msg)
-
     def arc(self, x, y, radius, start_angle, end_angle, clockwise=False):
         """
         """
@@ -422,23 +416,6 @@ class GraphicsContext(GraphicsContextBase):
             (end_angle - start_angle) * 180.0 / pi,
         )
         self.current_point = (x, y)
-
-    def arc_to(self, x1, y1, x2, y2, radius):
-        """
-        """
-        if self.current_pdf_path is None:
-            self.begin_path()
-
-        # Get the endpoints on the curve where it touches the line segments
-        t1, t2 = arc_to_tangent_points(
-            self.current_point, (x1, y1), (x2, y2), radius
-        )
-
-        # draw!
-        self.current_pdf_path.lineTo(*t1)
-        self.current_pdf_path.curveTo(x1, y1, x1, y1, *t2)
-        self.current_pdf_path.lineTo(x2, y2)
-        self.current_point = (x2, y2)
 
     # ----------------------------------------------------------------
     # Getting infomration on paths

--- a/kiva/qpainter.py
+++ b/kiva/qpainter.py
@@ -442,7 +442,7 @@ class GraphicsContext(object):
         self.path.arc_to(x1, y1, x2, y2, radius)
 
     # ----------------------------------------------------------------
-    # Getting infomration on paths
+    # Getting information on paths
     # ----------------------------------------------------------------
 
     def is_path_empty(self):

--- a/kiva/tests/drawing_tester.py
+++ b/kiva/tests/drawing_tester.py
@@ -78,6 +78,27 @@ class DrawingTester(object):
             self.gc.arc(150, 150, 100, 0.0, numpy.pi / 2)
             self.gc.stroke_path()
 
+    def test_arc_to(self):
+        with self.draw_and_check():
+            self.gc.begin_path()
+            self.gc.move_to(0, 50)
+            self.gc.arc_to(0, 150, 100, 150, 50)
+            self.gc.stroke_path()
+
+    def test_quad_curve_to(self):
+        with self.draw_and_check():
+            self.gc.begin_path()
+            self.gc.move_to(0, 50)
+            self.gc.quad_curve_to(0, 100, 50, 100)
+            self.gc.stroke_path()
+
+    def test_curve_to(self):
+        with self.draw_and_check():
+            self.gc.begin_path()
+            self.gc.move_to(300, 100)
+            self.gc.curve_to(230, 150, 270, 250, 200, 200)
+            self.gc.stroke_path()
+
     def test_text(self):
         for family in [
                 DECORATIVE, DEFAULT, ITALIC, MODERN, ROMAN, SCRIPT, TELETYPE]:

--- a/kiva/tests/test_svg_drawing.py
+++ b/kiva/tests/test_svg_drawing.py
@@ -26,7 +26,7 @@ class TestSVGDrawing(DrawingTester, unittest.TestCase):
         self.gc.save(filename)
         tree = ElementTree.parse(filename)
         elements = [element for element in tree.iter()]
-        if not len(elements) in [4, 5, 7]:
+        if len(elements) not in {4, 5, 7}:
             self.fail(
                 "The expected number of elements was not found. "
                 + f"Found {len(elements)}."
@@ -42,5 +42,8 @@ class TestSVGDrawing(DrawingTester, unittest.TestCase):
             fp.write(stream)
         tree = ElementTree.parse(filename)
         elements = [element for element in tree.iter()]
-        if not len(elements) in [4, 7]:
-            self.fail("The expected number of elements was not found")
+        if len(elements) not in {4, 7}:
+            self.fail(
+                "The expected number of elements was not found. "
+                + f"Found {len(elements)}."
+            )

--- a/kiva/tests/test_svg_drawing.py
+++ b/kiva/tests/test_svg_drawing.py
@@ -26,8 +26,11 @@ class TestSVGDrawing(DrawingTester, unittest.TestCase):
         self.gc.save(filename)
         tree = ElementTree.parse(filename)
         elements = [element for element in tree.iter()]
-        if not len(elements) in [4, 7]:
-            self.fail("The expected number of elements was not found")
+        if not len(elements) in [4, 5, 7]:
+            self.fail(
+                "The expected number of elements was not found. "
+                + f"Found {len(elements)}."
+            )
 
     def test_ipython_repr_svg(self):
         self.gc.begin_path()


### PR DESCRIPTION
This consists of:

- adding a simple implementation of `arc_to` for `basecore2d.GraphicsContext`
- removing the implementations of `arc_to` (which uses cubic beziers) and `quad_curve_to` (which raises masking the superclass) from the PDF backend. It inherits from `basecore2d.GraphicsContext` so we just use the implementations from that.
- adding tests for the curve methods to the drawing tester mixin.

Note that the PS and SVG backends won't draw eg. a rounded rectangle correctly until #987 is merged.