### PR TITLE
Fix issues where xvfb-run was failing occasionally

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Run kiva test suite (Linux)
         env:
           PYTHONFAULTHANDLER: 1
-        run: xvfb-run python -m unittest discover -v kiva
+        run: xvfb-run -a python -m unittest discover -v kiva
         if: matrix.os == 'ubuntu-latest'
         working-directory: ${{ runner.temp }}
       - name: Run kiva test suite (not Linux)
@@ -72,7 +72,7 @@ jobs:
         env:
           PYTHONFAULTHANDLER: 1
         # kiva agg requires at least 15-bit color depth.
-        run: xvfb-run --server-args="-screen 0 1024x768x24" python -m unittest discover -v enable
+        run: xvfb-run -a --server-args="-screen 0 1024x768x24" python -m unittest discover -v enable
         if: matrix.os == 'ubuntu-latest'
         working-directory: ${{ runner.temp }}
       - name: Run enable test suite (not Linux)

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -38,7 +38,7 @@ jobs:
         run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }} --runtime=${{ matrix.runtime }}
       - name: Run tests
         # kiva agg requires at least 15-bit color depth.
-        run: xvfb-run --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }} --runtime=${{ matrix.runtime }}
+        run: xvfb-run -a --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }} --runtime=${{ matrix.runtime }}
 
   # Test against EDM packages on Windows
   test-with-edm:

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run kiva test suite (Linux)
         env:
           PYTHONFAULTHANDLER: 1
-        run: xvfb-run python -m unittest discover -v kiva
+        run: xvfb-run -a python -m unittest discover -v kiva
         if: matrix.os == 'ubuntu-latest'
         working-directory: ${{ runner.temp }}
       - name: Run kiva test suite (not Linux)
@@ -73,7 +73,7 @@ jobs:
         env:
           PYTHONFAULTHANDLER: 1
         # kiva agg requires at least 15-bit color depth.
-        run: xvfb-run --server-args="-screen 0 1024x768x24" python -m unittest discover -v enable
+        run: xvfb-run -a --server-args="-screen 0 1024x768x24" python -m unittest discover -v enable
         if: matrix.os == 'ubuntu-latest'
         working-directory: ${{ runner.temp }}
       - name: Run enable test suite (not Linux)


### PR DESCRIPTION
This ensures that we are getting a new framebuffer for each test.

Thanks to @mdickinson for the solution.