### PR TITLE
Clean-up of Enable Qt toolkit code

### DIFF
--- a/enable/qt/base_window.py
+++ b/enable/qt/base_window.py
@@ -396,7 +396,7 @@ class _Window(AbstractWindow):
         if hasattr(event, 'modifiers'):
             modifiers = event.modifiers()
         if hasattr(event, 'buttons'):
-            modifiers = event.buttons()
+            buttons = event.buttons()
 
         self.control.handler.last_mouse_pos = (x, y)
 

--- a/enable/qt/base_window.py
+++ b/enable/qt/base_window.py
@@ -37,23 +37,9 @@ from traits.api import Instance, Property
 from .constants import (
     BUTTON_NAME_MAP,
     KEY_MAP,
-    MOUSE_WHEEL_AXIS_MAP,
     POINTER_MAP,
     DRAG_RESULTS_MAP,
 )
-
-
-# QtOpenGLWidgets is not currently exposed in pyface.qt
-if qt_api == "pyside6":
-    from PySide6.QtOpenGLWidgets import QOpenGLWidget
-elif qt_api == "pyqt6":
-    from PyQt6.QtOpenGLWidgets import QOpenGLWidget
-elif qt_api == "pyside2":
-    from PySide2.QtWidgets import QOpenGLWidget
-elif qt_api == "pyqt5":
-    from PyQt5.QtWidgets import QOpenGLWidget
-else:
-    QOpenGLWidget = QtOpenGL.QGLWidget
 
 
 class _QtWindowHandler(object):
@@ -299,63 +285,6 @@ class _QtWindow(QtGui.QWidget):
         return self.handler.sizeHint(qt_size_hint)
 
 
-class _QtGLWindow(QOpenGLWidget):
-    def __init__(self, parent, enable_window):
-        super().__init__(parent)
-        self.handler = _QtWindowHandler(self, enable_window)
-
-    def closeEvent(self, event):
-        self.handler.closeEvent(event)
-        return super().closeEvent(event)
-
-    def paintEvent(self, event):
-        super().paintEvent(event)
-        self.handler.paintEvent(event)
-
-    def resizeEvent(self, event):
-        super().resizeEvent(event)
-        self.handler.resizeEvent(event)
-
-    def keyPressEvent(self, event):
-        self.handler.keyPressEvent(event)
-
-    def keyReleaseEvent(self, event):
-        self.handler.keyReleaseEvent(event)
-
-    def enterEvent(self, event):
-        self.handler.enterEvent(event)
-
-    def leaveEvent(self, event):
-        self.handler.leaveEvent(event)
-
-    def mouseDoubleClickEvent(self, event):
-        self.handler.mouseDoubleClickEvent(event)
-
-    def mouseMoveEvent(self, event):
-        self.handler.mouseMoveEvent(event)
-
-    def mousePressEvent(self, event):
-        self.handler.mousePressEvent(event)
-
-    def mouseReleaseEvent(self, event):
-        self.handler.mouseReleaseEvent(event)
-
-    def wheelEvent(self, event):
-        self.handler.wheelEvent(event)
-
-    def dragEnterEvent(self, event):
-        self.handler.dragEnterEvent(event)
-
-    def dragLeaveEvent(self, event):
-        self.handler.dragLeaveEvent(event)
-
-    def dragMoveEvent(self, event):
-        self.handler.dragMoveEvent(event)
-
-    def dropEvent(self, event):
-        self.handler.dropEvent(event)
-
-
 class _Window(AbstractWindow):
 
     control = Instance(QtGui.QWidget)
@@ -450,26 +379,22 @@ class _Window(AbstractWindow):
         # If the control no longer exists, don't send mouse event
         if self.control is None:
             return None
