### PR TITLE
Fix WEIGHT_EXTRAHEAVY on Qt6

### DIFF
--- a/kiva/qpainter.py
+++ b/kiva/qpainter.py
@@ -14,7 +14,7 @@ import numpy as np
 import warnings
 
 # Major package imports.
-from pyface.qt import QtCore, QtGui
+from pyface.qt import QtCore, QtGui, is_qt5
 
 # Local imports.
 from .abstract_graphics_context import AbstractGraphicsContext
@@ -75,7 +75,7 @@ weight_to_qt_weight = {
     constants.WEIGHT_BOLD: QtGui.QFont.Weight.Bold,
     constants.WEIGHT_EXTRABOLD: QtGui.QFont.Weight.ExtraBold,
     constants.WEIGHT_HEAVY: QtGui.QFont.Weight.Black,
-    constants.WEIGHT_EXTRAHEAVY: 99,
+    constants.WEIGHT_EXTRAHEAVY: 99 if is_qt5 else QtGui.QFont.Weight.Black,
 }
 
 gradient_coord_modes = {}

--- a/kiva/tests/drawing_tester.py
+++ b/kiva/tests/drawing_tester.py
@@ -18,6 +18,20 @@ from PIL import Image
 from kiva.api import (
     DECORATIVE, DEFAULT, ITALIC, MODERN, NORMAL, ROMAN, SCRIPT, TELETYPE, Font
 )
+from kiva.constants import (
+    WEIGHT_THIN, WEIGHT_EXTRALIGHT, WEIGHT_LIGHT, WEIGHT_NORMAL, WEIGHT_MEDIUM,
+    WEIGHT_SEMIBOLD, WEIGHT_BOLD, WEIGHT_EXTRABOLD, WEIGHT_HEAVY,
+    WEIGHT_EXTRAHEAVY
+)
+
+
+families = [DECORATIVE, DEFAULT, MODERN, ROMAN, SCRIPT, TELETYPE]
+
+weights = [
+    WEIGHT_THIN, WEIGHT_EXTRALIGHT, WEIGHT_LIGHT, WEIGHT_NORMAL, WEIGHT_MEDIUM,
+    WEIGHT_SEMIBOLD, WEIGHT_BOLD, WEIGHT_EXTRABOLD, WEIGHT_HEAVY,
+    WEIGHT_EXTRAHEAVY,
+]
 
 
 class DrawingTester(object):
@@ -79,9 +93,8 @@ class DrawingTester(object):
             self.gc.stroke_path()
 
     def test_text(self):
-        for family in [
-                DECORATIVE, DEFAULT, ITALIC, MODERN, ROMAN, SCRIPT, TELETYPE]:
-            for weight in range(100, 1001, 100):
+        for family in families:
+            for weight in weights:
                 for style in [NORMAL, ITALIC]:
                     with self.subTest(family=family, weight=weight, style=style):
                         self.gc = self.create_graphics_context()


### PR DESCRIPTION
Also some changes to tests to make sure all weights are tested correctly.

Benchmark render on PySide6:
![image](https://user-images.githubusercontent.com/600761/183886857-cc60abde-8dba-4bf9-b59b-a4ca240c4823.png)

Fixes #989.