### PR TITLE
Restore CI to working state

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -67,17 +67,14 @@ jobs:
       - name: Run enable test suite
         env:
           PYTHONFAULTHANDLER: 1
-        with:
-          # kiva agg requires at least 15-bit color depth.
-          # The --server-args assumes xvfb-run is called, hence Linux only.
-          run: xvfb-run --server-args="-screen 0 1024x768x24" python -m unittest discover -v enable
-          working-directory: ${{ runner.temp }}
+        # kiva agg requires at least 15-bit color depth.
+        run: xvfb-run --server-args="-screen 0 1024x768x24" python -m unittest discover -v enable
+        working-directory: ${{ runner.temp }}
       - name: Run kiva test suite
         env:
           PYTHONFAULTHANDLER: 1
-        with:
-          run: xvfb-run python -m unittest discover -v kiva
-          working-directory: ${{ runner.temp }}
+        run: xvfb-run python -m unittest discover -v kiva
+        working-directory: ${{ runner.temp }}
 
   notify-on-failure:
     needs: test-ets

--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -25,12 +25,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install PySide2 (from PyPI) dependencies for Linux
         run: |
+          sudo apt-get update
           sudo apt-get install qtbase5-dev
           sudo apt-get install qtchooser
           sudo apt-get install qt5-qmake
           sudo apt-get install qtbase5-dev-tools
           sudo apt-get install libegl1
-          sudo apt-get install qt5-default
           sudo apt-get install libxkbcommon-x11-0
           sudo apt-get install libxcb-icccm4
           sudo apt-get install libxcb-image0

--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -12,7 +12,7 @@ jobs:
   test-ets:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         toolkit: ['pyside6', 'pyside2', 'wx']
         python-version: [3.8]
     runs-on: ${{ matrix.os }}
@@ -25,7 +25,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install PySide2 (from PyPI) dependencies for Linux
         run: |
-          sudo apt-get update
+          sudo apt-get install qtbase5-dev
+          sudo apt-get install qtchooser
+          sudo apt-get install qt5-qmake
+          sudo apt-get install qtbase5-dev-tools
+          sudo apt-get install libegl1
           sudo apt-get install qt5-default
           sudo apt-get install libxkbcommon-x11-0
           sudo apt-get install libxcb-icccm4
@@ -34,6 +38,7 @@ jobs:
           sudo apt-get install libxcb-randr0
           sudo apt-get install libxcb-render-util0
           sudo apt-get install libxcb-xinerama0
+          sudo apt-get install libxcb-shape0
         if: matrix.toolkit != 'wx'
       - name: Install Wx dependencies for Linux
         run: |
@@ -62,18 +67,16 @@ jobs:
       - name: Run enable test suite
         env:
           PYTHONFAULTHANDLER: 1
-        uses: GabrielBB/xvfb-action@v1
         with:
           # kiva agg requires at least 15-bit color depth.
           # The --server-args assumes xvfb-run is called, hence Linux only.
-          run: --server-args="-screen 0 1024x768x24" python -m unittest discover -v enable
+          run: xvfb-run --server-args="-screen 0 1024x768x24" python -m unittest discover -v enable
           working-directory: ${{ runner.temp }}
       - name: Run kiva test suite
         env:
           PYTHONFAULTHANDLER: 1
-        uses: GabrielBB/xvfb-action@v1
         with:
-          run: python -m unittest discover -v kiva
+          run: xvfb-run python -m unittest discover -v kiva
           working-directory: ${{ runner.temp }}
 
   notify-on-failure:

--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        toolkit: ['pyside6', 'pyside2', 'wx']
+        toolkit: ['pyside6', 'pyside2']
         python-version: [3.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install PySide2 (from PyPI) dependencies for Linux

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -54,10 +54,8 @@ jobs:
       - name: Install test environment
         run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }} --runtime=${{ matrix.runtime }}
       - name: Run tests
-        with:
-          # kiva agg requires at least 15-bit color depth.
-          # The --server-args assumes xvfb-run is called, hence Linux only.
-          run: xvfb-run --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }} --runtime=${{ matrix.runtime }}
+        # kiva agg requires at least 15-bit color depth.
+        run: xvfb-run --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }} --runtime=${{ matrix.runtime }}
 
   # Test against EDM packages on Windows and OSX
   test-with-edm:

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -15,7 +15,7 @@ jobs:
   test-edm-linux:
     strategy:
       matrix:
