### PR TITLE
fix the import of pyface.ui.qt.color for the new update

### DIFF
--- a/enable/trait_defs/ui/qt4/rgba_color_editor.py
+++ b/enable/trait_defs/ui/qt4/rgba_color_editor.py
@@ -16,7 +16,7 @@
 # -----------------------------------------------------------------------------
 
 from pyface.qt import QtGui
-from pyface.ui.qt4.color import toolkit_color_to_rgba, rgba_to_toolkit_color
+from pyface.ui.qt.color import toolkit_color_to_rgba, rgba_to_toolkit_color
 
 from traits.trait_base import SequenceTypes
 


### PR DESCRIPTION
The new pyface update move the qt tool kit from pyface.ui.qt4 to the pyface.ui.qt, this PR fixes the examples broken due to this update, closes #1024 