### PR TITLE
add ubuntu 3.11 test

### DIFF
--- a/.github/workflows/test-with-pypi.yml
+++ b/.github/workflows/test-with-pypi.yml
@@ -1,0 +1,52 @@
+name: Test with PyPI
+
+on: [pull_request, workflow_dispatch]
+
+env:
+  PYTHONUNBUFFERED: 1
+
+jobs:
+
+  # Test against PyPI packages
+  test-with-pypi-ubuntu:
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+        toolkit: ['null', 'pyqt5', 'pyside2', 'pyside6']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Qt dependencies for Linux
+        run: |
+          sudo apt-get update
+          sudo apt-get install qtbase5-dev
+          sudo apt-get install qtchooser
+          sudo apt-get install qt5-qmake
+          sudo apt-get install qtbase5-dev-tools
+          sudo apt-get install libegl1
+          sudo apt-get install libxkbcommon-x11-0
+          sudo apt-get install libxcb-icccm4
+          sudo apt-get install libxcb-image0
+          sudo apt-get install libxcb-keysyms1
+          sudo apt-get install libxcb-randr0
+          sudo apt-get install libxcb-render-util0
+          sudo apt-get install libxcb-xinerama0
+          sudo apt-get install libxcb-shape0
+        if: matrix.toolkit != 'wx'
+      - name: Install Wx dependencies for Linux
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsdl1.2-dev
+        if: matrix.toolkit == 'wx'
+      - name: Install GL dependencies for Linux
+        run: sudo apt-get install libglu1-mesa-dev
+      - name: Install test dependencies
+        run: python -m pip install wheel click coverage pyparsing
+      - name: Install package under test
+        run: python -m pip install .
+      - name: Run tests (Ubuntu)
+        run: |
+          mkdir testdir
+          cd testdir
+          xvfb-run -a python -X faulthandler -m unittest discover -v enable


### PR DESCRIPTION
With the latest python come out, we want to test whether enable can work under python 3.11. Since 3.11 is still not available in EDM, we setup a pypi test. closes issue #1016 