-        toolkit: ['null', 'pyqt5', 'pyside2', 'wx']
+        toolkit: ['null', 'pyqt5', 'pyside2']
         runtime: ['3.6']
         include:
           - toolkit: 'pyside6'
@@ -32,6 +32,13 @@ jobs:
           sudo apt-get install qtbase5-dev-tools
           sudo apt-get install libegl1
           sudo apt-get install libxkbcommon-x11-0
+          sudo apt-get install libxcb-icccm4
+          sudo apt-get install libxcb-image0
+          sudo apt-get install libxcb-keysyms1
+          sudo apt-get install libxcb-randr0
+          sudo apt-get install libxcb-render-util0
+          sudo apt-get install libxcb-xinerama0
+          sudo apt-get install libxcb-shape0
         if: matrix.toolkit != 'wx'
       - name: Install Wx dependencies for Linux
         run: |

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -7,7 +7,7 @@ name: Test with EDM
 on: pull_request
 
 env:
-  INSTALL_EDM_VERSION: 3.4.0
+  INSTALL_EDM_VERSION: 3.5.0
 
 jobs:
 

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -22,7 +22,7 @@ jobs:
             runtime: '3.8'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Qt dependencies for Linux
         run: |
           sudo apt-get update
@@ -46,7 +46,7 @@ jobs:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ matrix.runtime }}-${{ hashFiles('ci/edmtool.py') }}
       - name: Setup EDM
-        uses: enthought/setup-edm-action@v1
+        uses: enthought/setup-edm-action@v2
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install click to the default EDM environment

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -7,7 +7,7 @@ name: Test with EDM
 on: pull_request
 
 env:
-  INSTALL_EDM_VERSION: 3.2.1
+  INSTALL_EDM_VERSION: 3.4.0
 
 jobs:
 
@@ -20,12 +20,17 @@ jobs:
         include:
           - toolkit: 'pyside6'
             runtime: '3.8'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install Qt dependencies for Linux
         run: |
           sudo apt-get update
+          sudo apt-get install qtbase5-dev
+          sudo apt-get install qtchooser
+          sudo apt-get install qt5-qmake
+          sudo apt-get install qtbase5-dev-tools
+          sudo apt-get install libegl1
           sudo apt-get install libxkbcommon-x11-0
         if: matrix.toolkit != 'wx'
       - name: Install Wx dependencies for Linux
@@ -49,11 +54,10 @@ jobs:
       - name: Install test environment
         run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }} --runtime=${{ matrix.runtime }}
       - name: Run tests
-        uses: GabrielBB/xvfb-action@v1
         with:
           # kiva agg requires at least 15-bit color depth.
           # The --server-args assumes xvfb-run is called, hence Linux only.
-          run: --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }} --runtime=${{ matrix.runtime }}
+          run: xvfb-run --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }} --runtime=${{ matrix.runtime }}
 
   # Test against EDM packages on Windows and OSX
   test-with-edm:

--- a/ci/.edm.yaml
+++ b/ci/.edm.yaml
@@ -1,3 +1,4 @@
 store_url: https://packages.enthought.com
 repositories:
   - enthought/free
