### PR TITLE
Move kiva.image to kiva.oldagg

### DIFF
--- a/enable/qt/image.py
+++ b/enable/qt/image.py
@@ -8,46 +8,12 @@
 #
 # Thanks for using Enthought open source!
 
-from pyface.qt import QtCore, QtGui
-from kiva.agg import CompiledPath, GraphicsContextSystem as GraphicsContext
+from .oldagg import (
+    CompiledPath, font_metrics_provider, GraphicsContext, NativeScrollBar,
+    Window
+)
 
-from .base_window import BaseWindow
-from .scrollbar import NativeScrollBar
-
-
-class Window(BaseWindow):
-    def _create_gc(self, size, pix_format="bgra32"):
-        gc = GraphicsContext(
-            (size[0] + 1, size[1] + 1),
-            pix_format=pix_format,
-            base_pixel_scale=self.base_pixel_scale,
-            # We have to set bottom_up=0 or otherwise the PixelMap will
-            # appear upside down in the QImage.
-            bottom_up=0,
-        )
-        gc.translate_ctm(0.5, 0.5)
-
-        return gc
-
-    def _window_paint(self, event):
-        if self.control is None:
-            return
-
-        # self._gc is an image context
-        w = self._gc.width()
-        h = self._gc.height()
-        data = self._gc.pixel_map.convert_to_argb32string()
-        image = QtGui.QImage(data, w, h, QtGui.QImage.Format_ARGB32)
-        rect = QtCore.QRectF(
-            0, 0, w / self._gc.base_scale, h / self._gc.base_scale
-        )
-        painter = QtGui.QPainter(self.control)
-        painter.drawImage(rect, image)
-
-
-def font_metrics_provider():
-    from kiva.api import Font
-
-    gc = GraphicsContext((1, 1))
-    gc.set_font(Font())
-    return gc
+__all__ = [
+    "CompiledPath", "GraphicsContext", "NativeScrollBar", "Window",
+    "font_metrics_provider"
+]

--- a/enable/qt/oldagg.py
+++ b/enable/qt/oldagg.py
@@ -7,12 +7,47 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-from .image import (
-    CompiledPath, font_metrics_provider, GraphicsContext, NativeScrollBar,
-    Window
-)
 
-__all__ = [
-    "CompiledPath", "GraphicsContext", "NativeScrollBar", "Window",
-    "font_metrics_provider"
-]
+from pyface.qt import QtCore, QtGui
+from kiva.agg import CompiledPath, GraphicsContextSystem as GraphicsContext
+
+from .base_window import BaseWindow
+from .scrollbar import NativeScrollBar
+
+
+class Window(BaseWindow):
+    def _create_gc(self, size, pix_format="bgra32"):
+        gc = GraphicsContext(
+            (size[0] + 1, size[1] + 1),
+            pix_format=pix_format,
+            base_pixel_scale=self.base_pixel_scale,
+            # We have to set bottom_up=0 or otherwise the PixelMap will
+            # appear upside down in the QImage.
+            bottom_up=0,
+        )
+        gc.translate_ctm(0.5, 0.5)
+
+        return gc
+
+    def _window_paint(self, event):
+        if self.control is None:
+            return
+
+        # self._gc is an image context
+        w = self._gc.width()
+        h = self._gc.height()
+        data = self._gc.pixel_map.convert_to_argb32string()
+        image = QtGui.QImage(data, w, h, QtGui.QImage.Format_ARGB32)
+        rect = QtCore.QRectF(
+            0, 0, w / self._gc.base_scale, h / self._gc.base_scale
+        )
+        painter = QtGui.QPainter(self.control)
+        painter.drawImage(rect, image)
+
+
+def font_metrics_provider():
+    from kiva.api import Font
+
+    gc = GraphicsContext((1, 1))
+    gc.set_font(Font())
+    return gc

--- a/kiva/agg/tests/test_font_loading.py
+++ b/kiva/agg/tests/test_font_loading.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 import time
 
-from kiva.image import font_metrics_provider as FMP
+from kiva.oldagg import font_metrics_provider as FMP
 from kiva.api import Font
 
 counts = (500,)

--- a/kiva/image.py
+++ b/kiva/image.py
@@ -7,33 +7,13 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" This backend supports Kiva drawing into memory buffers.
 
