### PR TITLE
MAINT: add compatibility with pyface 8.0.0

### DIFF
--- a/enable/trait_defs/ui/qt4/rgba_color_editor.py
+++ b/enable/trait_defs/ui/qt4/rgba_color_editor.py
@@ -29,9 +29,16 @@ from traits.trait_base import SequenceTypes
 # subclass of the abstract ToolkitEditorFactory class
 # (in traitsui.api) with qt4-specific methods defined.
 # We need to override the implementations of the qt4-specific methods here.
-from traitsui.qt4.color_editor import (
-    ToolkitEditorFactory as BaseColorToolkitEditorFactory,
-)
+
+try:
+    from traitsui.qt.color_editor import (
+        ToolkitEditorFactory as BaseColorToolkitEditorFactory,
+    )
+# compatible with pyface < 8.0.0
+except ModuleNotFoundError:
+    from traitsui.qt4.color_editor import (
+        ToolkitEditorFactory as BaseColorToolkitEditorFactory,
+    )
 
 # -----------------------------------------------------------------------------
 #  The PyQt4 ToolkitEditorFactory class:


### PR DESCRIPTION
Recently, a lot of enthought open source packages such as enable, traitsui and pyface are changing the name of the qt folder name from qt4 to qt. This causes ModuleNotFoundErrors. Thus it would be necessary to add compatibility imports to handle these errors. This PR adds compatibility imports to solve the import error in enable/enable/examples/demo/enable/brush_draw.