+  - enthought/lgpl

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -210,7 +210,7 @@ def install(runtime, toolkit, environment, source):
         elif sys.platform == "linux":
             # XXX this is mainly for TravisCI workers; need a generic solution
             commands.append(
-                "edm run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04/ wxPython<4.1"  # noqa: E501
+                "edm run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/ wxPython"  # noqa: E501
             )
         else:
             commands.append(

--- a/ci/requirements_3.6.txt
+++ b/ci/requirements_3.6.txt
@@ -1,2 +1,2 @@
 pygarrayimage
-pyglet
+pyglet<2.0

--- a/ci/requirements_3.8.txt
+++ b/ci/requirements_3.8.txt
@@ -1,4 +1,4 @@
 pygarrayimage
-pyglet
+pyglet<2.0
 pypdf2<3.0
 reportlab

--- a/ci/requirements_3.8.txt
+++ b/ci/requirements_3.8.txt
@@ -1,4 +1,4 @@
 pygarrayimage
 pyglet
-pypdf2
+pypdf2<3.0
 reportlab

--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -29,7 +29,7 @@ __extras_require__ = {
     # Dependencies for constrained layout
     "layout": ["kiwisolver"],
     # Dependencies for PDF backend
-    "pdf": ["reportlab"],
+    "pdf": ["reportlab<3.0"],
     # Dependencies for SVG backend
     "svg": ["pyparsing"],
     # Dependencies purely for running tests.

--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -25,7 +25,7 @@ __extras_require__ = {
     # Dependencies for running enable/kiva's examples
     "examples": ["chaco", "mayavi", "scipy", "kiwisolver", "pyglet"],
     # Dependencies for GL backend support
-    "gl": ["pygarrayimage", "pyglet"],
+    "gl": ["pygarrayimage", "pyglet<2.0"],
     # Dependencies for constrained layout
     "layout": ["kiwisolver"],
     # Dependencies for PDF backend

--- a/enable/__init__.py
+++ b/enable/__init__.py
@@ -29,12 +29,12 @@ __extras_require__ = {
     # Dependencies for constrained layout
     "layout": ["kiwisolver"],
     # Dependencies for PDF backend
-    "pdf": ["reportlab<3.0"],
+    "pdf": ["reportlab"],
     # Dependencies for SVG backend
     "svg": ["pyparsing"],
     # Dependencies purely for running tests.
     "test": [
-        "PyPDF2",  # for pdf drawing tests in kiva.
+        "PyPDF2<3.0",  # for pdf drawing tests in kiva.
         "setuptools",
     ],
 }

--- a/enable/savage/svg/tests/test_document.py
+++ b/enable/savage/svg/tests/test_document.py
@@ -65,7 +65,7 @@ class TestBrushFromColourValue(unittest.TestCase):
 
     @patch('urllib.request.urlopen')
     def testURLFallback(self, mock_urlopen):
-        mock_urlopen.return_value = BytesIO(b"<html></html>")
+        mock_urlopen.return_value = BytesIO(b"<!doctype html><html></html>")
         self.document.state["fill"] = "url(http://example.com) red"
         self.assertEqual(
             self.document.getBrushFromState().color, (255, 0, 0, 255)

--- a/enable/savage/svg/tests/test_document.py
+++ b/enable/savage/svg/tests/test_document.py
@@ -8,8 +8,9 @@
 #
 # Thanks for using Enthought open source!
 
-from io import StringIO
+from io import BytesIO, StringIO
 import unittest
+from unittest.mock import patch
 import xml.etree.cElementTree as etree
 
 import enable.savage.svg.document as document
@@ -62,8 +63,10 @@ class TestBrushFromColourValue(unittest.TestCase):
         self.document.state["fill-opacity"] = -100
         self.assertEqual(self.document.getBrushFromState().color[-1], 0)
 
-    def testURLFallback(self):
-        self.document.state["fill"] = "url(http://google.com) red"
+    @patch('urllib.request.urlopen')
+    def testURLFallback(self, mock_urlopen):
+        mock_urlopen.return_value = BytesIO(b"<html></html")
+        self.document.state["fill"] = "url(http://example.com) red"
         self.assertEqual(
             self.document.getBrushFromState().color, (255, 0, 0, 255)
         )

--- a/enable/savage/svg/tests/test_document.py
+++ b/enable/savage/svg/tests/test_document.py
@@ -65,7 +65,7 @@ class TestBrushFromColourValue(unittest.TestCase):
 
     @patch('urllib.request.urlopen')
     def testURLFallback(self, mock_urlopen):
-        mock_urlopen.return_value = BytesIO(b"<html></html")
+        mock_urlopen.return_value = BytesIO(b"<html></html>")
         self.document.state["fill"] = "url(http://example.com) red"
         self.assertEqual(
             self.document.getBrushFromState().color, (255, 0, 0, 255)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["cython", "oldest-supported-numpy", "setuptools", "swig", "wheel"]
+requires = ["cython", "oldest-supported-numpy", "setuptools<65.2", "swig", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This gets CI back into a working state by:

- restricting PyPDF to a version before 3.0 (this is used in testing only) - #1008 
- restricting pyglet to a version < 2 - #1010 
- mocking svg url requests
- turning off wx tests for linux (we can't get a compatible wheel for the new ubuntu) - #1009 tracks this for the future

Everything is passing: https://github.com/enthought/enable/actions/runs/4186677329

There is a warning about set-output, but I don't think it is us.