-    Though this can be used to perform drawing in non-GUI applications,
-    the Image backend is also used by many of the GUI backends to draw into
-    the memory space of the graphics contexts.
-"""
+from kiva.oldagg import (
+    CompiledPath, font_metrics_provider, FontType, GraphicsContext,
+    GraphicsContextSystem, Image
+)
 
-# Soon the Agg subpackage will be renamed for real.  For now, just
-# proxy the imports.
-from .agg import GraphicsContextArray as GraphicsContext
-
-# FontType will be unified with the Kiva FontType soon.
-from .agg import AggFontType as FontType
-
-# GraphicsContextSystem wraps up platform- and toolkit- specific low
-# level calls with a GraphicsContextArray.  Eventually this low-level code
-# will be moved out of the Agg subpackage, and we won't have be importing
-# this here.
-from .agg import GraphicsContextSystem, Image
-
-# CompiledPath is an object that can efficiently store paths to be reused
-# multiple times.
-from .agg import CompiledPath
-
-
-def font_metrics_provider():
-    """ Create an object to be used for querying font metrics.
-    """
-
-    return GraphicsContext((1, 1))
+__all__ = [
+    "CompiledPath", "font_metrics_provider", "FontType", "GraphicsContext",
+    "GraphicsContextSystem", "Image"
+]

--- a/kiva/oldagg.py
+++ b/kiva/oldagg.py
@@ -7,12 +7,33 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-from kiva.image import (
-    CompiledPath, font_metrics_provider, FontType, GraphicsContext,
-    GraphicsContextSystem, Image
-)
+""" This backend supports Kiva drawing into memory buffers.
 
-__all__ = [
-    "CompiledPath", "font_metrics_provider", "FontType", "GraphicsContext",
-    "GraphicsContextSystem", "Image"
-]
+    Though this can be used to perform drawing in non-GUI applications,
+    the Image backend is also used by many of the GUI backends to draw into
+    the memory space of the graphics contexts.
+"""
+
+# Soon the Agg subpackage will be renamed for real.  For now, just
+# proxy the imports.
+from .agg import GraphicsContextArray as GraphicsContext
+
+# FontType will be unified with the Kiva FontType soon.
+from .agg import AggFontType as FontType
+
+# GraphicsContextSystem wraps up platform- and toolkit- specific low
+# level calls with a GraphicsContextArray.  Eventually this low-level code
+# will be moved out of the Agg subpackage, and we won't have be importing
+# this here.
+from .agg import GraphicsContextSystem, Image
+
+# CompiledPath is an object that can efficiently store paths to be reused
+# multiple times.
+from .agg import CompiledPath
+
+
+def font_metrics_provider():
+    """ Create an object to be used for querying font metrics.
+    """
+
+    return GraphicsContext((1, 1))

--- a/kiva/tests/agg/test_image.py
+++ b/kiva/tests/agg/test_image.py
@@ -116,7 +116,7 @@ def assert_close(desired, actual, diff_allowed=2):
 # ----------------------------------------------------------------------------
 
 
-class test_text_image(unittest.TestCase):
+class TestTextImage(unittest.TestCase):
     def test_antialias(self):
         gc = agg.GraphicsContextArray((200, 50), pix_format="bgra32")
         gc.set_antialias(1)
@@ -151,7 +151,7 @@ class test_text_image(unittest.TestCase):
         save(gc)
 
 
-class test_sun(unittest.TestCase):
+class TestSun(unittest.TestCase):
     def generic_sun(self, scheme):
         img = sun(scheme)
         sz = array((img.width(), img.height()))
@@ -224,7 +224,8 @@ def bench(stmt="pass", setup="pass", repeat=5, adjust_runs=True):
 #
 #
 # ----------------------------------------------------------------------------
-class test_interpolation_image(unittest.TestCase):
+class TestInterpolationImage(unittest.TestCase):
+
     size = (1000, 1000)
     color = 0.0
 

--- a/kiva/tests/test_agg_drawing.py
+++ b/kiva/tests/test_agg_drawing.py
@@ -12,7 +12,7 @@ import unittest
 import numpy as np
 
 from kiva.tests.drawing_tester import DrawingImageTester
-from kiva.image import GraphicsContext
+from kiva.oldagg import GraphicsContext
 
 
 class TestAggDrawing(DrawingImageTester, unittest.TestCase):

--- a/kiva/tests/test_graphics_context.py
+++ b/kiva/tests/test_graphics_context.py
@@ -15,7 +15,7 @@ from numpy import (
 from PIL import Image as PILImage
 
 
-from kiva.image import GraphicsContext
+from kiva.oldagg import GraphicsContext
 
 # alpha blending is approximate in agg, so we allow some "slop" between
 # desired and actual results, allow channel differences of to 2.


### PR DESCRIPTION
This is a simple PR that reverses the dependency of `kiva.image` and `kiva.oldagg`.  This is a prepatory PR for eventually replacing the old agg backend with celiagg.

Next step would be closer API compatibility between Oldagg and Celiagg (in particular, an `Image` class for `Celiagg`) together with optional use of Celiagg in place of Oldagg for experimentation.