### PR TITLE
Fix ciwheelbuild

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -16,21 +16,21 @@ jobs:
     steps:
 
     - name: Check out the release commit
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: arm64
       if: runner.os == 'Linux'
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.12.1
+      uses: pypa/cibuildwheel@v3.0
 
     - name: Check and upload wheels
       env:
@@ -46,10 +46,10 @@ jobs:
 
     steps:
     - name: Check out the release commit
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["cython", "numpy>=2", "setuptools", "swig", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-skip = 'pp* *-musllinux* cp36-* cp-37-* cp38-*'
+skip = 'pp* *-musllinux* cp38-*'
 
 [tool.cibuildwheel.linux]
 archs = ['auto', 'aarch64']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["cython", "numpy>=2", "setuptools", "swig", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-skip = 'pp* *-musllinux* cp36-*'
+skip = 'pp* *-musllinux* cp36-* cp-37-* cp38-*'
 
 [tool.cibuildwheel.linux]
 archs = ['auto', 'aarch64']


### PR DESCRIPTION
- Update skipped python versions
- Use latest cibuildwheel action 
- Use latest github actions
- Use latest docker actions
(the workflow has been tested to work on the 6.1.0 release https://pypi.org/project/enable/)