### PR TITLE
Add explicit float -> int conversion for Qt

### DIFF
--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -21,8 +21,6 @@ jobs:
             toolkit: 'wx'
           - os: 'macos-latest'
             toolkit: 'wx'
-          # PyQt5 API doesn't automatically cast float -> int, see #1037
-          - toolkit: 'pyqt5'
             python-version: '3.10'
           # Kiva tests hanging on windows, see #1038
           - os: 'windows-latest'

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -21,7 +21,6 @@ jobs:
             toolkit: 'wx'
           - os: 'macos-latest'
             toolkit: 'wx'
-            python-version: '3.10'
           # Kiva tests hanging on windows, see #1038
           - os: 'windows-latest'
             toolkit: 'pyqt5'

--- a/enable/qt4/base_window.py
+++ b/enable/qt4/base_window.py
@@ -380,7 +380,7 @@ class _Window(AbstractWindow):
             self.control.move(*pos)
 
         if size is not None:
-            self.control.resize(*size)
+            self.control.resize(*(int(x) for x in size))
 
     def _get_base_pixel_scale(self):
         if self.control is None:

--- a/enable/qt4/scrollbar.py
+++ b/enable/qt4/scrollbar.py
@@ -164,11 +164,11 @@ class NativeScrollBar(Component):
         # invert values for vertical ranges because of coordinate system issues
         value = self._correct_value(value, minimum, max_value)
 
-        self._control.setMinimum(minimum)
-        self._control.setMaximum(max_value)
-        self._control.setValue(value)
-        self._control.setPageStep(page_size)
-        self._control.setSingleStep(line_size)
+        self._control.setMinimum(int(minimum))
+        self._control.setMaximum(int(max_value))
+        self._control.setValue(int(value))
+        self._control.setPageStep(int(page_size))
+        self._control.setSingleStep(int(line_size))
 
     def _correct_value(self, value, min_value, max_value):
         """ Correct vertical position values for Qt and Enable conventions


### PR DESCRIPTION
This was happening implicitly until https://bugs.python.org/issue36048 This makes it explicit, which means things should work with PyQt5 on Python 3.10.

Fixes #1037 