### PR TITLE
Update swig wrapper to build on recent swig builds

### DIFF
--- a/kiva/agg/src/osx/plat_support.i
+++ b/kiva/agg/src/osx/plat_support.i
@@ -63,7 +63,8 @@ namespace agg24
         end_of_pix_formats
     };
 
-    %name(PixelMap) class pixel_map
+    %rename(PixelMap) pixel_map;
+    class pixel_map
     {
     public:
         ~pixel_map();


### PR DESCRIPTION
Latest version of swig do not like `%name` and the build fails on macos. This PR replaces %name with a %rename line.