### PR TITLE
Fix Quartz draw_path_at_points

### DIFF
--- a/kiva/quartz/ABCGI.pyx
+++ b/kiva/quartz/ABCGI.pyx
@@ -1062,7 +1062,7 @@ cdef class CGContext:
 
         apoints = <numpy.ndarray>(numpy.asarray(points, dtype=numpy.float32))
 
-        if apoints.nd != 2 or apoints.dimensions[1] != 2:
+        if apoints.ndim != 2 or apoints.shape[1] != 2:
             msg = "must pass array of 2-D points"
             raise ValueError(msg)
 

--- a/kiva/tests/drawing_tester.py
+++ b/kiva/tests/drawing_tester.py
@@ -19,9 +19,9 @@ from kiva.api import (
     DECORATIVE, DEFAULT, ITALIC, MODERN, NORMAL, ROMAN, SCRIPT, TELETYPE, Font
 )
 from kiva.constants import (
-    WEIGHT_THIN, WEIGHT_EXTRALIGHT, WEIGHT_LIGHT, WEIGHT_NORMAL, WEIGHT_MEDIUM,
-    WEIGHT_SEMIBOLD, WEIGHT_BOLD, WEIGHT_EXTRABOLD, WEIGHT_HEAVY,
-    WEIGHT_EXTRAHEAVY
+    FILL_STROKE, WEIGHT_THIN, WEIGHT_EXTRALIGHT, WEIGHT_LIGHT, WEIGHT_NORMAL,
+    WEIGHT_MEDIUM, WEIGHT_SEMIBOLD, WEIGHT_BOLD, WEIGHT_EXTRABOLD,
+    WEIGHT_HEAVY, WEIGHT_EXTRAHEAVY
 )
 
 
@@ -186,6 +186,23 @@ class DrawingTester(object):
 
             self.gc.begin_path()
             self.gc.arc(150, 150, 100, 0.0, 2 * numpy.pi)
+            self.gc.fill_path()
+
+    def test_draw_path_at_points(self):
+        if not hasattr(self.gc, 'draw_path_at_points'):
+            self.skipTest("GC doesn't have 'draw_marker_at_points' method.")
+
+        path = self.gc.get_empty_path()
+        path.move_to(-5, -5)
+        path.line_to(-5, 5)
+        path.line_to(5, 5)
+        path.line_to(5, -5)
+        path.close_path()
+
+        points = numpy.array([[0, 0], [10, 10], [20, 20], [30, 30]])
+
+        with self.draw_and_check():
+            self.gc.draw_path_at_points(points, path, FILL_STROKE)
             self.gc.fill_path()
 
     # Required methods ####################################################


### PR DESCRIPTION
Also adds a test for all backends which implement the method.

This was causing failures in Chaco scatterplots with the Quartz backend.