-        # If the event (if there is one) doesn't contain the mouse position,
-        # modifiers and buttons then get sensible defaults.
-        try:
-            if is_qt5:
-                x = event.x()
-                y = event.y()
-            else:
-                x = event.position().x()
-                y = event.position().y()
+
+        if is_qt5:
+            x = event.x()
+            y = event.y()
+        else:
+            x = event.position().x()
+            y = event.position().y()
+
+        # If the event doesn't contain modifiers and/or buttons then get
+        # sensible defaults.
+        modifiers = QtCore.Qt.KeyboardModifier.NoModifier
+        buttons = QtCore.Qt.MouseButton.NoButton
+        if hasattr(event, 'modifiers'):
             modifiers = event.modifiers()
-            buttons = event.buttons()
-        # The AttributeError is usually trigged when the mouse pointer
-        # leaves the ui window since the event of leaving the window
-        # is a "QEvent", which doesn't contain x and y positions.
-        except AttributeError:
-            pos = self.control.mapFromGlobal(QtGui.QCursor.pos())
-            x = pos.x()
-            y = pos.y()
-            modifiers = QtCore.Qt.KeyboardModifier.NoModifier
-            buttons = QtCore.Qt.MouseButton.NoButton
+        if hasattr(event, 'buttons'):
+            modifiers = event.buttons()
 
         self.control.handler.last_mouse_pos = (x, y)
 
@@ -516,15 +441,13 @@ class _Window(AbstractWindow):
         # If the control no longer exists, don't send mouse event
         if self.control is None:
             return None
-        # If the event (if there is one) doesn't contain the mouse position,
-        # modifiers and buttons then get sensible defaults.
-        try:
-            x = event.x()
-            y = event.y()
-        except AttributeError:
-            pos = self.control.mapFromGlobal(QtGui.QCursor.pos())
-            x = pos.x()
-            y = pos.y()
+
+        if is_qt5:
+            position = event.pos()
+        else:
+            position = event.position()
+        x = position.x()
+        y = position.y()
 
         self.control.handler.last_mouse_pos = (x, y)
 
@@ -544,11 +467,11 @@ class _Window(AbstractWindow):
             )
 
         try:
-            from traitsui.qt.clipboard import PyMimeData
+            from pyface.mimedata import PyMimeData
         except ImportError:
-            # traitsui isn't available, warn and just make mimedata available
+            # pyface isn't available, warn and just make raw mimedata available
             # on event
-            warnings.warn("traitsui.qt is unavailable", ImportWarning)
+            warnings.warn("pyface.mimedata is unavailable", ImportWarning)
             obj = None
         else:
             mimedata = PyMimeData.coerce(mimedata)
@@ -629,16 +552,6 @@ class _Window(AbstractWindow):
         """
         # Handle the pixel scale adjustment here since `self._size` is involved
         return int(self._size[1] / self.base_pixel_scale - y - 1)
-
-
-class BaseGLWindow(_Window):
-    # The toolkit control
-    control = Instance(_QtGLWindow)
-
-    def _create_control(self, parent, enable_window):
-        """ Create the toolkit control.
-        """
-        return _QtGLWindow(parent, enable_window)
 
 
 class BaseWindow(_Window):

--- a/enable/qt/base_window.py
+++ b/enable/qt/base_window.py
@@ -380,12 +380,14 @@ class _Window(AbstractWindow):
         if self.control is None:
             return None
 
-        if is_qt5:
-            x = event.x()
-            y = event.y()
+        if hasattr(event, 'pos'):
+            position = event.pos()
+        elif hasattr(event, 'position'):
+            position = event.position()
         else:
-            x = event.position().x()
-            y = event.position().y()
+            position = self.control.mapFromGlobal(QtGui.QCursor.pos())
+        x = position.x()
+        y = position.y()
 
         # If the event doesn't contain modifiers and/or buttons then get
         # sensible defaults.


### PR DESCRIPTION
This PR:
- removes some remaining OpenGL code that is no longer used
- cleans up the logic around the creation of mouse events and drag events

This is a follow-up to some of the issues identified in #1030 